### PR TITLE
Fixed example of config for verify setting.

### DIFF
--- a/pulp_smash/__main__.py
+++ b/pulp_smash/__main__.py
@@ -20,7 +20,7 @@ MESSAGE = tuple((
     }}''',
     '''\
     Customize the "base_url" and "auth" keys as needed. You may also want to
-    add `"verify": False`. Doing so makes Pulp Smash ignore SSL verification
+    add `"verify": false`. Doing so makes Pulp Smash ignore SSL verification
     errors.
     ''',
     '''\


### PR DESCRIPTION
The capitalized False in the example is not proper JSON. I was getting an error until I changed it to a lower case. 