### PR TITLE
Make Travis notify chat.freenode.net#pulp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ script:
 after_success:
     coveralls
 notifications:
-    irc: "chat.freenode.net#robottelo"
+    irc: "chat.freenode.net#pulp"


### PR DESCRIPTION
Given that the purpose of Pulp Smash is to test Pulp, it makes more sense for
Pulp contributors to see notifications than Robottelo contributors.