### PR TITLE
Update login test

### DIFF
--- a/pulp_smash/tests/test_login.py
+++ b/pulp_smash/tests/test_login.py
@@ -14,6 +14,15 @@ from unittest2 import TestCase
 
 LOGIN_KEYS = {'certificate', 'key'}
 LOGIN_PATH = '/pulp/api/v2/actions/login/'
+ERROR_KEYS = {
+    '_href',
+    'error',
+    'error_message',
+    'exception',
+    'href',  # Present prior to Pulp 3.0 for backward compatibility.
+    'http_status',
+    'traceback',
+}
 
 
 class LoginSuccessTestCase(TestCase):
@@ -58,4 +67,4 @@ class LoginFailureTestCase(TestCase):
         "certificate" keys.
 
         """
-        self.assertNotEqual(set(self.response.json().keys()), LOGIN_KEYS)
+        self.assertEqual(set(self.response.json().keys()), ERROR_KEYS)


### PR DESCRIPTION
Update method `pulp_smash.tests.test_login.LoginFailureTestCase.test_body`. Formerly, the test asserted that the response body did not contain "key" and "certificate" keys, as documented [here](https://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/authentication.html). Now, the test asserts that the response body has the keys documented [here](https://pulp.readthedocs.org/en/latest/dev-guide/conventions/exceptions.html#exception-handling), plus the "href" key as documented [here](PulpQE#9 (comment)).

Test results:

    $ python -m unittest2 pulp_smash.tests.test_login
    F...
    ======================================================================
    FAIL: test_body (pulp_smash.tests.test_login.LoginFailureTestCase)
    Assert that the response is valid JSON and does not have "key" and
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "pulp_smash/tests/test_login.py", line 70, in test_body
        self.assertEqual(set(self.response.json().keys()), ERROR_KEYS)
    AssertionError: Items in the first set but not the second:
    u'http_request_method'
    u'auth_error_code'
    Items in the second set but not the first:
    u'href'

    ----------------------------------------------------------------------
    Ran 4 tests in 1.319s

    FAILED (failures=1)