### PR TITLE
Ignore SSL verification warnings

### DIFF
--- a/docs/about.rst
+++ b/docs/about.rst
@@ -11,12 +11,10 @@ Why does Pulp Smash exist? What are its goals, and what does it *not* do?
 Why Pulp Smash?
 ---------------
 
-Pulp Smash exists to make testing Pulp easy.
+Pulp Smash exists to make testing Pulp easy. [1]_
 
 Scope and Limitations
 ---------------------
-
-This is a list of goals that 
 
 Portability
 ~~~~~~~~~~~
@@ -29,7 +27,7 @@ Pulp Smash should be usable in any environment that supports:
 * `GNU Make`_ (or a compatible clone),
 * and the `XDG Base Directory Specification`_.
 
-This level of portability [1]_ allows Pulp Smash to be accessible [2]_.
+This level of portability [2]_ allows Pulp Smash to be accessible [3]_.
 
 Provisioning
 ~~~~~~~~~~~~
@@ -42,7 +40,7 @@ Destructiveness
 
 Should Pulp Smash record all changes it makes to a remote system and revert them
 when testing is complete, or should systems be treated as throw-away? In other
-words, should the systems under test be treated like pets or cattle? [3]_ This
+words, should the systems under test be treated like pets or cattle? [4]_ This
 has yet to be decided.
 
 Contributing
@@ -79,23 +77,21 @@ Please adhere to the following guidelines:
   in the commit message.
 * When in doubt, ask on IRC. Join the #pulp channel on `freenode`_.
 
-.. [1] Portable software cannot make assumptions about its environment. It
+.. [1] See: http://www.ichimonji10.name/blog/9/
+.. [2] Portable software cannot make assumptions about its environment. It
     cannot reference ``/etc/pki/tls/certs/ca-bundle.crt``  or call ``yum``.
     Instead, it must use standardized mechanisms for interacting with its
     environment. This separation of concerns should lead to an application with
     fewer responsibilities. Fewer responsibilities means fewer bugs and more
     focused developers.
-.. [2] An inaccessible project is a dead project. Labeling a project "open
+.. [3] An inaccessible project is a dead project. Labeling a project "open
     source" and licensing it under a suitable terms does not change that fact.
     People have better things to do than bang their head against a wall.
-.. [3] The "pets vs cattle" analogy is widely attributed to Bill Baker of
+.. [4] The "pets vs cattle" analogy is widely attributed to Bill Baker of
     Microsoft.
 
 .. _GNU Make: https://www.gnu.org/software/make/
-.. _Pulp Automation: https://github.com/RedHatQE/pulp-automation
 .. _Rebasing: http://www.git-scm.com/book/en/v2/Git-Branching-Rebasing
 .. _XDG Base Directory Specification: http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
 .. _freenode: https://freenode.net/
 .. _good commit messages: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
-.. _pulp_auto.repo: https://github.com/RedHatQE/pulp-automation/blob/master/pulp_auto/repo.py
-.. _tests.general_tests.test_01_log_in: https://github.com/RedHatQE/pulp-automation/blob/master/tests/general_tests/test_01_log_in.py

--- a/pulp_smash/tests/__init__.py
+++ b/pulp_smash/tests/__init__.py
@@ -7,5 +7,40 @@ interfaces exposed by Pulp, including its API and CLI.
 
 These tests are entirely different from the tests in :mod:`tests`.
 
+-----
+
+By default, Requests refuses to make insecure HTTPS connections. You can
+override this behaviour by passing ``verify=False``. For example::
+
+    requests.get('https://insecure.example.com', verify=False)
+
+If you do this, Requests will make the connection. However, an
+``InsecureRequestWarning`` is still raised. This is problematic. If a user has
+explicitly stated that they want insecure HTTPS connections and they are
+pestered about that fact, the user is effectively trained to ignore warnings.
+
+Thus, when this module is imported, it suppresses
+``requests.packages.urllib3.exceptions.InsecureRequestWarning``. This filtering
+does not affect whether SSL verification is performed. If an insecure
+connection is attempted and ``verify=True`` or is unspecified, the connection
+is not made.
+
+.. NOTE:: The ``InsecureRequestWarning`` suppression is process-wide.
+
+Unfortunately, Python's warnings and filter system is process-wide. Imagine an
+application which uses both Pulp Smash and some other library, and imagine that
+the other library generates ``InsecureRequestWarning`` warnings. The warnings
+raised by that application are suppressed by the filter created here. The
+``warnings.catch_warnings`` context manager is not a good solution to this
+problem, as it is thread-unsafe.
+
 """
 from __future__ import unicode_literals
+
+import requests
+from warnings import simplefilter
+
+simplefilter(
+    'ignore',
+    requests.packages.urllib3.exceptions.InsecureRequestWarning,
+)


### PR DESCRIPTION
Fix #4:

> Let's suppress SSL verification warnings. If a user sets "verify": False in
> their configuration file, then the responsibility for the fall-out of that
> decision lies with them. And if they do not suppress SSL verification, then a
> different warning is raised.

Do this by using `warnings.simplefilter`. Example results:

    $ python -m unittest2 discover pulp_smash.tests
    ....F...
    ======================================================================
    FAIL: test_body (pulp_smash.tests.test_login.LoginFailureTestCase)
    Assert that the response is valid JSON and does not have "key" and
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "/home/ichimonji10/code/pulp-smash/pulp_smash/tests/test_login.py", line 70, in test_body
        self.assertEqual(set(self.response.json().keys()), ERROR_KEYS)
    AssertionError: Items in the first set but not the second:
    'auth_error_code'
    'http_request_method'
    Items in the second set but not the first:
    'href'

    ----------------------------------------------------------------------
    Ran 8 tests in 4.857s

    FAILED (failures=1)

The test failure is known about and should be present. See #9.