### PR TITLE
WIP: Skip known failing tests

### DIFF
--- a/pulp_smash/constants.py
+++ b/pulp_smash/constants.py
@@ -17,6 +17,8 @@ ERROR_KEYS = frozenset((
 .. _Exception Handling:
     https://pulp.readthedocs.org/en/latest/dev-guide/conventions/exceptions.html
 
+The ``href`` key is present prior to Pulp 3.0 for backward compatibility.
+
 """
 
 LOGIN_PATH = '/pulp/api/v2/actions/login/'

--- a/pulp_smash/tests/platform/api_v2/test_login.py
+++ b/pulp_smash/tests/platform/api_v2/test_login.py
@@ -15,11 +15,6 @@ from unittest2 import TestCase
 # Upon successfully logging in, the response should contain these keys.
 _LOGIN_KEYS = {'certificate', 'key'}
 
-# Failed login attempts produce a non-standard response.
-#
-# The ``href`` key is present prior to Pulp 3.0 for backward compatibility.
-_LOGIN_ERROR_KEYS = ERROR_KEYS | {'href'}
-
 
 class LoginSuccessTestCase(TestCase):
     """Tests for successfully logging in."""
@@ -64,7 +59,13 @@ class LoginFailureTestCase(TestCase):
 
     def test_body(self):
         """Assert that the response is valid JSON and has correct keys."""
+        self.skipTest('See: ???')  # FIXME
+        # AssertionError: Items in the first set but not the second:
+        # u'href'
+        # Items in the second set but not the first:
+        # u'http_request_method'
+        # u'property_names'
         self.assertEqual(
+            ERROR_KEYS,
             frozenset(self.response.json().keys()),
-            _LOGIN_ERROR_KEYS,
         )

--- a/pulp_smash/tests/platform/api_v2/test_repository.py
+++ b/pulp_smash/tests/platform/api_v2/test_repository.py
@@ -56,6 +56,9 @@ class CreateSuccessTestCase(TestCase):
 
     def test_location_header(self):
         """Assert that the Location header is correctly set in the response."""
+        self.skipTest('See: ???')  # FIXME
+        # AssertionError: u'https://pulp.example.com[68 chars]d81/' !=
+        # '81ade399-f198-4181-94b1-c7f67157fd81'
         for response, attrs in zip(self.responses, self.attrs_iter):
             with self.subTest((response, attrs)):
                 url = '{}{}{}/'.format(
@@ -109,29 +112,43 @@ class CreateFailureTestCase(TestCase):
 
     def test_status_code(self):
         """Assert that each response has the expected HTTP status code."""
-        for response, status_code in zip(self.responses, self.status_codes):
-            with self.subTest((response, status_code)):
+        for body, response, status_code in zip(
+                self.bodies, self.responses, self.status_codes):
+            with self.subTest(body=body):
+                if isinstance(body, list):
+                    self.skipTest('See: https://pulp.plan.io/issues/1356')
                 self.assertEqual(response.status_code, status_code)
 
     def test_location_header(self):
         """Assert that the Location header is correctly set in the response."""
-        for i, response in enumerate(self.responses):
-            with self.subTest(i=i):
-                self.assertNotIn('Location', response.headers)
+        for body, response in zip(self.bodies, self.responses):
+            with self.subTest(body=body):
+                if isinstance(body, list):
+                    self.skipTest('See: https://pulp.plan.io/issues/1356')
+                else:
+                    self.assertNotIn('Location', response.headers)
 
     def test_exception_keys_json(self):
         """Assert the JSON body returned contains the correct keys."""
-        for i, response in enumerate(self.responses):
-            with self.subTest(i=i):
-                self.assertEqual(
-                    frozenset(response.json().keys()),
-                    ERROR_KEYS,
-                )
+        for body, response in zip(self.bodies, self.responses):
+            with self.subTest(body=body):
+                if isinstance(body, list):
+                    self.skipTest('See: https://pulp.plan.io/issues/1356')
+                self.skipTest('See: ???')  # FIXME
+                # AssertionError: Items in the first set but not the second:
+                # u'href'
+                # Items in the second set but not the first:
+                # u'http_request_method'
+                # u'property_names'
+                self.assertEqual(frozenset(response.json().keys()), ERROR_KEYS)
 
     def test_exception_json_http_status(self):
         """Assert the JSON body returned contains the correct HTTP code."""
-        for response, status_code in zip(self.responses, self.status_codes):
-            with self.subTest((response, status_code)):
+        for body, response, status_code in zip(
+                self.bodies, self.responses, self.status_codes):
+            with self.subTest(body=body):
+                if isinstance(body, list):
+                    self.skipTest('See: https://pulp.plan.io/issues/1356')
                 self.assertEqual(response.json()['http_status'], status_code)
 
     @classmethod

--- a/pulp_smash/tests/platform/api_v2/test_user.py
+++ b/pulp_smash/tests/platform/api_v2/test_user.py
@@ -138,15 +138,19 @@ class ReadUpdateDeleteTestCase(TestCase):
 
     def test_use_deleted_user(self):
         """Assert that one cannot read, update or delete a deleted user."""
-        url = self.cfg.base_url + self.attrs_iter[-1]['_href']  # deleted user
-        methods = ('get', 'put', 'delete')
-        responses = tuple((
-            getattr(requests, method)(url, **self.cfg.get_requests_kwargs())
-            for method in methods
-        ))
-        for method, response in zip(methods, responses):
-            with self.subTest(method=method):
-                self.assertEqual(response.status_code, 404)
+        actions_kwargs = {}
+        for action in ('get', 'put', 'delete'):
+            actions_kwargs[action] = self.cfg.get_requests_kwargs()
+            actions_kwargs[action]['url'] = (
+                self.cfg.base_url + self.attrs_iter[-1]['_href']
+            )
+        actions_kwargs['put']['json'] = {}
+        for action, kwargs in actions_kwargs.items():
+            with self.subTest(action=action):
+                self.assertEqual(
+                    getattr(requests, action)(**kwargs).status_code,
+                    404
+                )
 
     def test_updated_user(self):
         """Assert that the updated user has the assigned attributes."""


### PR DESCRIPTION
Skip failing tests. This is a temporary solution until #29 and #30 are fixed.
The idea is that it's better to highlight real regressions than drown the user
in known issues. In the immediate future, developers who'd like to know if
they've fixed an issue can remove relevant `skipTest()` lines from their local
copies of the test suite. Not optimal, but workable.

Tested against Pulp 2.6:

    $ python -m unittest2 discover pulp_smash.tests
    ....s...ssssssss.ss.....ssss...........................
    ----------------------------------------------------------------------
    Ran 50 tests in 43.777s

    OK (skipped=15)