### PR TITLE
Rename utility function, expand coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ test:
 	python $(TEST_OPTIONS)
 
 test-coverage:
-	coverage run --source pulp_smash.config $(TEST_OPTIONS)
+	coverage run --source pulp_smash.config,pulp_smash.utils $(TEST_OPTIONS)
 
 package:
 	./setup.py sdist bdist_wheel --universal

--- a/pulp_smash/tests/platform/api_v2/test_repository.py
+++ b/pulp_smash/tests/platform/api_v2/test_repository.py
@@ -20,7 +20,7 @@ import requests
 
 from pulp_smash.config import get_config
 from pulp_smash.constants import REPOSITORY_PATH, ERROR_KEYS
-from pulp_smash.utils import rand_str
+from pulp_smash.utils import uuid4
 from unittest2 import TestCase
 
 
@@ -38,12 +38,12 @@ class CreateSuccessTestCase(TestCase):
         cls.cfg = get_config()
         cls.url = cls.cfg.base_url + REPOSITORY_PATH
         cls.bodies = (
-            {'id': rand_str()},
+            {'id': uuid4()},
             {
-                'id': rand_str(),
-                'display_name': rand_str(),
-                'description': rand_str(),
-                'notes': {rand_str(): rand_str()},
+                'id': uuid4(),
+                'display_name': uuid4(),
+                'description': uuid4(),
+                'notes': {uuid4(): uuid4()},
             },
 
         )
@@ -103,7 +103,7 @@ class CreateFailureTestCase(TestCase):
         """
         cls.cfg = get_config()
         cls.url = cls.cfg.base_url + REPOSITORY_PATH
-        identical_id = rand_str()
+        identical_id = uuid4()
         cls.bodies = (
             (201, {'id': identical_id}),
             (400, {'id': None}),
@@ -181,11 +181,11 @@ class ReadUpdateDeleteSuccessTestCase(TestCase):
         cls.cfg = get_config()
         cls.update_body = {
             'delta': {
-                'display_name': rand_str(),
-                'description': rand_str()
+                'display_name': uuid4(),
+                'description': uuid4()
             }
         }
-        cls.bodies = [{'id': rand_str()} for _ in range(3)]
+        cls.bodies = [{'id': uuid4()} for _ in range(3)]
         cls.paths = []
         for body in cls.bodies:
             response = requests.post(

--- a/pulp_smash/tests/platform/api_v2/test_search.py
+++ b/pulp_smash/tests/platform/api_v2/test_search.py
@@ -32,7 +32,7 @@ from __future__ import unicode_literals
 import requests
 from pulp_smash.config import get_config
 from pulp_smash.constants import USER_PATH
-from random import randint
+from pulp_smash.utils import uuid4
 from unittest2 import TestCase, skip
 
 from sys import version_info
@@ -49,7 +49,7 @@ def _create_user(server_config):
     """Create a user with a random login. Return the decoded JSON response."""
     response = requests.post(
         server_config.base_url + USER_PATH,
-        json={'login': type('')(randint(-999999, 999999))},
+        json={'login': uuid4()},
         **server_config.get_requests_kwargs()
     )
     response.raise_for_status()

--- a/pulp_smash/tests/platform/api_v2/test_user.py
+++ b/pulp_smash/tests/platform/api_v2/test_user.py
@@ -19,13 +19,8 @@ from __future__ import unicode_literals
 import requests
 from pulp_smash.config import get_config
 from pulp_smash.constants import LOGIN_PATH, USER_PATH
-from random import randint
+from pulp_smash.utils import uuid4
 from unittest2 import TestCase
-
-
-def _rand_str():
-    """Return a randomized string."""
-    return type('')(randint(-100000, 100000))
 
 
 def _search_logins(response):
@@ -47,8 +42,8 @@ class CreateTestCase(TestCase):
         """
         cls.cfg = get_config()
         cls.bodies = (
-            {'login': _rand_str()},
-            {key: _rand_str() for key in {'login', 'password', 'name'}},
+            {'login': uuid4()},
+            {key: uuid4() for key in {'login', 'password', 'name'}},
         )
         cls.responses = tuple((
             requests.post(
@@ -108,8 +103,8 @@ class ReadUpdateDeleteTestCase(TestCase):
         """Create three users and read, update and delete them respectively."""
         # Create three users and save the locations of each.
         cls.update_body = {'delta': {
-            'name': _rand_str(),
-            'password': _rand_str(),
+            'name': uuid4(),
+            'password': uuid4(),
             'roles': ['super-users'],
         }}
         cls.cfg = get_config()
@@ -117,7 +112,7 @@ class ReadUpdateDeleteTestCase(TestCase):
         for _ in range(3):
             response = requests.post(
                 cls.cfg.base_url + USER_PATH,
-                json={'login': _rand_str()},
+                json={'login': uuid4()},
                 **cls.cfg.get_requests_kwargs()
             )
             response.raise_for_status()
@@ -232,7 +227,7 @@ class SearchTestCase(TestCase):
         """
         # Create a user and note information about it.
         cls.cfg = get_config()
-        cls.login = _rand_str()
+        cls.login = uuid4()
         response = requests.post(
             cls.cfg.base_url + USER_PATH,
             json={'login': cls.login},
@@ -254,7 +249,7 @@ class SearchTestCase(TestCase):
             {'criteria': {'filters': {'roles': ['super-users']}}},
             {'criteria': {'filters': {'roles': []}}},
             {'criteria': {'filters': {'login': cls.login}}},
-            {'criteria': {'filters': {'login': _rand_str()}}},
+            {'criteria': {'filters': {'login': uuid4()}}},
         ))
         cls.responses = tuple((
             requests.post(

--- a/pulp_smash/tests/rpm/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_sync_publish.py
@@ -37,7 +37,7 @@ import requests
 from itertools import chain
 from pulp_smash.config import get_config
 from pulp_smash.constants import REPOSITORY_PATH
-from pulp_smash.utils import rand_str
+from pulp_smash.utils import uuid4
 from time import sleep
 from unittest2 import TestCase
 
@@ -230,12 +230,12 @@ def _add_yum_distributor(server_config, href, responses=None):
         server_config.base_url + href + 'distributors/',
         json={
             'auto_publish': False,
-            'distributor_id': rand_str(),
+            'distributor_id': uuid4(),
             'distributor_type_id': 'yum_distributor',
             'distributor_config': {
                 'http': True,
                 'https': True,
-                'relative_url': '/' + rand_str(),
+                'relative_url': '/' + uuid4(),
             },
         },
         **server_config.get_requests_kwargs()
@@ -264,7 +264,7 @@ def _publish_repo(server_config, href, distributor_id, responses=None):
 def _gen_rpm_repo_body():
     """Return a semi-random dict that can be used for creating an RPM repo."""
     return {
-        'id': rand_str(),
+        'id': uuid4(),
         'importer_config': {},
         'importer_type_id': 'yum_importer',
         'notes': {'_repo-type': 'rpm-repo'},
@@ -334,7 +334,7 @@ class CreateTestCase(_BaseTestCase):
         """Create two RPM repositories, with and without feeds."""
         super(CreateTestCase, cls).setUpClass()
         cls.bodies = tuple((_gen_rpm_repo_body() for _ in range(2)))
-        cls.bodies[1]['importer_config'] = {'feed': rand_str()}  # invalid feed
+        cls.bodies[1]['importer_config'] = {'feed': uuid4()}  # invalid feed
         cls.attrs_iter = tuple((
             _create_repo(cls.cfg, body) for body in cls.bodies
         ))
@@ -427,7 +427,7 @@ class SyncInvalidFeedTestCase(_BaseTestCase):
         """Create an RPM repository with an invalid feed and sync it."""
         super(SyncInvalidFeedTestCase, cls).setUpClass()
         body = _gen_rpm_repo_body()
-        body['importer_config']['feed'] = rand_str()  # set an invalid feed
+        body['importer_config']['feed'] = uuid4()  # set an invalid feed
         cls.attrs_iter = (_create_repo(cls.cfg, body),)  # things to delete
         cls.sync_repo = []  # raw responses
         cls.task_bodies = tuple(chain.from_iterable(  # response bodies

--- a/pulp_smash/utils.py
+++ b/pulp_smash/utils.py
@@ -2,9 +2,9 @@
 """Utility functions for Pulp tests."""
 from __future__ import unicode_literals
 
-from uuid import uuid4
+import uuid
 
 
-def rand_str():
-    """Return a randomized string."""
-    return type('')(uuid4())
+def uuid4():
+    """Return a random UUID, as a unicode string."""
+    return type('')(uuid.uuid4())

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,14 @@
+# coding=utf-8
+"""Unit tests for :mod:`pulp_smash.utils`."""
+from __future__ import unicode_literals
+
+from pulp_smash import utils
+from unittest2 import TestCase
+
+
+class UUID4TestCase(TestCase):
+    """Test :meth:`pulp_smash.utils.uuid4`."""
+
+    def test_type(self):
+        """Assert the method returns a unicode string."""
+        self.assertIsInstance(utils.uuid4(), type(''))


### PR DESCRIPTION
Rename function `pulp_smash.utils.rand_str` to `pulp_smash.utils.uuid4` to
better reflect the actual nature of the function. Walk through modules and
fiddle with imports as needed, and in some cases drop private random string
generation functions. Make the `test-coverage` make target cover module
`pulp_smash.utils`.

Test results when rebased onto the `failures` branch (#38) and run against a
Pulp 2.6 system:

    $ python -m unittest2 discover pulp_smash.tests
    ....s...ssssssss.ss.....ssss........................................s........
    ----------------------------------------------------------------------
    Ran 72 tests in 66.057s

    OK (skipped=16)

Fix #35.