### PR TITLE
Support `./setup.py test`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
     - 3.4
     - 3.5
 install:
+    - ./setup.py test; git clean -dfx
     - pip install -r requirements.txt -r requirements-dev.txt
 script:
     # See: https://github.com/PulpQE/pulp-smash/issues/1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,10 +7,6 @@ pylint
 # For `make test-coverage`
 coveralls
 
-# For `make test`
-mock
-unittest2
-
 # For `make docs-html` and `make docs-clean`
 sphinx
 

--- a/setup.py
+++ b/setup.py
@@ -42,5 +42,6 @@ setup(
         'Programming Language :: Python :: 3.5',
     ],
     packages=find_packages(),
-    install_requires=['packaging', 'pyxdg', 'requests', 'unittest2'],
+    install_requires=['mock', 'packaging', 'pyxdg', 'requests', 'unittest2'],
+    test_suite='tests',
 )


### PR DESCRIPTION
From #2:

> The canonical way to run Pulp Smash's unit tests is via the `make test` command.
> This works, but its implementation is entirely ad-hoc. We should consider
> supporting the `test` command provided by setuptools. According to [the
> documentation](http://pythonhosted.org/setuptools/setuptools.html#test):
>
> > The test command runs a project’s unit tests without actually deploying it, by
> > temporarily putting the project’s source on sys.path, after first running
> > build_ext -i and egg_info to ensure that any C extensions and project metadata
> > are up-to-date.

Remove `unittest2` from `requirements-dev.txt`. It is already listed in
`setup.py`, and the duplication was a bug.

Move `mock` from `requirements-dev.txt` to `setup.py`. This change means that
Pulp Smash has a new base dependency, but this is the only change necessary to
support `./setup.py test`, so the change seems worthwhile.

Make Travis test this new command as part of the testing procedure.