### PR TITLE
Fix failing `lint` make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ docs-clean:
 	@cd docs; $(MAKE) clean
 
 lint-flake8:
-	flake8 . --ignore D100,D104
+	flake8 . --ignore D203
 
 lint-pylint:
 	pylint --reports=n --disable=I docs/conf.py tests setup.py \

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,8 @@
 flake8
 flake8-docstrings
 flake8-quotes
-pylint
+pylint<1.5.0
+astroid<1.4.0
 
 # For `make test-coverage`
 coveralls


### PR DESCRIPTION
Update the `lint` make target so it passes. See individual commit messages for more details.

Fix #46.