### PR TITLE
Make Pulp Smash test MODIFIED issues

### DIFF
--- a/pulp_smash/utils.py
+++ b/pulp_smash/utils.py
@@ -23,9 +23,9 @@ _UNTESTABLE_BUGS = frozenset((
     'NEW',  # bug just entered into tracker
     'ASSIGNED',  # bug has been assigned to an engineer
     'POST',  # bug fix is being reviewed by dev ("posted for review")
-    'MODIFIED',  # bug fix has been accepted by dev
 ))
 _TESTABLE_BUGS = frozenset((
+    'MODIFIED',  # bug fix has been accepted by dev
     'ON_QA',  # bug fix is being reviewed by qe
     'VERIFIED',  # bug fix has been accepted by qe
     'CLOSED - CURRENTRELEASE',


### PR DESCRIPTION
The `bug_is_testable` and `bug_is_untestable` functions talk to the pulp.plan.io bug tracker, inspect the state of a named bug and then tell the caller whether the named bug is testable or not. Make these functions treat MODIFIED issues as test-worthy. Both before and after this patch:

    ============  ==================
    Pulp Version  Test Suite Results
    ============  ==================
    2.6           OK (skipped=13)
    2.7           OK (skipped=12)
    dev           OK (skipped=12)
    ============  ==================