### PR TITLE
Introduce `pulp_smash.api.Client`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,13 @@ lint-flake8:
 	flake8 . --ignore D203
 
 lint-pylint:
-	pylint --reports=n --disable=I docs/conf.py tests setup.py \
+	pylint --reports=n --ignore-imports=y --disable=I \
+		docs/conf.py \
+		setup.py \
+		tests \
 		pulp_smash/__init__.py \
 		pulp_smash/__main__.py \
+		pulp_smash/api.py \
 		pulp_smash/config.py \
 		pulp_smash/constants.py \
 		pulp_smash/selectors.py \
@@ -38,7 +42,8 @@ test:
 	python $(TEST_OPTIONS)
 
 test-coverage:
-	coverage run --source pulp_smash.config,pulp_smash.utils $(TEST_OPTIONS)
+	coverage run --source pulp_smash.api,pulp_smash.config,pulp_smash.utils \
+	$(TEST_OPTIONS)
 
 package:
 	./setup.py sdist bdist_wheel --universal

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ lint-pylint:
 		pulp_smash/__main__.py \
 		pulp_smash/config.py \
 		pulp_smash/constants.py \
+		pulp_smash/selectors.py \
 		pulp_smash/utils.py
 	pylint --reports=n --disable=I,duplicate-code pulp_smash/tests/
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -13,6 +13,7 @@ developers, not a gospel.
     api/pulp_smash
     api/pulp_smash.config
     api/pulp_smash.constants
+    api/pulp_smash.selectors
     api/pulp_smash.tests
     api/pulp_smash.tests.docker
     api/pulp_smash.tests.docker.api_v2
@@ -34,4 +35,5 @@ developers, not a gospel.
     api/pulp_smash.utils
     api/tests
     api/tests.test_config
+    api/tests.test_selectors
     api/tests.test_utils

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -11,6 +11,7 @@ developers, not a gospel.
 .. toctree::
 
     api/pulp_smash
+    api/pulp_smash.api
     api/pulp_smash.config
     api/pulp_smash.constants
     api/pulp_smash.selectors

--- a/docs/api/pulp_smash.api.rst
+++ b/docs/api/pulp_smash.api.rst
@@ -1,0 +1,6 @@
+`pulp_smash.api`
+================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.api`
+
+.. automodule:: pulp_smash.api

--- a/docs/api/pulp_smash.selectors.rst
+++ b/docs/api/pulp_smash.selectors.rst
@@ -1,0 +1,6 @@
+`pulp_smash.selectors`
+======================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.selectors`
+
+.. automodule:: pulp_smash.selectors

--- a/docs/api/tests.test_selectors.rst
+++ b/docs/api/tests.test_selectors.rst
@@ -1,0 +1,6 @@
+`tests.test_selectors`
+======================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/tests.test_selectors`
+
+.. automodule:: tests.test_selectors

--- a/pulp_smash/api.py
+++ b/pulp_smash/api.py
@@ -1,0 +1,252 @@
+# coding=utf-8
+"""Tools for working with Pulp's API."""
+from __future__ import unicode_literals
+
+import warnings
+try:  # try Python 3 import first
+    from urllib.parse import urljoin
+except ImportError:
+    from urlparse import urljoin  # pylint:disable=C0411,E0401
+
+import requests
+
+from pulp_smash import utils
+
+
+_SENTINEL = object()
+
+
+def _check_http_202_content_type(response):
+    """Issue a warning if the content-type is not application/json."""
+    if not (response.headers.get('Content-Type', '')
+            .startswith('application/json')):
+        _warn_http_202_content_type(response)
+
+
+def _warn_http_202_content_type(response):
+    """Issue a warning about the response status code."""
+    if 'Content-Type' in response.headers:
+        content_type = '"{}"'.format(response.headers['Content-Type'])
+    else:
+        content_type = 'not present'
+    message = (
+        'All HTTP 202 responses returned by Pulp should have a content-type '
+        'of "application/json" and include a JSON call report. However, the '
+        'Content-Type is {}. Here is the HTTP method, URL and headers from '
+        'the request that generated this anomalous response: {} {} {}'
+    )
+    message = message.format(
+        content_type,
+        response.request.method,
+        response.request.url,
+        response.request.headers,
+    )
+    warnings.warn(message, RuntimeWarning)
+
+
+def _handle_202(server_config, response):
+    """Check for an HTTP 202 response and handle it appropriately."""
+    if response.status_code == 202:  # "Accepted"
+        _check_http_202_content_type(response)
+        tuple(utils.poll_spawned_tasks(server_config, response.json()))
+
+
+def echo_handler(server_config, response):  # pylint:disable=unused-argument
+    """Immediately return ``response``."""
+    return response
+
+
+def safe_handler(server_config, response):
+    """Check the response status code and wait for tasks to complete.
+
+    Raise an exception if the response has an HTTP 4XX or 5XX status code. Wait
+    for tasks to complete if the response has an HTTP Accepted status code.
+    Return the response.
+    """
+    response.raise_for_status()
+    _handle_202(server_config, response)
+    return response
+
+
+def json_handler(server_config, response):
+    """Check status code, wait for tasks to complete, and return decoded JSON.
+
+    Raise an exception if the response has an HTTP 4XX or 5XX status code. Wait
+    for tasks to complete if the response has an HTTP Accepted status code.
+    Return the response's decoded JSON body.
+    """
+    response.raise_for_status()
+    _handle_202(server_config, response)
+    return response.json()
+
+
+class Client(object):
+    """A convenience object for working with an API.
+
+    This class is a wrapper around the ``requests.api`` module provided by
+    `Requests`_. Each of the functions from that module are exposed as methods
+    here, and each of the arguments accepted by Requests' functions are also
+    accepted by these methods.
+
+    The difference between this class and the `Requests`_ functions lies in its
+    configurable request and response handling mechanisms. This class is
+    flexible enough that it should be usable with any API, but certain defaults
+    have been set to work well with `Pulp`_.
+
+    As an example, let's say that you'd like to create a user, then read that
+    user's information back from the server. This is one way to do it:
+
+    >>> from pulp_smash.api import Client
+    >>> from pulp_smash.config import get_config
+    >>> client = Client(get_config())
+    >>> response = client.post('/pulp/api/v2/users/', {'login': 'Alice'})
+    >>> client.get(response.json()['_href'])
+
+    This works, but handling raw responses can be kludgy. It is possible to set
+    a custom callback function that handles responses differently. For example,
+    the :func:`pulp_smash.api.json_handler` is much like the default
+    :func:`pulp_smash.api.safe_handler`, except that it expects response bodies
+    to be JSON and returns the decoded body:
+
+    >>> from pulp_smash.api import Client, json_handler
+    >>> from pulp_smash.config import get_config
+    >>> client = Client(get_config(), json_handler)
+    >>> attrs = client.post('/pulp/api/v2/users/', {'login': 'Alice'})
+    >>> client.get(attrs['_href'])
+
+    It is also possible to set request parameters, both on a per-client and
+    per-request basis. Here is an example:
+
+    >>> from pulp_smash.api import Client
+    >>> from pulp_smash.config import ServerConfig
+    >>> cfg = ServerConfig('http://example.com')
+    >>> client = Client(cfg)
+    >>> client.request_kwargs['url']  # copied from `cfg`
+    'http://example.com'
+    >>> client.request_kwargs['url'] = 'http://sub.example.com'
+    >>> client.get('http://sub2.example.com')  # overrides `request_kwargs`
+    >>> client.request_kwargs['url']  # but only for that one call
+    'http://sub.example.com'
+
+    As shown above, each client copies options from the
+    :class:`pulp_smash.config.ServerConfig` given to it. New default arguments
+    can then be set via the ``request_kwargs`` dict, and per-request arguments
+    can also be set. What can be placed in ``request_kwargs``? Anything that
+    the `Requests`_ functions accept. You can set ``verify``, ``auth`` and
+    more.
+
+    The ``url`` argument is slightly special. When making a call, it is
+    possible to pass in a relative URL:
+
+    >>> from pulp_smash.api import Client
+    >>> from pulp_smash.config import get_config
+    >>> client = Client(get_config())
+    >>> response = client.get('/pulp/api/v2/')  # i.e. url='/pulp/api/v2/'
+
+    What happens here? When a request is made, ``client.request_kwargs['url']``
+    is joined to ``'/pulp/api/v2/'`` using ``urljoin`` (from the standard
+    library). This allows one to easily use the hrefs returned by Pulp in
+    constructing new requests. Refer back to the "users" example in this
+    docstring as an example.
+
+    The remainder of this docstring contains design notes. They should not be
+    necessary for an end user, but may be useful to developers interested in
+    hacking at this class.
+
+    Requests' ``requests.api.post`` method has the following signature::
+
+        def post(url, data=None, json=None, **kwargs)
+
+    Pulp supports only JSON for most of its API endpoints, so it makes sense
+    for us to demote ``data`` to being a regular kwarg and list ``json`` as the
+    one and only positional argument.
+
+    We make ``json`` a positional argument for ``post()``, ``put()`` and
+    ``patch()``, but not the other methods. Why? Because HTTP OPTIONS, GET,
+    HEAD and DELETE **must not** have bodies. This is stated by the HTTP/1.1
+    specification, and network intermediaries such as caches are at liberty to
+    drop such bodies.
+
+    Why the sentinel? Imagine the following scenario: a user provides a default
+    JSON payload in ``self.request_kwargs``, but they want to skip sending that
+    payload for just one request. How can they do that? With ``client.post(url,
+    None)``.
+
+    .. _Pulp: http://www.pulpproject.org/
+    .. _Requests: http://docs.python-requests.org/en/latest/
+    """
+
+    def __init__(
+            self,
+            server_config,
+            response_handler=None,
+            request_kwargs=None,
+    ):
+        """Initialize this object with needed instance attributes."""
+        self._cfg = server_config
+        self.request_kwargs = self._cfg.get_requests_kwargs()
+        self.request_kwargs['url'] = self._cfg.base_url
+        self.request_kwargs.update(
+            {} if request_kwargs is None else request_kwargs
+        )
+        if response_handler is None:
+            self.response_handler = safe_handler
+        else:
+            self.response_handler = response_handler
+
+    def delete(self, url, **kwargs):
+        """Send an HTTP DELETE request."""
+        return self.request('DELETE', url, **kwargs)
+
+    def get(self, url, **kwargs):
+        """Send an HTTP GET request."""
+        return self.request('GET', url, **kwargs)
+
+    def head(self, url, **kwargs):
+        """Send an HTTP HEAD request."""
+        return self.request('HEAD', url, **kwargs)
+
+    def options(self, url, **kwargs):
+        """Send an HTTP OPTIONS request."""
+        return self.request('OPTIONS', url, **kwargs)
+
+    def patch(self, url, json=_SENTINEL, **kwargs):
+        """Send an HTTP PATCH request."""
+        if json is _SENTINEL:
+            return self.request('PATCH', url, **kwargs)
+        else:
+            return self.request('PATCH', url, json=json, **kwargs)
+
+    def post(self, url, json=_SENTINEL, **kwargs):
+        """Send an HTTP POST request."""
+        if json is _SENTINEL:
+            return self.request('POST', url, **kwargs)
+        else:
+            return self.request('POST', url, json=json, **kwargs)
+
+    def put(self, url, json=_SENTINEL, **kwargs):
+        """Send an HTTP PUT request."""
+        if json is _SENTINEL:
+            return self.request('PUT', url, **kwargs)
+        else:
+            return self.request('PUT', url, json=json, **kwargs)
+
+    def request(self, method, url, **kwargs):
+        """Send an HTTP request.
+
+        Arguments passed directly in to this method override (but do not
+        overwrite!) arguments specified in ``self.request_kwargs``.
+        """
+        # The `self.request_kwargs` dict should *always* have a "url" argument.
+        # This is enforced by `self.__init__`. This allows us to call the
+        # `requests.request` function and satisfy its signature:
+        #
+        #     request(method, url, **kwargs)
+        #
+        request_kwargs = self.request_kwargs.copy()
+        request_kwargs['url'] = urljoin(request_kwargs['url'], url)
+        request_kwargs.update(kwargs)
+        return self.response_handler(
+            self._cfg,
+            requests.request(method, **request_kwargs),
+        )

--- a/pulp_smash/selectors.py
+++ b/pulp_smash/selectors.py
@@ -1,0 +1,160 @@
+# coding=utf-8
+"""Tools for selecting and deselecting tests."""
+from __future__ import unicode_literals
+
+import warnings
+from functools import wraps
+
+import requests
+from packaging.version import Version
+
+# These are all possible values for a bug's "status" field.
+#
+# These statuses apply to bugs filed at https://pulp.plan.io. They are ordered
+# according to an ideal workflow. As of this writing, these is no canonical
+# public source for this information. But see:
+# http://pulp.readthedocs.org/en/latest/dev-guide/contributing/bugs.html#fixing
+_UNTESTABLE_BUGS = frozenset((
+    'NEW',  # bug just entered into tracker
+    'ASSIGNED',  # bug has been assigned to an engineer
+    'POST',  # bug fix is being reviewed by dev ("posted for review")
+))
+_TESTABLE_BUGS = frozenset((
+    'MODIFIED',  # bug fix has been accepted by dev
+    'ON_QA',  # bug fix is being reviewed by qe
+    'VERIFIED',  # bug fix has been accepted by qe
+    'CLOSED - CURRENTRELEASE',
+    'CLOSED - DUPLICATE',
+    'CLOSED - NOTABUG',
+    'CLOSED - WONTFIX',
+    'CLOSED - WORKSFORME',
+))
+
+# A mapping between bug IDs and bug statuses. Used by `_get_bug_status`.
+#
+# Bug IDs and statuses should be integers and strings, respectively. Example:
+#
+#     _BUG_STATUS_CACHE[1356] → 'NEW'
+#     _BUG_STATUS_CACHE['1356'] → KeyError
+#
+_BUG_STATUS_CACHE = {}
+
+
+def _get_bug_status(bug_id):
+    """Fetch information about bug ``bug_id`` from https://pulp.plan.io."""
+    # Declaring as global right before assignment triggers: `SyntaxWarning:
+    # name '_BUG_STATUS_CACHE' is used prior to global declaration`
+    global _BUG_STATUS_CACHE  # pylint:disable=global-variable-not-assigned
+
+    # It's rarely a good idea to do type checking in a duck-typed language.
+    # However, efficiency dictates we do so here. Without this type check, the
+    # following will cause us to talk to the bug tracker twice and store two
+    # values in the cache:
+    #
+    #     _get_bug_status(1356)
+    #     _get_bug_status('1356')
+    #
+    if not isinstance(bug_id, int):
+        raise TypeError(
+            'Bug IDs should be integers. The given ID, {} is a {}.'
+            .format(bug_id, type(bug_id))
+        )
+    try:
+        return _BUG_STATUS_CACHE[bug_id]
+    except KeyError:
+        pass
+
+    # Get, cache and return bug status.
+    response = requests.get(
+        'https://pulp.plan.io/issues/{}.json'.format(bug_id)
+    )
+    response.raise_for_status()
+    _BUG_STATUS_CACHE[bug_id] = response.json()['issue']['status']['name']
+    return _BUG_STATUS_CACHE[bug_id]
+
+
+class BugStatusUnknownError(Exception):
+    """Indicates a bug has a status that Pulp Smash doesn't know about."""
+
+
+def bug_is_testable(bug_id):
+    """Tell the caller whether bug ``bug_id`` should be tested.
+
+    :param bug_id: An integer bug ID, taken from https://pulp.plan.io.
+    :returns: ``True`` if the bug is testable, or ``False`` otherwise.
+    :raises: ``TypeError`` if ``bug_id`` is not an integer.
+    :raises pulp_smash.selectors.BugStatusUnknownError: If the bug has a status
+        Pulp Smash does not recognize.
+    :raises: BugTrackerUnavailableWarning: If the bug tracker cannot be
+        contacted.
+    """
+    try:
+        status = _get_bug_status(bug_id)
+    except requests.exceptions.ConnectionError as err:
+        message = (
+            'Cannot contact the bug tracker. Pulp Smash will assume that the '
+            'bug referenced is testable. Error: {}'.format(err)
+        )
+        warnings.warn(message, RuntimeWarning)
+        return True
+
+    if status in _TESTABLE_BUGS:
+        return True
+    elif status in _UNTESTABLE_BUGS:
+        return False
+    else:
+        # Alternately, we could raise a warning and `return True`.
+        raise BugStatusUnknownError(
+            'Bug {} has a status of {}. Pulp Smash only knows how to handle '
+            'the following statuses: {}'
+            .format(bug_id, status, _TESTABLE_BUGS | _UNTESTABLE_BUGS)
+        )
+
+
+def bug_is_untestable(bug_id):
+    """Return the inverse of :meth:`bug_is_testable`."""
+    return not bug_is_testable(bug_id)
+
+
+def require(version_string):
+    """A decorator for optionally skipping test methods.
+
+    This decorator concisely encapsulates a common pattern for skipping tests.
+    It can be used like so:
+
+    >>> from pulp_smash.config import get_config
+    >>> from pulp_smash.utils import require
+    >>> from unittest import TestCase
+    >>> class MyTestCase(TestCase):
+    ...
+    ...     @classmethod
+    ...     def setUpClass(cls):
+    ...         cls.cfg = get_config()
+    ...
+    ...     @require('2.7')  # References `self.cfg`
+    ...     def test_foo(self):
+    ...         pass  # Add a test for Pulp 2.7+ here.
+
+    Notice that ``cls.cfg`` is assigned to. This is a **requirement**.
+
+    :param version_string: A PEP 440 compatible version string.
+    """
+    # Running the test suite can take a long time. Let's parse the version
+    # string now instead of waiting until the test is running.
+    min_version = Version(version_string)
+
+    def plain_decorator(test_method):
+        """An argument-less decorator. Accepts the function being wrapped."""
+        @wraps(test_method)
+        def new_test_method(self, *args, **kwargs):
+            """A wrapper around a test method."""
+            if self.cfg.version < min_version:
+                self.skipTest(
+                    'This test requires Pulp {} or later, but Pulp {} is '
+                    'being tested. If this seems wrong, try checking the '
+                    '"settings" option in the Pulp Smash configuration file.'
+                    .format(version_string, self.cfg.version)
+                )
+            return test_method(self, *args, **kwargs)
+        return new_test_method
+    return plain_decorator

--- a/pulp_smash/tests/platform/api_v2/test_content_applicability.py
+++ b/pulp_smash/tests/platform/api_v2/test_content_applicability.py
@@ -10,7 +10,7 @@ import requests
 from packaging.version import Version
 from unittest2 import TestCase
 
-from pulp_smash import utils
+from pulp_smash import selectors
 from pulp_smash.config import get_config
 from pulp_smash.constants import CALL_REPORT_KEYS
 
@@ -49,7 +49,7 @@ class SuccessTestCase(TestCase):
         for i, response in enumerate(self.responses):
             with self.subTest(i):
                 if (i == 1 and self.cfg.version >= Version('2.8') and
-                        utils.bug_is_untestable(1448)):
+                        selectors.bug_is_untestable(1448)):
                     self.skipTest('https://pulp.plan.io/issues/1448')
                 self.assertEqual(
                     frozenset(response.json().keys()),

--- a/pulp_smash/tests/platform/api_v2/test_login.py
+++ b/pulp_smash/tests/platform/api_v2/test_login.py
@@ -9,9 +9,9 @@ from __future__ import unicode_literals
 import requests
 from unittest2 import TestCase
 
+from pulp_smash import selectors
 from pulp_smash.config import get_config
 from pulp_smash.constants import ERROR_KEYS, LOGIN_KEYS, LOGIN_PATH
-from pulp_smash.utils import bug_is_untestable
 
 
 class LoginSuccessTestCase(TestCase):
@@ -54,6 +54,6 @@ class LoginFailureTestCase(TestCase):
 
     def test_body(self):
         """Assert that the response is valid JSON and has correct keys."""
-        if bug_is_untestable(1412):
+        if selectors.bug_is_untestable(1412):
             self.skipTest('https://pulp.plan.io/issues/1412')
         self.assertEqual(frozenset(self.response.json().keys()), ERROR_KEYS)

--- a/pulp_smash/tests/platform/api_v2/test_login.py
+++ b/pulp_smash/tests/platform/api_v2/test_login.py
@@ -6,11 +6,9 @@
 """
 from __future__ import unicode_literals
 
-import requests
 from unittest2 import TestCase
 
-from pulp_smash import selectors
-from pulp_smash.config import get_config
+from pulp_smash import api, config, selectors
 from pulp_smash.constants import ERROR_KEYS, LOGIN_KEYS, LOGIN_PATH
 
 
@@ -20,11 +18,7 @@ class LoginSuccessTestCase(TestCase):
     @classmethod
     def setUpClass(cls):
         """Successfully log in to the server."""
-        cfg = get_config()
-        cls.response = requests.post(
-            cfg.base_url + LOGIN_PATH,
-            **cfg.get_requests_kwargs()
-        )
+        cls.response = api.Client(config.get_config()).post(LOGIN_PATH)
 
     def test_status_code(self):
         """Assert that the response has an HTTP 200 status code."""
@@ -41,12 +35,8 @@ class LoginFailureTestCase(TestCase):
     @classmethod
     def setUpClass(cls):
         """Unsuccessfully log in to the server."""
-        cfg = get_config()
-        cfg.auth = ('', '')
-        cls.response = requests.post(
-            cfg.base_url + LOGIN_PATH,
-            **cfg.get_requests_kwargs()
-        )
+        client = api.Client(config.get_config(), api.echo_handler)
+        cls.response = client.post(LOGIN_PATH, auth=('', ''))
 
     def test_status_code(self):
         """Assert that the response has an HTTP 401 status code."""

--- a/pulp_smash/tests/platform/api_v2/test_repository.py
+++ b/pulp_smash/tests/platform/api_v2/test_repository.py
@@ -27,13 +27,8 @@ from unittest2 import TestCase
 
 from pulp_smash.config import get_config
 from pulp_smash.constants import REPOSITORY_PATH, ERROR_KEYS
-from pulp_smash.utils import (
-    bug_is_untestable,
-    create_repository,
-    delete,
-    require,
-    uuid4,
-)
+from pulp_smash.selectors import bug_is_untestable, require
+from pulp_smash.utils import create_repository, delete, uuid4
 
 
 class CreateSuccessTestCase(TestCase):

--- a/pulp_smash/tests/rpm/api_v2/test_iso_crud.py
+++ b/pulp_smash/tests/rpm/api_v2/test_iso_crud.py
@@ -11,7 +11,7 @@ import requests
 import unittest2
 from packaging.version import Version
 
-from pulp_smash import config, constants, utils
+from pulp_smash import config, constants, selectors, utils
 
 
 _DISTRIBUTOR = {
@@ -207,7 +207,8 @@ class ReadUpdateDeleteTestCase(_BaseTestCase):
 
     def test_read_distributors(self):
         """Assert each read w/distributors contains info about distributors."""
-        if self.cfg.version < Version('2.8') and utils.bug_is_untestable(1452):
+        if (self.cfg.version < Version('2.8') and
+                selectors.bug_is_untestable(1452)):
             self.skipTest('https://pulp.plan.io/issues/1452')
         for key in {'read_distributors', 'read_details'}:
             with self.subTest(key=key):

--- a/pulp_smash/tests/rpm/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_sync_publish.py
@@ -43,8 +43,8 @@ from unittest2 import TestCase
 
 from pulp_smash.config import get_config
 from pulp_smash.constants import CALL_REPORT_KEYS
+from pulp_smash.selectors import bug_is_untestable
 from pulp_smash.utils import (
-    bug_is_untestable,
     create_repository,
     delete,
     get,

--- a/pulp_smash/utils.py
+++ b/pulp_smash/utils.py
@@ -3,8 +3,6 @@
 from __future__ import unicode_literals
 
 import uuid
-import warnings
-from functools import wraps
 from time import sleep
 try:  # try Python 3 import first
     from urllib.parse import urljoin
@@ -12,51 +10,15 @@ except ImportError:
     from urlparse import urljoin  # pylint:disable=C0411,E0401
 
 import requests
-from packaging.version import Version
 
 from pulp_smash.constants import REPOSITORY_PATH, USER_PATH
 
 
 _TASK_END_STATES = ('canceled', 'error', 'finished', 'skipped', 'timed out')
 
-# These are all possible values for a bug's "status" field.
-#
-# These statuses apply to bugs filed at https://pulp.plan.io. They are ordered
-# according to an ideal workflow. As of this writing, these is no canonical
-# public source for this information. But see:
-# http://pulp.readthedocs.org/en/latest/dev-guide/contributing/bugs.html#fixing
-_UNTESTABLE_BUGS = frozenset((
-    'NEW',  # bug just entered into tracker
-    'ASSIGNED',  # bug has been assigned to an engineer
-    'POST',  # bug fix is being reviewed by dev ("posted for review")
-))
-_TESTABLE_BUGS = frozenset((
-    'MODIFIED',  # bug fix has been accepted by dev
-    'ON_QA',  # bug fix is being reviewed by qe
-    'VERIFIED',  # bug fix has been accepted by qe
-    'CLOSED - CURRENTRELEASE',
-    'CLOSED - DUPLICATE',
-    'CLOSED - NOTABUG',
-    'CLOSED - WONTFIX',
-    'CLOSED - WORKSFORME',
-))
-
-# A mapping between bug IDs and bug statuses. Used by `_get_bug_status`.
-#
-# Bug IDs and statuses should be integers and strings, respectively. Example:
-#
-#     _BUG_STATUS_CACHE[1356] → 'NEW'
-#     _BUG_STATUS_CACHE['1356'] → KeyError
-#
-_BUG_STATUS_CACHE = {}
-
 
 class TaskTimedOutException(Exception):
     """Indicates that polling a task timed out."""
-
-
-class BugStatusUnknownError(Exception):
-    """Indicates a bug has a status that Pulp Smash doesn't know about."""
 
 
 def uuid4():
@@ -243,50 +205,6 @@ def publish_repository(server_config, href, distributor_id, responses=None):
     ), responses)
 
 
-def require(version_string):
-    """A decorator for optionally skipping test methods.
-
-    This decorator concisely encapsulates a common pattern for skipping tests.
-    It can be used like so:
-
-    >>> from pulp_smash.config import get_config
-    >>> from pulp_smash.utils import require
-    >>> from unittest import TestCase
-    >>> class MyTestCase(TestCase):
-    ...
-    ...     @classmethod
-    ...     def setUpClass(cls):
-    ...         cls.cfg = get_config()
-    ...
-    ...     @require('2.7')  # References `self.cfg`
-    ...     def test_foo(self):
-    ...         pass  # Add a test for Pulp 2.7+ here.
-
-    Notice that ``cls.cfg`` is assigned to. This is a **requirement**.
-
-    :param version_string: A PEP 440 compatible version string.
-    """
-    # Running the test suite can take a long time. Let's parse the version
-    # string now instead of waiting until the test is running.
-    min_version = Version(version_string)
-
-    def plain_decorator(test_method):
-        """An argument-less decorator. Accepts the function being wrapped."""
-        @wraps(test_method)
-        def new_test_method(self, *args, **kwargs):
-            """A wrapper around a test method."""
-            if self.cfg.version < min_version:
-                self.skipTest(
-                    'This test requires Pulp {} or later, but Pulp {} is '
-                    'being tested. If this seems wrong, try checking the '
-                    '"settings" option in the Pulp Smash configuration file.'
-                    .format(version_string, self.cfg.version)
-                )
-            return test_method(self, *args, **kwargs)
-        return new_test_method
-    return plain_decorator
-
-
 def sync_repository(server_config, href, responses=None):
     """Sync a repository.
 
@@ -301,75 +219,3 @@ def sync_repository(server_config, href, responses=None):
         json={'override_config': {}},
         **server_config.get_requests_kwargs()
     ), responses)
-
-
-def _get_bug_status(bug_id):
-    """Fetch information about bug ``bug_id`` from https://pulp.plan.io."""
-    # Declaring as global right before assignment triggers: `SyntaxWarning:
-    # name '_BUG_STATUS_CACHE' is used prior to global declaration`
-    global _BUG_STATUS_CACHE  # pylint:disable=global-variable-not-assigned
-
-    # It's rarely a good idea to do type checking in a duck-typed language.
-    # However, efficiency dictates we do so here. Without this type check, the
-    # following will cause us to talk to the bug tracker twice and store two
-    # values in the cache:
-    #
-    #     _get_bug_status(1356)
-    #     _get_bug_status('1356')
-    #
-    if not isinstance(bug_id, int):
-        raise TypeError(
-            'Bug IDs should be integers. The given ID, {} is a {}.'
-            .format(bug_id, type(bug_id))
-        )
-    try:
-        return _BUG_STATUS_CACHE[bug_id]
-    except KeyError:
-        pass
-
-    # Get, cache and return bug status.
-    response = requests.get(
-        'https://pulp.plan.io/issues/{}.json'.format(bug_id)
-    )
-    response.raise_for_status()
-    _BUG_STATUS_CACHE[bug_id] = response.json()['issue']['status']['name']
-    return _BUG_STATUS_CACHE[bug_id]
-
-
-def bug_is_testable(bug_id):
-    """Tell the caller whether bug ``bug_id`` should be tested.
-
-    :param bug_id: An integer bug ID, taken from https://pulp.plan.io.
-    :returns: ``True`` if the bug is testable, or ``False`` otherwise.
-    :raises: ``TypeError`` if ``bug_id`` is not an integer.
-    :raises pulp_smash.utils.BugStatusUnknownError: If the bug has a status
-        Pulp Smash does not recognize.
-    :raises: BugTrackerUnavailableWarning: If the bug tracker cannot be
-        contacted.
-    """
-    try:
-        status = _get_bug_status(bug_id)
-    except requests.exceptions.ConnectionError as err:
-        message = (
-            'Cannot contact the bug tracker. Pulp Smash will assume that the '
-            'bug referenced is testable. Error: {}'.format(err)
-        )
-        warnings.warn(message, RuntimeWarning)
-        return True
-
-    if status in _TESTABLE_BUGS:
-        return True
-    elif status in _UNTESTABLE_BUGS:
-        return False
-    else:
-        # Alternately, we could raise a warning and `return True`.
-        raise BugStatusUnknownError(
-            'Bug {} has a status of {}. Pulp Smash only knows how to handle '
-            'the following statuses: {}'
-            .format(bug_id, status, _TESTABLE_BUGS | _UNTESTABLE_BUGS)
-        )
-
-
-def bug_is_untestable(bug_id):
-    """Return the inverse of :meth:`bug_is_testable`."""
-    return not bug_is_testable(bug_id)

--- a/pulp_smash/utils.py
+++ b/pulp_smash/utils.py
@@ -11,7 +11,7 @@ except ImportError:
 
 import requests
 
-from pulp_smash.constants import REPOSITORY_PATH, USER_PATH
+from pulp_smash.constants import REPOSITORY_PATH
 
 
 _TASK_END_STATES = ('canceled', 'error', 'finished', 'skipped', 'timed out')
@@ -37,22 +37,6 @@ def create_repository(server_config, body, responses=None):
     """
     return handle_response(requests.post(
         urljoin(server_config.base_url, REPOSITORY_PATH),
-        json=body,
-        **server_config.get_requests_kwargs()
-    ), responses)
-
-
-def create_user(server_config, body, responses=None):
-    """Create a user. Return the response body.
-
-    :param server_config: A :class:`pulp_smash.config.ServerConfig` object.
-    :param body: An object to encode as JSON and pass as the request body.
-    :param responses: Same as :meth:`handle_response`.
-    :returns: Same as :meth:`handle_response`.
-    :raises: Same as :meth:`handle_response`.
-    """
-    return handle_response(requests.post(
-        urljoin(server_config.base_url, USER_PATH),
         json=body,
         **server_config.get_requests_kwargs()
     ), responses)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,108 @@
+# coding=utf-8
+"""Unit tests for :mod:`pulp_smash.api`."""
+from __future__ import unicode_literals
+
+import mock
+import unittest2
+
+from pulp_smash import api, config
+
+
+class EchoHandlerTestCase(unittest2.TestCase):
+    """Tests for :func:`pulp_smash.api.echo_handler`."""
+
+    def test_return(self):
+        """Assert the passed-in ``response`` is returned."""
+        kwargs = {key: mock.Mock() for key in ('server_config', 'response')}
+        self.assertIs(kwargs['response'], api.echo_handler(**kwargs))
+
+    def test_raise_for_status(self):
+        """Assert ``response.raise_for_status()`` is not called."""
+        kwargs = {key: mock.Mock() for key in ('server_config', 'response')}
+        api.echo_handler(**kwargs)
+        self.assertEqual(kwargs['response'].raise_for_status.call_count, 0)
+
+    def test_202_check_skipped(self):
+        """Assert HTTP 202 responses are not treated specially."""
+        kwargs = {key: mock.Mock() for key in ('server_config', 'response')}
+        with mock.patch.object(api, '_handle_202') as handle_202:
+            api.echo_handler(**kwargs)
+        self.assertEqual(handle_202.call_count, 0)
+
+
+class SafeHandlerTestCase(unittest2.TestCase):
+    """Tests for :func:`pulp_smash.api.safe_handler`."""
+
+    def test_return(self):
+        """Assert the passed-in ``response`` is returned."""
+        kwargs = {key: mock.Mock() for key in ('server_config', 'response')}
+        self.assertIs(kwargs['response'], api.safe_handler(**kwargs))
+
+    def test_raise_for_status(self):
+        """Assert ``response.raise_for_status()`` is called."""
+        kwargs = {key: mock.Mock() for key in ('server_config', 'response')}
+        api.safe_handler(**kwargs)
+        self.assertEqual(kwargs['response'].raise_for_status.call_count, 1)
+
+    def test_202_check_run(self):
+        """Assert HTTP 202 responses are not treated specially."""
+        kwargs = {key: mock.Mock() for key in ('server_config', 'response')}
+        with mock.patch.object(api, '_handle_202') as handle_202:
+            api.safe_handler(**kwargs)
+        self.assertEqual(handle_202.call_count, 1)
+
+
+class JsonHandlerTestCase(unittest2.TestCase):
+    """Tests for :func:`pulp_smash.api.json_handler`."""
+
+    def test_return(self):
+        """Assert the JSON-decoded body of ``response`` is returned."""
+        kwargs = {key: mock.Mock() for key in ('server_config', 'response')}
+        out = api.json_handler(**kwargs)
+        self.assertEqual(kwargs['response'].json.return_value, out)
+
+    def test_raise_for_status(self):
+        """Assert ``response.raise_for_status()`` is called."""
+        kwargs = {key: mock.Mock() for key in ('server_config', 'response')}
+        api.json_handler(**kwargs)
+        self.assertEqual(kwargs['response'].raise_for_status.call_count, 1)
+
+    def test_202_check_run(self):
+        """Assert HTTP 202 responses are not treated specially."""
+        kwargs = {key: mock.Mock() for key in ('server_config', 'response')}
+        with mock.patch.object(api, '_handle_202') as handle_202:
+            api.json_handler(**kwargs)
+        self.assertEqual(handle_202.call_count, 1)
+
+
+class ClientTestCase(unittest2.TestCase):
+    """Tests for :class:`pulp_smash.api.Client`."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Assert methods delegate to :meth:`pulp_smash.api.Client.request`.
+
+        All methods on :class:`pulp_smash.api.Client`, such as
+        :meth:`pulp_smash.api.Client.delete`, should delegate to
+        :meth:`pulp_smash.api.Client.request`. Mock out ``request`` and call
+        the other methods.
+        """
+        methods = {'delete', 'get', 'head', 'options', 'patch', 'post', 'put'}
+        cls.mocks = {}
+        for method in methods:
+            client = api.Client(config.ServerConfig('http://example.com'))
+            with mock.patch.object(client, 'request') as request:
+                getattr(client, method)('')
+            cls.mocks[method] = request
+
+    def test_called_once(self):
+        """Assert each method calls ``request`` exactly once."""
+        for meth, request in self.mocks.items():
+            with self.subTest(meth=meth):
+                self.assertEqual(request.call_count, 1)
+
+    def test_http_action(self):
+        """Assert each method calls ``request`` with the right HTTP action."""
+        for meth, request in self.mocks.items():
+            with self.subTest(meth=meth):
+                self.assertEqual(request.call_args[0][0], meth.upper())

--- a/tests/test_selectors.py
+++ b/tests/test_selectors.py
@@ -1,0 +1,50 @@
+# coding=utf-8
+"""Unit tests for :mod:`pulp_smash.selectors`."""
+from __future__ import unicode_literals
+
+import random
+
+import mock
+from unittest2 import TestCase
+
+from pulp_smash import selectors
+
+
+class BugTestableTestCase(TestCase):
+    """Test :meth:`pulp_smash.selectors.bug_is_testable` and its partner."""
+
+    def test_testable_status(self):
+        """Make the dependent function return a "testable" bug status."""
+        with mock.patch.object(
+            selectors,
+            '_get_bug_status',
+            # pylint:disable=protected-access
+            return_value=random.sample(selectors._TESTABLE_BUGS, 1)[0]
+        ):
+            with self.subTest():
+                self.assertTrue(selectors.bug_is_testable(None))
+            with self.subTest():
+                self.assertFalse(selectors.bug_is_untestable(None))
+
+    def test_untestable_status(self):
+        """Make the dependent function return a "untestable" bug status."""
+        with mock.patch.object(
+            selectors,
+            '_get_bug_status',
+            # pylint:disable=protected-access
+            return_value=random.sample(selectors._UNTESTABLE_BUGS, 1)[0]
+        ):
+            with self.subTest():
+                self.assertFalse(selectors.bug_is_testable(None))
+            with self.subTest():
+                self.assertTrue(selectors.bug_is_untestable(None))
+
+    def test_unknown_status(self):
+        """Make the dependent function return an unknown bug status."""
+        with mock.patch.object(
+            selectors,
+            '_get_bug_status',
+            return_value=None,
+        ):
+            with self.assertRaises(selectors.BugStatusUnknownError):
+                selectors.bug_is_testable(None)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -69,23 +69,6 @@ class CreateRepositoryTestCase(CommonAssertionsMixin, TestCase):
         cls.mocks = {'handle_response': hand_resp, 'request': request}
 
 
-class CreateUserTestCase(CommonAssertionsMixin, TestCase):
-    """Test :meth:`pulp_smash.utils.create_user`."""
-
-    @classmethod
-    def setUpClass(cls):
-        """Mock out dependencies and call the function under test."""
-        inputs = {
-            'server_config': ServerConfig('http://example.com'),
-            'body': None,
-            'responses': None,
-        }
-        with mock.patch.object(utils, 'handle_response') as hand_resp:
-            with mock.patch.object(requests, 'post') as request:
-                cls.output = utils.create_user(**inputs)
-        cls.mocks = {'handle_response': hand_resp, 'request': request}
-
-
 class DeleteTestCase(CommonAssertionsMixin, TestCase):
     """Test :meth:`pulp_smash.utils.delete`."""
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,8 +2,6 @@
 """Unit tests for :mod:`pulp_smash.utils`."""
 from __future__ import unicode_literals
 
-import random
-
 import mock
 import requests
 from unittest2 import TestCase
@@ -189,39 +187,3 @@ class SyncRepositoryTestCase(CommonAssertionsMixin, TestCase):
             with mock.patch.object(requests, 'post') as request:
                 cls.output = utils.sync_repository(**inputs)
         cls.mocks = {'handle_response': hand_resp, 'request': request}
-
-
-class BugTestableTestCase(TestCase):
-    """Test :meth:`pulp_smash.utils.bug_is_testable` and its counterpart."""
-
-    def test_testable_status(self):
-        """Make the dependent function return a "testable" bug status."""
-        with mock.patch.object(
-            utils,
-            '_get_bug_status',
-            # pylint:disable=protected-access
-            return_value=random.sample(utils._TESTABLE_BUGS, 1)[0]
-        ):
-            with self.subTest():
-                self.assertTrue(utils.bug_is_testable(None))
-            with self.subTest():
-                self.assertFalse(utils.bug_is_untestable(None))
-
-    def test_untestable_status(self):
-        """Make the dependent function return a "untestable" bug status."""
-        with mock.patch.object(
-            utils,
-            '_get_bug_status',
-            # pylint:disable=protected-access
-            return_value=random.sample(utils._UNTESTABLE_BUGS, 1)[0]
-        ):
-            with self.subTest():
-                self.assertFalse(utils.bug_is_testable(None))
-            with self.subTest():
-                self.assertTrue(utils.bug_is_untestable(None))
-
-    def test_unknown_status(self):
-        """Make the dependent function return an unknown bug status."""
-        with mock.patch.object(utils, '_get_bug_status', return_value=None):
-            with self.assertRaises(utils.BugStatusUnknownError):
-                utils.bug_is_testable(None)


### PR DESCRIPTION
Partially address #64. Introduce, document and partially unit test a new class, `pulp_smash.api.Client`. This series of commits reworks the following modules:

* `pulp_smash.tests.platform.api_v2.test_user`
* `pulp_smash.tests.platform.api_v2.test_login`
* `pulp_smash.tests.platform.api_v2.test_content_applicability`
* `pulp_smash.tests.platform.api_v2.test_search`

Also move functions for selecting and deselecting tests (such as `@require`) to `pulp_smash.selectors`.