### PR TITLE
Add a CLI helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ lint-pylint:
 		pulp_smash/__init__.py \
 		pulp_smash/__main__.py \
 		pulp_smash/api.py \
+		pulp_smash/cli.py \
 		pulp_smash/config.py \
 		pulp_smash/constants.py \
 		pulp_smash/selectors.py \
@@ -42,7 +43,7 @@ test:
 	python $(TEST_OPTIONS)
 
 test-coverage:
-	coverage run --source pulp_smash.api,pulp_smash.config,pulp_smash.selectors,pulp_smash.utils \
+	coverage run --source pulp_smash.api,pulp_smash.cli,pulp_smash.config,pulp_smash.selectors,pulp_smash.utils \
 	$(TEST_OPTIONS)
 
 package:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -12,6 +12,7 @@ developers, not a gospel.
 
     api/pulp_smash
     api/pulp_smash.api
+    api/pulp_smash.cli
     api/pulp_smash.config
     api/pulp_smash.constants
     api/pulp_smash.selectors
@@ -36,6 +37,7 @@ developers, not a gospel.
     api/pulp_smash.utils
     api/tests
     api/tests.test_api
+    api/tests.test_cli
     api/tests.test_config
     api/tests.test_selectors
     api/tests.test_utils

--- a/docs/api/pulp_smash.cli.rst
+++ b/docs/api/pulp_smash.cli.rst
@@ -1,0 +1,6 @@
+`pulp_smash.cli`
+================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.cli`
+
+.. automodule:: pulp_smash.cli

--- a/docs/api/tests.test_cli.rst
+++ b/docs/api/tests.test_cli.rst
@@ -1,0 +1,6 @@
+`tests.test_cli`
+================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/tests.test_cli`
+
+.. automodule:: tests.test_cli

--- a/pulp_smash/__main__.py
+++ b/pulp_smash/__main__.py
@@ -20,15 +20,19 @@ MESSAGE = tuple((
         "base_url": "https://pulp.example.com",
         "auth": ["username", "password"],
         "verify": true,
-        "version": "2.7.5"
+        "version": "2.7.5",
+        "cli_transport": "local"
     }}''',
     '''\
-    The `verify` and `version` keys are completely optional. By default, Pulp
-    Smash respects SSL verification procedures, but the `verify` option can be
-    used to explicitly enable or disable SSL verification. By default, Pulp
-    Smash assumes that the Pulp server under test is the absolute latest
-    development version, but the `version` option can be used to explicitly run
-    tests suitable for an older version of Pulp.
+    The `verify`, `version` and `cli_transport` keys are optional. The `verify`
+    option can be used to explicitly enable or disable SSL verification. The
+    `version` option can be used to explicitly run tests suitable for an older
+    version of Pulp. By default, Pulp Smash assumes that the Pulp server under
+    test is the latest development version. The `cli_transport` key can be used
+    to explicitly choose how to contact the Pulp server when executing shell
+    commands. This can be set to "local" or "ssh". If omitted, Pulp Smash
+    guesses which transport to use by comparing the hostname in the `base_url`
+    against the current system's hostname.
     ''',
     '''\
     Notes:

--- a/pulp_smash/cli.py
+++ b/pulp_smash/cli.py
@@ -1,0 +1,189 @@
+# coding=utf-8
+"""Tools for working with Pulp's CLI."""
+from __future__ import unicode_literals
+
+import socket
+import subprocess
+from sys import version_info
+try:  # try Python 3 import first
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse  # pylint:disable=C0411,E0401
+
+import plumbum
+
+
+def _get_hostname(urlstring):
+    """Get the hostname from a URL string.
+
+    ``urlparse`` follows RFC 1808 and requires that network locations be
+    prefixed with "//". This function is a thin wrapper. It treats the leading
+    "//" as optional::
+
+    >>> urls = ('ftp://localhost', '//localhost', 'localhost', 'localhost:123')
+    >>> for url in urls:
+    ...     print((_get_hostname(url), urlparse(url).hostname))
+    ('localhost', 'localhost')
+    ('localhost', 'localhost')
+    ('localhost', None)
+    ('localhost', None)
+
+    Usage::
+
+        if server_config is None:
+            server_config = get_config()
+        hostname = _get_hostname(server_config.base_url)
+
+    :param urlstring: A string such as "localhost:3000", "pulp.example.com" or
+        "https://pulp.example.com".
+    :returns: A hostname, such as "localhost" or "pulp.example.com".
+
+    """
+    parts = urlparse(urlstring)
+    if parts.hostname is None:
+        return _get_hostname('//' + parts.path)
+    else:
+        return parts.hostname
+
+
+def echo_handler(completed_proc):
+    """Immediately return ``completed_proc``."""
+    return completed_proc
+
+
+def code_handler(completed_proc):
+    """Check the process for a non-zero return code. Return the process.
+
+    Check the return code by calling ``completed_proc.check_returncode()``.
+    See: :meth:`pulp_smash.cli.CompletedProcess.check_returncode`.
+    """
+    completed_proc.check_returncode()
+    return completed_proc
+
+
+class CompletedProcess(object):
+    # pylint:disable=too-few-public-methods
+    """A process that has finished running.
+
+    This class mimics the ``subprocess.CompletedProcess`` class available in
+    Python 3.5 and above. It has minor differences, such as requiring all
+    constructor arguments. An instance of this class is returned by
+    :meth:`pulp_smash.cli.Client.run`.
+
+    All constructor arguments are stored as instance attributes.
+
+    :param args: The list or str args passed to run().
+    :param returncode: The exit code of the process, negative for signals.
+    :param stdout: The standard output.
+    :param stderr: The standard error.
+    """
+
+    def __init__(self, args, returncode, stdout, stderr):
+        """Initialize a new object."""
+        self.args = args
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+    def __repr__(self):
+        """Provide an ``eval``-compatible string representation."""
+        str_kwargs = ', '.join([
+            'args={!r}'.format(self.args),
+            'returncode={!r}'.format(self.returncode),
+            'stdout={!r}'.format(self.stdout),
+            'stderr={!r}'.format(self.stderr),
+        ])
+        return '{}({})'.format(type(self).__name__, str_kwargs)
+
+    def check_returncode(self):
+        """Raise ``subprocess.CalledProcessError`` if exit code is non-zero."""
+        if self.returncode:
+            if version_info < (3, 5):  # pragma: no cover
+                args = [self.returncode, self.args, self.stdout]
+            else:  # pragma: no cover
+                args = [self.returncode, self.args, self.stdout, self.stderr]
+            raise subprocess.CalledProcessError(*args)
+
+
+class Client(object):  # pylint:disable=too-few-public-methods
+    """A convenience object for working with a CLI.
+
+    This class provides the ability to execute shell commands on either the
+    local system or a remote system. Here is a simple usage example:
+
+    >>> from pulp_smash import cli, config
+    >>> server_config = config.ServerConfig('localhost')
+    >>> client = cli.Client(server_config)
+    >>> response = client.run(('echo', '-n', 'foo'))
+    >>> response.returncode == 0
+    True
+    >>> response.stdout == 'foo'
+    True
+    >>> response.stderr == ''
+    True
+
+    You can customize how commands are executed and how responses are handled
+    by fiddling with the two public instance attributes:
+
+    ``machine``
+        A `Plumbum`_ machine. :meth:`run` delegates all command execution
+        responsibilities to this object.
+    ``response_handler``
+        A callback function. Each time ``machine`` executes a command, the
+        result is handed to this callback, and the callback's return value is
+        handed to the user.
+
+    If ``server_config.cli_transport`` is ``'local'`` or ``'ssh``, set
+    ``machine`` so that commands run locally or over SSH, respectively. If
+    ``server_config.cli_transport`` is ``None``, guess how to set ``machine``
+    by comparing the hostname embedded in ``server_config.base_url`` against
+    the current system's hostname. If they match, set ``machine`` to execute
+    commands locally; and vice versa.
+
+    :param pulp_smash.config.ServerConfig server_config: Information about the
+        system on which commands will be executed.
+    :param response_handler: A callback function. Defaults to
+        :func:`pulp_smash.cli.code_handler`.
+
+    .. _Plumbum: http://plumbum.readthedocs.org/en/latest/index.html
+    """
+
+    def __init__(self, server_config, response_handler=None):
+        """Initialize this object with needed instance attributes."""
+        # How do we make requests?
+        hostname = _get_hostname(server_config.base_url)
+        if server_config.cli_transport is None:
+            transport = 'local' if hostname == socket.gethostname() else 'ssh'
+        else:
+            transport = server_config.cli_transport
+        if transport == 'local':
+            self.machine = plumbum.machines.local
+        else:  # transport == 'ssh'
+            # The SshMachine is a wrapper around the system's "ssh" binary.
+            # Thus, it uses ~/.ssh/config, ~/.ssh/known_hosts, etc.
+            self.machine = (  # pylint:disable=redefined-variable-type
+                plumbum.machines.SshMachine(hostname)
+            )
+
+        # How do we handle responses?
+        if response_handler is None:
+            self.response_handler = code_handler
+        else:
+            self.response_handler = response_handler
+
+    def run(self, args, **kwargs):
+        """Run a command and ``return self.response_handler(result)``.
+
+        This method is a thin wrapper around Plumbum's `BaseCommand.run`_
+        method, which is itself a thin wrapper around the standard library's
+        `subprocess.Popen`_ class. See their documentation for detailed usage
+        instructions. See :class:`pulp_smash.cli.Client` for a usage example.
+
+        .. _BaseCommand.run:
+           http://plumbum.readthedocs.org/en/latest/api/commands.html#plumbum.commands.base.BaseCommand.run
+        .. _subprocess.Popen:
+           https://docs.python.org/3/library/subprocess.html#subprocess.Popen
+        """
+        code, stdout, stderr = self.machine[args[0]].run(args[1:], **kwargs)
+        completed_process = CompletedProcess(args, code, stdout, stderr)
+        return self.response_handler(completed_process)

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,13 @@ setup(
         'Programming Language :: Python :: 3.5',
     ],
     packages=find_packages(),
-    install_requires=['mock', 'packaging', 'pyxdg', 'requests', 'unittest2'],
+    install_requires=[
+        'mock',
+        'packaging',
+        'plumbum',
+        'pyxdg',
+        'requests',
+        'unittest2',
+    ],
     test_suite='tests',
 )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,133 @@
+# coding=utf-8
+"""Unit tests for :mod:`pulp_smash.api`."""
+from __future__ import unicode_literals
+
+import socket
+import subprocess
+
+import mock
+import unittest2
+from plumbum.machines.local import LocalMachine
+
+from pulp_smash import cli, config, utils
+
+
+class GetHostnameTestCase(unittest2.TestCase):
+    """Tests for ``pulp_smash.cli._get_hostname``."""
+
+    def test_parsing(self):
+        """Assert the function extracts hostnames as shown in its docstring."""
+        hostname = utils.uuid4()
+        urlstrings = (
+            '//' + hostname,
+            'ftp://' + hostname,
+            hostname + ':123',
+            hostname,
+        )
+        outputs = [
+            cli._get_hostname(urlstring)  # pylint:disable=protected-access
+            for urlstring in urlstrings
+        ]
+        for urlstring, output in zip(urlstrings, outputs):
+            with self.subTest(urlstring=urlstring):
+                self.assertEqual(output, hostname)
+
+
+class EchoHandlerTestCase(unittest2.TestCase):
+    """Tests for :func:`pulp_smash.cli.echo_handler`."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Call the function under test, and record inputs and outputs."""
+        cls.completed_proc = mock.Mock()
+        cls.output = cli.echo_handler(cls.completed_proc)
+
+    def test_input_returned(self):
+        """Assert the passed-in ``completed_proc`` is returned."""
+        self.assertIs(self.completed_proc, self.output)
+
+    def test_check_returncode(self):
+        """Assert ``completed_proc.check_returncode()`` is not called."""
+        self.assertEqual(self.completed_proc.check_returncode.call_count, 0)
+
+
+class CodeHandlerTestCase(unittest2.TestCase):
+    """Tests for :func:`pulp_smash.cli.code_handler`."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Call the function under test, and record inputs and outputs."""
+        cls.completed_proc = mock.Mock()
+        cls.output = cli.code_handler(cls.completed_proc)
+
+    def test_input_returned(self):
+        """Assert the passed-in ``completed_proc`` is returned."""
+        self.assertIs(self.completed_proc, self.output)
+
+    def test_check_returncode(self):
+        """Assert ``completed_proc.check_returncode()`` is not called."""
+        self.assertEqual(self.completed_proc.check_returncode.call_count, 1)
+
+
+class CompletedProcessTestCase(unittest2.TestCase):
+    """Tests for :class:`pulp_smash.cli.CompletedProcess`."""
+
+    def setUp(self):
+        """Generate kwargs that can be used to instantiate a completed proc."""
+        self.kwargs = {
+            key: utils.uuid4()
+            for key in {'args', 'returncode', 'stdout', 'stderr'}
+        }
+
+    def test_init(self):
+        """Assert all constructor arguments are saved as instance attrs."""
+        completed_proc = cli.CompletedProcess(**self.kwargs)
+        for key, value in self.kwargs.items():
+            with self.subTest(key=key):
+                self.assertTrue(hasattr(completed_proc, key))
+                self.assertEqual(getattr(completed_proc, key), value)
+
+    def test_check_returncode_zero(self):
+        """Call ``check_returncode`` when ``returncode`` is zero."""
+        self.kwargs['returncode'] = 0
+        completed_proc = cli.CompletedProcess(**self.kwargs)
+        self.assertIsNone(completed_proc.check_returncode())
+
+    def test_check_returncode_nonzero(self):
+        """Call ``check_returncode`` when ``returncode`` is not zero."""
+        self.kwargs['returncode'] = 1
+        completed_proc = cli.CompletedProcess(**self.kwargs)
+        with self.assertRaises(subprocess.CalledProcessError):
+            completed_proc.check_returncode()
+
+    def test_can_eval(self):
+        """Assert ``__repr__()`` can be parsed by ``eval()``."""
+        string = repr(cli.CompletedProcess(**self.kwargs))
+        from pulp_smash.cli import CompletedProcess  # noqa
+        # pylint:disable=eval-used
+        self.assertEqual(string, repr(eval(string)))
+
+
+class ClientTestCase(unittest2.TestCase):
+    """Tests for :class:`pulp_smash.cli.Client`."""
+
+    def test_explicit_local_transport(self):
+        """Assert it is possible to explicitly ask for a "local" transport."""
+        cfg = config.ServerConfig(utils.uuid4(), cli_transport='local')
+        self.assertIsInstance(cli.Client(cfg).machine, LocalMachine)
+
+    def test_implicit_local_transport(self):
+        """Assert it is possible to implicitly ask for a "local" transport."""
+        cfg = config.ServerConfig(socket.gethostname())
+        self.assertIsInstance(cli.Client(cfg).machine, LocalMachine)
+
+    def test_default_response_handler(self):
+        """Assert the default response handler checks return codes."""
+        cfg = config.ServerConfig(utils.uuid4(), cli_transport='local')
+        self.assertIs(cli.Client(cfg).response_handler, cli.code_handler)
+
+    def test_explicit_response_handler(self):
+        """Assert it is possible to explicitly set a response handler."""
+        cfg = config.ServerConfig(utils.uuid4(), cli_transport='local')
+        handler = mock.Mock()
+        self.assertIs(cli.Client(cfg, handler).response_handler, handler)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,7 +24,9 @@ def _gen_attrs():
 
     :returns: A dict. It populates all attributes in a ``ServerConfig``.
     """
-    attrs = {key: utils.uuid4() for key in ('base_url', 'verify')}
+    attrs = {
+        key: utils.uuid4() for key in ('base_url', 'cli_transport', 'verify')
+    }
     attrs['auth'] = [utils.uuid4() for _ in range(2)]
     attrs['version'] = '.'.join(
         type('')(random.randint(1, 150)) for _ in range(4)
@@ -156,7 +158,7 @@ class GetRequestsKwargsTestCase(unittest2.TestCase):
     def test_kwargs(self):
         """Assert that the method returns correct values."""
         attrs = self.attrs.copy()
-        for key in ('base_url', 'version'):
+        for key in ('base_url', 'cli_transport', 'version'):
             del attrs[key]
         attrs['auth'] = tuple(attrs['auth'])
         self.assertEqual(attrs, self.kwargs)


### PR DESCRIPTION
Add, document and test module `pulp_smash.cli`. This module provides "tools for
working with Pulp's CLI." This fixes #32:

> It'd be nice if we could inspect the state of remote systems under test. For
> example, it may be useful to log in to a remote system and determine whether
> certain files are lying around in certain places in the file system.

Here's a simple example of how to use the new module:

```python
>>> from pulp_smash import cli, config
>>> server_config = config.ServerConfig('localhost')
>>> client = cli.Client(server_config)
>>> response = client.run(('echo', '-n', 'foo'))
>>> response.returncode == 0
True
>>> response.stdout == 'foo'
True
>>> response.stderr == ''
True
```

The `Client` class is flexible enough that both request and response handling
can be customized on a per-instance basis. See the docstrings in module
`pulp_smash.cli` for details.

Add "plumbum" as a dependency. It is used by the CLI helper.

Many thanks to @elyezer for help in brainstorming a solution to this issue.

This commit does not affect test results (107 tests):

    ============  =============================
    Pulp Version  Test Suite Results
    ============  =============================
    2.7           OK
    dev (2.8)     FAILED (errors=2, skipped=13)
    ============  =============================