### PR TITLE
Refactor test, skip known failing assertion

### DIFF
--- a/pulp_smash/tests/rpm/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_sync_publish.py
@@ -205,6 +205,9 @@ class SyncValidFeedTestCase(_BaseTestCase):
                 'package_group': 2,
                 'package_category': 1,
         }.items():
+            if (unit_type == 'rpm' and self.cfg.version >= Version('2.8') and
+                    selectors.bug_is_untestable(1570)):
+                continue
             with self.subTest(unit_type=unit_type):
                 self.assertEqual(counts.get(unit_type), count)
 

--- a/pulp_smash/tests/rpm/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_sync_publish.py
@@ -199,10 +199,14 @@ class SyncValidFeedTestCase(_BaseTestCase):
                 selectors.bug_is_untestable(1455)):
             self.skipTest('https://pulp.plan.io/issues/1455')
         counts = self.repo.get('content_unit_counts', {})
-        self.assertEqual(counts.get('rpm'), 32)
-        self.assertEqual(counts.get('erratum'), 4)
-        self.assertEqual(counts.get('package_group'), 2)
-        self.assertEqual(counts.get('package_category'), 1)
+        for unit_type, count in {
+                'rpm': 32,
+                'erratum': 4,
+                'package_group': 2,
+                'package_category': 1,
+        }.items():
+            with self.subTest(unit_type=unit_type):
+                self.assertEqual(counts.get(unit_type), count)
 
 
 class SyncInvalidFeedTestCase(_BaseTestCase):


### PR DESCRIPTION
This PR includes two logically separate commits. The first commit refactors a test and places assertions within a `subTest` context manager. This allows the various assertions to all run, even if some fail. The second commit skips one of those assertions due to [issue 1570](https://pulp.plan.io/issues/1570). See the individual commit messages for more details.