### PR TITLE
More descriptive ConfigFileNotFoundError message

### DIFF
--- a/pulp_smash/config.py
+++ b/pulp_smash/config.py
@@ -344,6 +344,12 @@ def _get_config_file_path(xdg_config_dir, xdg_config_file):
             return path
     raise exceptions.ConfigFileNotFoundError(
         'No configuration files could be located after searching for a file '
-        'named "{0}" in the standard XDG configuration paths, such as '
-        '"~/.config/{1}/".'.format(xdg_config_file, xdg_config_dir)
+        'named "{0}" in the standard XDG configuration paths, the following '
+        'paths were searched: {1}.'.format(
+            xdg_config_file,
+            ', '.join([
+                os.path.join(config_dir, xdg_config_dir, xdg_config_file)
+                for config_dir in BaseDirectory.xdg_config_dirs
+            ])
+        )
     )


### PR DESCRIPTION
Make ConfigFileNotFoundError error when searching for the configuration
file more clear in terms of which paths have been searched.

After the changes:

```
$ XDG_CONFIG_DIRS=`pwd`/pulp_smash python -c "from pulp_smash.config import get_config; get_config()"
Traceback (most recent call last):
  ...
pulp_smash.exceptions.ConfigFileNotFoundError: No configuration files could be located after searching for a file named "settings.json" in the standard XDG configuration paths, the following paths were searched: /home/elyezer/.config/pulp_smash/settings.json, /home/elyezer/pulp-smash/pulp_smash/pulp_smash/settings.json.
```