### PR TITLE
RPM tests bugfix

### DIFF
--- a/pulp_smash/tests/rpm/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_sync_publish.py
@@ -164,6 +164,7 @@ class SyncValidFeedTestCase(_BaseTestCase):
         cls.tasks = tuple(utils.poll_spawned_tasks(cls.cfg, cls.report.json()))
         client.response_handler = api.json_handler
         cls.repo = client.get(repo['_href'])
+        cls.resources.add(repo['_href'])
 
     def test_start_sync_code(self):
         """Assert the call to sync a repository returns an HTTP 202."""
@@ -231,6 +232,7 @@ class SyncInvalidFeedTestCase(_BaseTestCase):
         cls.report = client.post(path, {'override_config': {}})
         cls.report.raise_for_status()
         cls.tasks = tuple(utils.poll_spawned_tasks(cls.cfg, cls.report.json()))
+        cls.resources.add(repo['_href'])
 
     def test_start_sync_code(self):
         """Assert the call to sync a repository returns an HTTP 202."""


### PR DESCRIPTION
    SyncValidFeedTestCase and SyncInvalidFeedTestCase didn't delete
    repositories after completition.
    Fixed by adding repositories' paths to resources for deletion.

    This commit does not affect functionality of pulp-smash.