### PR TITLE
Let pylint use all CPU cores

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 TEST_OPTIONS=-m unittest discover --start-directory tests --top-level-directory .
+CPU_COUNT=$(shell python -c "from multiprocessing import cpu_count; print(cpu_count())")
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of:"
@@ -23,7 +24,7 @@ lint-flake8:
 	flake8 . --ignore D203
 
 lint-pylint:
-	pylint --reports=n --ignore-imports=y --disable=I \
+	pylint -j $(CPU_COUNT) --reports=n --ignore-imports=y --disable=I \
 		docs/conf.py \
 		setup.py \
 		tests \
@@ -36,7 +37,7 @@ lint-pylint:
 		pulp_smash/exceptions.py \
 		pulp_smash/selectors.py \
 		pulp_smash/utils.py
-	pylint --reports=n --disable=I,duplicate-code pulp_smash/tests/
+	pylint -j $(CPU_COUNT) --reports=n --disable=I,duplicate-code pulp_smash/tests/
 
 lint: lint-flake8 lint-pylint
 


### PR DESCRIPTION
By default, Pylint acts in a completely single-threaded manner. This is a
horrible inefficiency on modern CPUs that often offer four or more cores. Edit
the `lint-pylint` make target and set the `--jobs` flag for each pylint
invocation.

This change brings significant performance improvements. On one test system
available to the author, `lint-pylint` execution time dropped from 16 to 11
seconds. On a second test system, execution time dropped from 43 to 22 seconds.