### PR TITLE
Explain that Pulp Smash is highly destructive

### DIFF
--- a/docs/about.rst
+++ b/docs/about.rst
@@ -38,10 +38,15 @@ own systems.
 Destructiveness
 ~~~~~~~~~~~~~~~
 
-Should Pulp Smash record all changes it makes to a remote system and revert them
-when testing is complete, or should systems be treated as throw-away? In other
-words, should the systems under test be treated like pets or cattle? [4]_ This
-has yet to be decided.
+*Pulp Smash is highly destructive!* You should not use Pulp Smash for testing if
+you care about the state of the target system. Pulp Smash will do the following
+to a system under test, and possibly more:
+
+* It will drop databases.
+* It will forcefully delete files from the filesystem.
+* It will stop and start system services.
+
+Pulp Smash treats the system(s) under test as cattle, not pets. [4]_
 
 Contributing
 ------------


### PR DESCRIPTION
Fix #5:

> The *Pulp Smash* → *About* → *Scope and Limitations* →
> [*Destructiveness*](http://pulp-smash.readthedocs.org/en/latest/about.html#destructiveness)
> section in the documentation should be expanded. That section currently
> states:
>
> > Should Pulp Smash record all changes it makes to a remote system and revert
> > them when testing is complete, or should systems be treated as throw-away?
> > In other words, should the systems under test be treated like pets or
> > cattle? [3] This has yet to be decided.
>
> It would be good to decide this so that we can adapt tests from the existing
> Pulp Automation test suite with confidence.

As of 7297270084267b4ffe8e9279542b558cc93dbf04, we have clearly decided that Pulp Smash is a destructive test suite that does terrible things to the systems it targets.