### PR TITLE
Refactor logic for detecting a service manager

### DIFF
--- a/pulp_smash/cli.py
+++ b/pulp_smash/cli.py
@@ -281,18 +281,19 @@ class Service(object):
             pass
 
         client = Client(server_config, echo_handler)
-        managers_commands = {
-            'systemd': ('which', 'systemctl'),
-            'sysv': ('which', 'service'),
-        }
-        for service_manager, command in managers_commands.items():
-            if client.run(command).returncode == 0:
+        commands_managers = (
+            ('which systemctl', 'systemd'),
+            ('which service', 'sysv'),
+            ('test -x /sbin/service', 'sysv'),
+        )
+        for command, service_manager in commands_managers:
+            if client.run(command.split()).returncode == 0:
                 _SERVICE_MANAGERS[hostname] = service_manager
                 return service_manager
         raise exceptions.NoKnownServiceManagerError(
             'Unable to determine the service manager used by {}. It does not '
             'appear to be any of {}.'
-            .format(hostname, managers_commands.values())
+            .format(hostname, {manager for _, manager in commands_managers})
         )
 
     def start(self):


### PR DESCRIPTION
Refactor function `pulp_smash.cli._get_service_manager`. This function currently attempts to determine which service manager is used by executing commands like:

    which systemctl
    which service

This works in some cases. But on some systems, like RHEL 6, both of these commands will fail — despite the fact that `/sbin/service` exists! The issue is that, when executing commands remotely (e.g. `ssh pulp.example.com which service`), a non-interactive shell is launched. And the commands that add `/sbin` to `$PATH` only are contained in `/etc/profile`, which only executes for interactive shells.

Edit the `_get_service_manager` function and make it also execute the following:

    test -x /sbin/service

Also, edit several details of that function, including the message generated when no service manager can be found.

The following command succeeds:

    python -m unittest2 pulp_smash.tests.rpm.api_v2.test_broker

Fix #86: "checking for presence of 'service' on EL6 fails"