### PR TITLE
Make broker reconnect tests green

### DIFF
--- a/pulp_smash/tests/rpm/api_v2/test_broker.py
+++ b/pulp_smash/tests/rpm/api_v2/test_broker.py
@@ -77,8 +77,16 @@ class BrokerTestCase(unittest2.TestCase):
         ))
 
     def tearDown(self):
-        """Ensure Pulp services are running."""
-        for service in self.services + (self.broker,):
+        """Ensure Pulp services and AMQP broker are running.
+
+        Stop all relevant services, then start them again. This approach is
+        slow, but see `when broker reconnect test fails, all following tests
+        fail <https://github.com/PulpQE/pulp-smash/issues/91>`_.
+        """
+        services = self.services + (self.broker,)
+        for service in services:
+            service.stop()
+        for service in services:
             service.start()
 
     def test_broker_connect(self):

--- a/pulp_smash/tests/rpm/api_v2/test_broker.py
+++ b/pulp_smash/tests/rpm/api_v2/test_broker.py
@@ -33,7 +33,7 @@ except ImportError:
 
 import unittest2
 
-from pulp_smash import api, cli, config, utils
+from pulp_smash import api, cli, config, selectors, utils
 from pulp_smash.constants import PULP_SERVICES, REPOSITORY_PATH
 
 
@@ -118,6 +118,8 @@ class BrokerTestCase(unittest2.TestCase):
         3. Test Pulp's health. Create an RPM repository, sync it, add a
            distributor, publish it, and download an RPM.
         """
+        if selectors.bug_is_untestable(1635):
+            self.skipTest('https://pulp.plan.io/issues/1635')
         # We assume that the broker and other services are already running. As
         # a result, we skip step 1 and go straight to step 2.
         self.broker.stop()


### PR DESCRIPTION
In the first commit, better isolate each of the broker reconnect tests. In the second commit, skip a known-failing test.