### PR TITLE
Add CLI tests for creating & syncing docker repos

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -21,6 +21,9 @@ developers, not a gospel.
     api/pulp_smash.tests.docker
     api/pulp_smash.tests.docker.api_v2
     api/pulp_smash.tests.docker.api_v2.test_crud
+    api/pulp_smash.tests.docker.cli
+    api/pulp_smash.tests.docker.cli.test_crud
+    api/pulp_smash.tests.docker.cli.test_sync
     api/pulp_smash.tests.ostree
     api/pulp_smash.tests.ostree.api_v2
     api/pulp_smash.tests.ostree.api_v2.test_sync_publish

--- a/docs/api/pulp_smash.tests.docker.cli.rst
+++ b/docs/api/pulp_smash.tests.docker.cli.rst
@@ -1,0 +1,6 @@
+`pulp_smash.tests.docker.cli`
+=============================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.docker.cli`
+
+.. automodule:: pulp_smash.tests.docker.cli

--- a/docs/api/pulp_smash.tests.docker.cli.test_crud.rst
+++ b/docs/api/pulp_smash.tests.docker.cli.test_crud.rst
@@ -1,0 +1,7 @@
+`pulp_smash.tests.docker.cli.test_crud`
+=======================================
+
+Location: :doc:`/index` → :doc:`/api` →
+:doc:`/api/pulp_smash.tests.docker.cli.test_crud`
+
+.. automodule:: pulp_smash.tests.docker.cli.test_crud

--- a/docs/api/pulp_smash.tests.docker.cli.test_sync.rst
+++ b/docs/api/pulp_smash.tests.docker.cli.test_sync.rst
@@ -1,0 +1,7 @@
+`pulp_smash.tests.docker.cli.test_sync`
+=======================================
+
+Location: :doc:`/index` → :doc:`/api` →
+:doc:`/api/pulp_smash.tests.docker.cli.test_sync`
+
+.. automodule:: pulp_smash.tests.docker.cli.test_sync

--- a/pulp_smash/tests/docker/cli/__init__.py
+++ b/pulp_smash/tests/docker/cli/__init__.py
@@ -1,0 +1,3 @@
+# coding=utf-8
+"""Tests that communicate with the server via the pulp-admin CLI client."""
+from __future__ import unicode_literals

--- a/pulp_smash/tests/docker/cli/test_crud.py
+++ b/pulp_smash/tests/docker/cli/test_crud.py
@@ -1,0 +1,65 @@
+# coding=utf-8
+"""CRUD tests for docker repositories.
+
+These tests can also be accomplished via the API. However, there is value in
+showing that the pulp-admin CLI client correctly interfaces with the API.
+"""
+from __future__ import unicode_literals
+
+import unittest2
+
+from pulp_smash import cli, config, utils
+
+_FEED = 'https://example.com'
+_UPSTREAM_NAME = 'foo/bar'
+
+
+class CreateTestCase(unittest2.TestCase):
+    """Create docker repositories, both successfully and unsuccessfully."""
+
+    def setUp(self):
+        """Provide a server config and a repository ID."""
+        self.cfg = config.get_config()
+        self.repo_id = utils.uuid4()
+
+    def tearDown(self):
+        """Delete created resources."""
+        cli.Client(self.cfg).run(
+            'pulp-admin docker repo delete --repo-id {}'
+            .format(self.repo_id).split()
+        )
+
+    def test_basic(self):
+        """Create a docker repository. Only provide a repository ID.
+
+        Assert the return code is 0.
+        """
+        completed_proc = cli.Client(self.cfg, cli.echo_handler).run(
+            'pulp-admin docker repo create --repo-id {}'
+            .format(self.repo_id).split()
+        )
+        self.assertEqual(completed_proc.returncode, 0)
+
+    def test_with_feed_upstream_name(self):
+        """Create a docker repository. Provide a feed and upstream name.
+
+        Assert the return code is 0.
+        """
+        completed_proc = cli.Client(self.cfg, cli.echo_handler).run(
+            'pulp-admin docker repo create '
+            '--repo-id {} --feed {} --upstream-name {}'
+            .format(self.repo_id, _FEED, _UPSTREAM_NAME).split()
+        )
+        self.assertEqual(completed_proc.returncode, 0)
+
+    def test_duplicate_ids(self):
+        """Create two docker repositories with identical IDs.
+
+        Assert only the first repository is created.
+        """
+        client = cli.Client(self.cfg)
+        command = 'pulp-admin docker repo create --repo-id ' + self.repo_id
+        client.run(command.split())
+
+        client.response_handler = cli.echo_handler
+        self.assertNotEqual(client.run(command.split()).returncode, 0)

--- a/pulp_smash/tests/docker/cli/test_sync.py
+++ b/pulp_smash/tests/docker/cli/test_sync.py
@@ -1,0 +1,120 @@
+# coding=utf-8
+"""Tests for syncing docker repositories."""
+from __future__ import unicode_literals
+
+import unittest2
+from packaging.version import Version
+
+from pulp_smash import cli, config, selectors, utils
+
+_CREATE_COMMAND = (
+    'pulp-admin docker repo create '
+    '--feed {feed} '
+    '--repo-id {repo_id} '
+    '--upstream-name {upstream_name} '
+)
+_UPSTREAM_NAME = 'library/busybox'
+
+
+def _sync_repo(server_config, repo_id):
+    return cli.Client(server_config, cli.echo_handler).run(
+        'pulp-admin docker repo sync run --repo-id {}'.format(repo_id).split()
+    )
+
+
+class _BaseTestCase(unittest2.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        """Provide a server config and a repository ID."""
+        cls.cfg = config.get_config()
+        cls.repo_id = utils.uuid4()
+
+    @classmethod
+    def tearDownClass(cls):
+        """Delete the created repository."""
+        command = 'pulp-admin docker repo delete --repo-id {}'
+        cli.Client(cls.cfg).run(command.format(cls.repo_id).split())
+
+
+class _SuccessMixin(object):
+
+    def test_return_code(self):
+        """Assert the "sync" command has a return code of 0."""
+        self.assertEqual(self.completed_proc.returncode, 0)
+
+    def test_task_succeeded(self):
+        """Assert the phrase "Task Succeeded" is in stdout."""
+        self.assertIn('Task Succeeded', self.completed_proc.stdout)
+
+    def test_task_failed(self):
+        """Assert the phrase "Task Failed" is not in stdout."""
+        self.assertNotIn('Task Failed', self.completed_proc.stdout)
+
+
+class SyncV1TestCase(_SuccessMixin, _BaseTestCase):
+    """Show it is possible to sync a docker repository with a v1 registry."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create and sync a docker repository with a v1 registry."""
+        super(SyncV1TestCase, cls).setUpClass()
+        kwargs = {
+            'feed': 'https://index.docker.io',  # v1 feed
+            'repo_id': cls.repo_id,
+            'upstream_name': _UPSTREAM_NAME,
+        }
+        cli.Client(cls.cfg).run(_CREATE_COMMAND.format(**kwargs).split())
+        cls.completed_proc = _sync_repo(cls.cfg, cls.repo_id)
+
+
+class SyncV2TestCase(_SuccessMixin, _BaseTestCase):
+    """Show it is possible to sync a docker repository with a v2 registry."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create and sync a docker repository with a v2 registry.
+
+        This method requires Pulp 2.8 and above, and will raise a ``SkipTest``
+        exception if run against an earlier version of Pulp.
+        """
+        super(SyncV2TestCase, cls).setUpClass()
+        if cls.cfg.version < Version('2.8'):
+            raise unittest2.SkipTest('These tests require Pulp 2.8 or above.')
+        kwargs = {
+            'feed': 'https://registry-1.docker.io',  # v2 feed
+            'repo_id': cls.repo_id,
+            'upstream_name': _UPSTREAM_NAME,
+        }
+        cli.Client(cls.cfg).run(_CREATE_COMMAND.format(**kwargs).split())
+        cls.completed_proc = _sync_repo(cls.cfg, cls.repo_id)
+
+
+class InvalidFeedTestCase(_BaseTestCase):
+    """Show Pulp behaves correctly when syncing a repo with an invalid feed."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create a docker repo with an invalid feed and sync it."""
+        super(InvalidFeedTestCase, cls).setUpClass()
+        kwargs = {
+            'feed': 'https://docker.example.com',
+            'repo_id': cls.repo_id,
+            'upstream_name': _UPSTREAM_NAME,
+        }
+        cli.Client(cls.cfg).run(_CREATE_COMMAND.format(**kwargs).split())
+        cls.completed_proc = _sync_repo(cls.cfg, cls.repo_id)
+
+    def test_return_code(self):
+        """Assert the "sync" command has a non-zero return code."""
+        if selectors.bug_is_untestable(1637):
+            self.skipTest('https://pulp.plan.io/issues/1637')
+        self.assertNotEqual(self.completed_proc.returncode, 0)
+
+    def test_task_succeeded(self):
+        """Assert the phrase "Task Succeeded" is not in stdout."""
+        self.assertNotIn('Task Succeeded', self.completed_proc.stdout)
+
+    def test_task_failed(self):
+        """Assert the phrase "Task Failed" is in stdout."""
+        self.assertIn('Task Failed', self.completed_proc.stdout)


### PR DESCRIPTION
Add CLI tests for creating & syncing docker repos

Add and document the following modules:

* `pulp_smash.tests.docker.cli`
* `pulp_smash.tests.docker.cli.test_crud`
* `pulp_smash.tests.docker.cli.test_sync`

Test results after this addition:

    =========  ==========  ==================
    Pulp Ver.  Num. Tests  Test Suite Results
    =========  ==========  ==================
    2.7        9           OK (skipped=2)
    dev (2.8)  12          OK (skipped=1)
    =========  ==========  ==================

Test results generated with:

    python -m unittest2 discover pulp_smash.tests.docker.cli

Submit Pulp issue 1637 [1], "Pulp Admin returns 0 even when docker sync fails." This issue accounts for one skipped test on both Pulp 2.7 and dev.

Submit Pulp issue 1640 [2], "Pulp 2.7 should gracefully fail with Docker v2 feeds." This issue accounts for the second skipped test on Pulp 2.7, and for why three fewer tests are run.

Fix #88, "Test that Docker images can be synced from the v2 registry."

[1] https://pulp.plan.io/issues/1637
[2] https://pulp.plan.io/issues/1640
[3] https://github.com/PulpQE/pulp-smash/issues/88