### PR TITLE
Conditionally execute OSTree tests

### DIFF
--- a/pulp_smash/constants.py
+++ b/pulp_smash/constants.py
@@ -57,6 +57,13 @@ LOGIN_PATH = '/pulp/api/v2/actions/login/'
     https://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/authentication.html
 """
 
+PLUGIN_TYPES_PATH = '/pulp/api/v2/plugins/types/'
+"""See: `Retrieve All Content Unit Types`_.
+
+.. _Retrieve All Content Unit Types:
+   http://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/server_plugins.html#retrieve-all-content-unit-types
+"""
+
 PULP_SERVICES = {
     'httpd',
     'pulp_celerybeat',

--- a/pulp_smash/tests/ostree/__init__.py
+++ b/pulp_smash/tests/ostree/__init__.py
@@ -1,3 +1,43 @@
 # coding=utf-8
 """Functional tests for Pulp's ostree plugin."""
 from __future__ import unicode_literals
+
+import os
+
+from pulp_smash import api, config
+from pulp_smash.constants import PLUGIN_TYPES_PATH
+
+
+def _get_plugin_type_ids():
+    """Get the ID of each of Pulp's plugins.
+
+    Each Pulp plugin adds one (or more?) content unit type to Pulp. Each of
+    these content unit types is identified by a certain unique identifier. For
+    example, the `Python type`_ has an ID of ``python_package``.
+
+    :returns: A set of plugin IDs. For example: ``{'ostree',
+        'python_package'}``.
+
+    .. _Python type:
+       http://pulp-python.readthedocs.org/en/latest/reference/python-type.html
+    """
+    client = api.Client(config.get_config(), api.json_handler)
+    plugin_types = client.get(PLUGIN_TYPES_PATH)
+    return {plugin_type['id'] for plugin_type in plugin_types}
+
+
+def load_tests(loader, standard_tests, pattern):
+    """Load OSTree tests only if the plugin is installed on the target host.
+
+    This method is called automatically by the unittest test runner. For more
+    information, see documentation on the `load_tests Protocol
+    <https://docs.python.org/3/library/unittest.html#load-tests-protocol>`_.
+
+    This method may not work correctly on Pulp 2.8. See Pulp issue #1642, `List
+    of Content Unit Types is Incomplete <https://pulp.plan.io/issues/1642>`_.
+    """
+    if 'ostree' in _get_plugin_type_ids():
+        this_dir = os.path.dirname(__file__)
+        package_tests = loader.discover(start_dir=this_dir, pattern=pattern)
+        standard_tests.addTests(package_tests)
+    return standard_tests

--- a/pulp_smash/tests/ostree/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/ostree/api_v2/test_sync_publish.py
@@ -39,15 +39,6 @@ _BRANCHES = (
 )
 
 
-def setUpModule():  # pylint:disable=invalid-name
-    """Temporarily skip OSTree tests due to partial availability of the plugin.
-
-    The OSTree plugin is only available on certain supported distributions. For
-    example, it is available on Fedora 23, but not Fedora 22.
-    """
-    raise unittest2.SkipTest('https://github.com/PulpQE/pulp-smash/issues/84')
-
-
 def _gen_repo():
     """Return OSTree repo body."""
     return {


### PR DESCRIPTION
Remove the unconditional `skipTest` exception raised by function `setUpModule` in module `pulp_smash.tests.ostree.api_v2.test_sync_publish`.

Add a `load_tests` function [1] to package `pulp_smash.tests.ostree`. This function talks to the Pulp server under test, asks it for a list of content unit types, and uses that information in choosing whether to run the OSTree tests.

This works because each plugin adds one (or more?) content unit type to Pulp. The types added by a given plugin are listed in the documentation for those plugins. For example, see:

* http://pulp-ostree.readthedocs.org/en/latest/tech-reference/type.html
* http://pulp-python.readthedocs.org/en/latest/reference/python-type.html

Due to Pulp issue 1642 [2], this only works well on Pulp 2.7. On Pulp 2.8, the OSTree plugin does not appear to be installed (even if present), so these tests are skipped.

Before this commit, all OSTree tests are skipped. Test results after this commit:

    =========  ==========  ==================
    Pulp Ver.  Num. Tests  Test Suite Results
    =========  ==========  ==================
    2.7        18          OK
    dev (2.8)  0           OK
    =========  ==========  ==================

Test results after this commit against systems without the OSTree plugin installed:

    =========  ==========  ==================
    Pulp Ver.  Num. Tests  Test Suite Results
    =========  ==========  ==================
    2.7        0           OK
    dev (2.8)  0           OK
    =========  ==========  ==================

[1] https://docs.python.org/3.5/library/unittest.html#load-tests-protocol
[2] https://pulp.plan.io/issues/1642

Related to #84