### PR TITLE
Isolates the RPM publish test case by resetting Pulp during setUp

### DIFF
--- a/pulp_smash/tests/rpm/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_sync_publish.py
@@ -280,6 +280,7 @@ class PublishTestCase(_BaseTestCase):
            RPMs from both repositories.
         """
         super(PublishTestCase, cls).setUpClass()
+        utils.reset_pulp(cls.cfg)  # See: https://pulp.plan.io/issues/1406
         cls.responses = {}
         cls.rpms = []  # Raw RPMs
 


### PR DESCRIPTION
We are seeing a failure during the nightly Jenkins run of pulp-smash. My investigation led me to isolating this test. 