### PR TITLE
Adds login command to the docker cli test setUp

### DIFF
--- a/pulp_smash/tests/docker/cli/test_crud.py
+++ b/pulp_smash/tests/docker/cli/test_crud.py
@@ -21,6 +21,10 @@ class CreateTestCase(unittest2.TestCase):
         """Provide a server config and a repository ID."""
         self.cfg = config.get_config()
         self.repo_id = utils.uuid4()
+        cli.Client(self.cfg).run(
+            'pulp-admin login -u {} -p {}'
+            .format(self.cfg.auth[0], self.cfg.auth[1]).split()
+        )
 
     def tearDown(self):
         """Delete created resources."""

--- a/pulp_smash/tests/docker/cli/test_sync.py
+++ b/pulp_smash/tests/docker/cli/test_sync.py
@@ -29,6 +29,10 @@ class _BaseTestCase(unittest2.TestCase):
         """Provide a server config and a repository ID."""
         cls.cfg = config.get_config()
         cls.repo_id = utils.uuid4()
+        cli.Client(cls.cfg).run(
+            'pulp-admin login -u {} -p {}'
+            .format(cls.cfg.auth[0], cls.cfg.auth[1]).split()
+        )
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
Tests were failing because the commands were being executed without logging in
or providing -u and -p options.