### PR TITLE
Check Task report and Call report for errors.

### DIFF
--- a/pulp_smash/exceptions.py
+++ b/pulp_smash/exceptions.py
@@ -11,6 +11,19 @@ class BugStatusUnknownError(Exception):
     """
 
 
+class CallReportError(Exception):
+    """Returned Call report contains errors.
+
+    For more information about pulp's task handling see
+    `Synchronous and Asynchronous Calls`_ and `Task management`_.
+
+    .. _Synchronous and Asynchronous Calls:
+        http://pulp.readthedocs.org/en/latest/dev-guide/conventions/sync-v-async.html
+    .. _Task management:
+        http://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/tasks.html
+    """
+
+
 class ConfigFileNotFoundError(Exception):
     """We cannot find the requested Pulp Smash configuration file.
 
@@ -30,6 +43,19 @@ class NoKnownServiceManagerError(Exception):
     """We cannot determine the service manager used by a system.
 
     A "service manager" is a tool such as ``systemctl`` or ``service``.
+    """
+
+
+class TaskReportError(Exception):
+    """Polled task is in error state.
+
+    For more information about pulp's task handling see
+    `Synchronous and Asynchronous Calls`_ and `Task management`_.
+
+    .. _Synchronous and Asynchronous Calls:
+        http://pulp.readthedocs.org/en/latest/dev-guide/conventions/sync-v-async.html
+    .. _Task management:
+        http://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/tasks.html
     """
 
 


### PR DESCRIPTION
This commit extends functionality of pulp_smash.api.safe_handler
to check for errors in Task report or Call report and if error was
reported, raises TaskReportError or CallReportError respectively.

This commit does not change number of tests or their results.