### PR TITLE
Add tests to assert that --enable-v{1,2} works.

### DIFF
--- a/pulp_smash/tests/docker/cli/test_copy.py
+++ b/pulp_smash/tests/docker/cli/test_copy.py
@@ -103,7 +103,7 @@ class CopyAllImagesTestCase(_BaseTestCase, _CopyMixin):
         super(CopyAllImagesTestCase, cls).setUpClass()
 
         # Create a pair of repositories.
-        docker_utils.repo_create(
+        docker_utils.repo_create_update(
             cls.cfg,
             enable_v1='true',
             enable_v2='false',
@@ -111,7 +111,7 @@ class CopyAllImagesTestCase(_BaseTestCase, _CopyMixin):
             repo_id=cls.repo_ids[0],
             upstream_name=_UPSTREAM_NAME,
         )
-        docker_utils.repo_create(cls.cfg, repo_id=cls.repo_ids[1])
+        docker_utils.repo_create_update(cls.cfg, repo_id=cls.repo_ids[1])
 
         # Sync the first and copy some content units to the second.
         docker_utils.repo_sync(cls.cfg, cls.repo_ids[0])
@@ -154,7 +154,7 @@ class CopyAllManifestsTestCase(_BaseTestCase, _CopyMixin):
         super(CopyAllManifestsTestCase, cls).setUpClass()
 
         # Create a pair of repositories.
-        docker_utils.repo_create(
+        docker_utils.repo_create_update(
             cls.cfg,
             enable_v1='false',
             enable_v2='true',
@@ -162,7 +162,7 @@ class CopyAllManifestsTestCase(_BaseTestCase, _CopyMixin):
             repo_id=cls.repo_ids[0],
             upstream_name=_UPSTREAM_NAME,
         )
-        docker_utils.repo_create(cls.cfg, repo_id=cls.repo_ids[1])
+        docker_utils.repo_create_update(cls.cfg, repo_id=cls.repo_ids[1])
 
         # Sync the first and copy some content units to the second.
         docker_utils.repo_sync(cls.cfg, cls.repo_ids[0])
@@ -208,7 +208,7 @@ class CopyAllTagsTestCase(_BaseTestCase, _CopyMixin):
         super(CopyAllTagsTestCase, cls).setUpClass()
 
         # Create a pair of repositories.
-        docker_utils.repo_create(
+        docker_utils.repo_create_update(
             cls.cfg,
             enable_v1='false',
             enable_v2='true',
@@ -216,7 +216,7 @@ class CopyAllTagsTestCase(_BaseTestCase, _CopyMixin):
             repo_id=cls.repo_ids[0],
             upstream_name=_UPSTREAM_NAME,
         )
-        docker_utils.repo_create(cls.cfg, repo_id=cls.repo_ids[1])
+        docker_utils.repo_create_update(cls.cfg, repo_id=cls.repo_ids[1])
 
         # Sync the first and copy some content units to the second.
         docker_utils.repo_sync(cls.cfg, cls.repo_ids[0])

--- a/pulp_smash/tests/docker/cli/test_sync.py
+++ b/pulp_smash/tests/docker/cli/test_sync.py
@@ -49,7 +49,7 @@ class SyncV1TestCase(_SuccessMixin, _BaseTestCase):
     def setUpClass(cls):
         """Create and sync a docker repository with a v1 registry."""
         super(SyncV1TestCase, cls).setUpClass()
-        docker_utils.repo_create(
+        docker_utils.repo_create_update(
             cls.cfg,
             feed=DOCKER_V1_FEED_URL,
             repo_id=cls.repo_id,
@@ -71,7 +71,7 @@ class SyncV2TestCase(_SuccessMixin, _BaseTestCase):
         super(SyncV2TestCase, cls).setUpClass()
         if cls.cfg.version < Version('2.8'):
             raise unittest2.SkipTest('These tests require Pulp 2.8 or above.')
-        docker_utils.repo_create(
+        docker_utils.repo_create_update(
             cls.cfg,
             feed=DOCKER_V2_FEED_URL,
             repo_id=cls.repo_id,
@@ -93,7 +93,7 @@ class SyncUnnamespacedV2TestCase(_SuccessMixin, _BaseTestCase):
         super(SyncUnnamespacedV2TestCase, cls).setUpClass()
         if cls.cfg.version < Version('2.8'):
             raise unittest2.SkipTest('These tests require Pulp 2.8 or above.')
-        docker_utils.repo_create(
+        docker_utils.repo_create_update(
             cls.cfg,
             feed=DOCKER_V2_FEED_URL,
             repo_id=cls.repo_id,
@@ -109,7 +109,7 @@ class InvalidFeedTestCase(_BaseTestCase):
     def setUpClass(cls):
         """Create a docker repo with an invalid feed and sync it."""
         super(InvalidFeedTestCase, cls).setUpClass()
-        docker_utils.repo_create(
+        docker_utils.repo_create_update(
             cls.cfg,
             feed='https://docker.example.com',
             repo_id=cls.repo_id,

--- a/pulp_smash/tests/docker/cli/utils.py
+++ b/pulp_smash/tests/docker/cli/utils.py
@@ -31,15 +31,16 @@ def repo_copy(server_config, unit_type, from_repo_id=None, to_repo_id=None):
 
 # Yes, this function has an annoying number of arguments. It may be better to
 # adopt some other solution such as providing a string for interpolation.
-def repo_create(  # pylint:disable=too-many-arguments
+def repo_create_update(  # pylint:disable=too-many-arguments
         server_config,
         enable_v1=None,
         enable_v2=None,
         feed=None,
         repo_id=None,
-        upstream_name=None):
-    """Execute ``pulp-admin docker repo create``."""
-    cmd = 'pulp-admin docker repo create'.split()
+        upstream_name=None,
+        action='create'):
+    """Execute ``pulp-admin docker repo create/update``."""
+    cmd = 'pulp-admin docker repo {}'.format(action).split()
     if enable_v1 is not None:
         cmd.extend(('--enable-v1', enable_v1))
     if enable_v2 is not None:
@@ -56,6 +57,16 @@ def repo_create(  # pylint:disable=too-many-arguments
 def repo_delete(server_config, repo_id):
     """Execute ``pulp-admin docker repo delete``."""
     cmd = 'pulp-admin docker repo delete --repo-id {}'.format(repo_id).split()
+    return cli.Client(server_config).run(cmd)
+
+
+def repo_list(server_config, repo_id=None, details=False):
+    """Execute ``pulp-admin docker repo list``."""
+    cmd = 'pulp-admin docker repo list'.split()
+    if repo_id is not None:
+        cmd.extend(('--repo-id', repo_id))
+    if details:
+        cmd.append('--details')
     return cli.Client(server_config).run(cmd)
 
 


### PR DESCRIPTION
Our Docker CLI extensions had an oversight where users could not
update the --enable-v{1,2} flags on their repositories. This
commit adds tests that ensure those flags operate correctly.

https://pulp.plan.io/issues/1710