### PR TITLE
Add tests for `background` lazy sync.

### DIFF
--- a/pulp_smash/tests/rpm/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_sync_publish.py
@@ -524,3 +524,86 @@ class SyncOnDemandTestCase(utils.BaseAPITestCase):
     def test_same_rpm_cache_header(self):
         """Assert the second request resulted in a cache hit from Squid."""
         self.assertIn('HIT', self.same_rpm.headers['X-Cache-Lookup'])
+
+
+class SyncBackgroundTestCase(utils.BaseAPITestCase):
+    """Assert Yum supports background syncing."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create an RPM repository with a valid feed and sync it.
+
+        Do the following:
+
+        0. Reset Pulp, including the Squid cache.
+        1. Sync/publish a repository using the 'background' download policy.
+        2. Assert all the content is downloaded by a background task after the
+           sync.
+        """
+        super(SyncBackgroundTestCase, cls).setUpClass()
+        if cls.cfg.version < Version('2.8'):
+            raise unittest2.SkipTest('This test requires Pulp 2.8 or greater.')
+
+        # Required to ensure content is actually downloaded.
+        utils.reset_squid(cls.cfg)
+        utils.reset_pulp(cls.cfg)
+
+        client = api.Client(cls.cfg, api.json_handler)
+
+        # Create the repository
+        body = _gen_repo()
+        body['importer_config'] = {
+            'feed': RPM_FEED_URL,
+            'download_policy': 'background',
+        }
+        distributor = _gen_distributor()
+        distributor['auto_publish'] = True
+        distributor['distributor_config']['relative_url'] = body['id']
+        body['distributors'] = [distributor]
+
+        repo = client.post(REPOSITORY_PATH, body)
+        cls.resources.add(repo['_href'])
+
+        # Sync and read the repository
+        sync_path = urljoin(repo['_href'], 'actions/sync/')
+        sync = client.post(sync_path, {'override_config': {}})
+        cls.repo = client.get(repo['_href'], params={'details': True})
+        cls.tasks = tuple(api.poll_spawned_tasks(cls.cfg, sync))
+
+        # Download an RPM to ensure it's satisfied locally.
+        client.response_handler = api.safe_handler
+        path = urljoin('/pulp/repos/', repo['id'] + '/')
+        path = urljoin(path, RPM)
+        cls.rpm = client.get(path)
+
+    def test_repo_local_units(self):
+        """Assert that all content is downloaded for the repository."""
+        self.assertEqual(
+            self.repo['locally_stored_units'],
+            sum(self.repo['content_unit_counts'].values()),
+        )
+
+    def test_request_history(self):
+        """Assert that the request was serviced directly by Pulp.
+
+        If Pulp did not have the content available locally, it would redirect
+        the client to the streamer and the rpm request would contain a history
+        entry for that redirect.
+        """
+        self.assertEqual(0, len(self.rpm.history))
+
+    def test_rpm_checksum(self):
+        """Assert the checksum of the downloaded RPM matches the metadata."""
+        checksum = hashlib.sha256(self.rpm.content).hexdigest()
+        self.assertEqual(RPM_SHA256_CHECKSUM, checksum)
+
+    def test_spawned_download_task(self):
+        """Assert that a download task was spawned as a result of the sync."""
+        expected_tags = {
+            'pulp:repository:' + self.repo['id'],
+            'pulp:action:download',
+        }
+
+        tasks = [t for t in self.tasks if set(t['tags']) == expected_tags]
+        self.assertEqual(1, len(tasks))
+        self.assertEqual('finished', tasks[0]['state'])


### PR DESCRIPTION
This adds tests for creating and syncing a repository with the
`background` download policy. It asserts that a download task is
dispatched, all repository units are reported as being local, and
that the RPM is served directly by Pulp.

Fixes issue #72