### PR TITLE
Add redundant publish metadata test

### DIFF
--- a/pulp_smash/tests/rpm/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_sync_publish.py
@@ -501,3 +501,99 @@ class SyncOnDemandTestCase(utils.BaseAPITestCase):
     def test_same_rpm_cache_header(self):
         """Assert the second request resulted in a cache hit from Squid."""
         self.assertIn('HIT', self.same_rpm.headers['X-Cache-Lookup'])
+
+
+class RedundantPublishSameMetadata(utils.BaseAPITestCase):
+    """Redundantly publish a repo without changes."""
+
+    @classmethod
+    def _download_repomd_xml(cls, url):
+        cls.client.response_handler = api.safe_handler
+        result = cls.client.get(url)
+        cls.client.response_handler = api.json_handler
+        return result
+
+    @classmethod
+    def setUpClass(cls):
+        """Test a redundant publish on a repo.
+
+        Do the following:
+
+        1. Create a new repo with zoo's feed
+        2. Publish the repo a first time
+        3. Publish the repo a second time, without any changes
+        """
+        super(RedundantPublishSameMetadata, cls).setUpClass()
+        if selectors.bug_is_untestable(1724):
+            raise unittest2.SkipTest('https://pulp.plan.io/issues/1724')
+
+        cls.repo_id = utils.uuid4()
+        relative_url = urljoin('repos/', cls.repo_id)
+        feed = 'https://repos.fedorapeople.org/repos/pulp/pulp/demo_repos/zoo/'
+
+        repomd_xml = '/pulp/repos/{relative_url}/repodata/repomd.xml'\
+            .format(relative_url=relative_url)
+
+        sync_data = {'override_config': {}}
+
+        publish_data = {'override_config': {}, 'id': 'yum_distributor'}
+
+        body = {
+            'display_name': 'TwoPublishes test repo',
+            'description': 'TwoPublishes test repo - delete me',
+            'distributors': [
+                {
+                    'distributor_id': 'yum_distributor',
+                    'auto_publish': False,
+                    'distributor_config': {
+                        'http': False,
+                        'relative_url': relative_url,
+                        'https': True
+                    },
+                    'distributor_type_id': 'yum_distributor'
+                }
+            ],
+            'notes': {'_repo-type': 'rpm-repo'},
+            'importer_type_id': 'yum_importer',
+            'importer_config': {
+                'feed': feed
+            },
+            'id': cls.repo_id
+        }
+
+        cls.client = api.Client(cls.cfg, api.json_handler)
+        try:
+            repo = cls.client.post(REPOSITORY_PATH, body)
+
+            sync_path = urljoin(repo['_href'], 'actions/sync/')
+            publish_path = urljoin(repo['_href'], 'actions/publish/')
+
+            cls.client.post(sync_path, sync_data)
+
+            cls.client.post(publish_path, publish_data)
+            cls.publish1_repomd = cls._download_repomd_xml(repomd_xml)
+
+            cls.client.post(publish_path, publish_data)
+            cls.publish2_repomd = cls._download_repomd_xml(repomd_xml)
+
+        except:
+            cls.tearDownClass()
+            raise
+
+    @classmethod
+    def tearDownClass(cls):
+        """Delete the repository we just created."""
+        if hasattr(cls, 'client'):
+            try:
+                cls.client.delete(urljoin(REPOSITORY_PATH, cls.repo_id))
+            except:  # pylint: disable=bare-except
+                pass
+
+    def test_compare_repomd(self):
+        """Assert the repodata is the same."""
+        if selectors.bug_is_untestable(1724):
+            self.skipTest('https://pulp.plan.io/issues/1724')
+
+        self.assertEqual(self.publish1_repomd.content,
+                         self.publish2_repomd.content,
+                         'Expected identical metadata on redundant publish')


### PR DESCRIPTION
Test that metadata creation is identical before and after a redundant
publish

closes #127

Depends on https://pulp.plan.io/issues/1724