### PR TITLE
Add tests for removal of RPM orphans

### DIFF
--- a/pulp_smash/constants.py
+++ b/pulp_smash/constants.py
@@ -69,6 +69,13 @@ LOGIN_PATH = '/pulp/api/v2/actions/login/'
     https://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/authentication.html
 """
 
+ORPHANS_PATH = 'pulp/api/v2/content/orphans/'
+"""See: `Orphaned Content`_.
+
+.. _Orphaned Content:
+    http://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/content/orphan.html
+"""
+
 PLUGIN_TYPES_PATH = '/pulp/api/v2/plugins/types/'
 """See: `Retrieve All Content Unit Types`_.
 

--- a/pulp_smash/tests/rpm/api_v2/test_orphan_remove.py
+++ b/pulp_smash/tests/rpm/api_v2/test_orphan_remove.py
@@ -1,0 +1,63 @@
+# coding=utf-8
+"""Test the removal of rpm orphans.
+
+This module assumes that the tests in
+:mod:`pulp_smash.tests.platform.api_v2.test_repository` and
++`pulp_smash.tests.platform.api_v2.test_sync_publish` hold true.
+"""
+
+from __future__ import unicode_literals
+try:
+    from urllib.parse import urljoin
+except ImportError:
+    from urlparse import urljoin  # pylint:disable=C0411,E0401
+
+from pulp_smash import api, utils
+from pulp_smash.constants import (ORPHANS_PATH, REPOSITORY_PATH, RPM_FEED_URL)
+from pulp_smash.tests.rpm.api_v2.utils import gen_repo
+
+
+def _count_orphans(client):
+    """Count the number of orphans."""
+    orphan_dict = client.get(ORPHANS_PATH)
+    total_orphans = 0
+    for _, data in orphan_dict.items():
+        total_orphans += data.get('count') or 0
+    return total_orphans
+
+
+class OrphanRemoveAllTestCase(utils.BaseAPITestCase):
+    """Establish that orphan removal does a full cleanup."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create an RPM repo, sync it, delete the repo, remove orphans."""
+        super(OrphanRemoveAllTestCase, cls).setUpClass()
+        client = api.Client(cls.cfg, api.json_handler)
+        body = gen_repo()
+        body['importer_config']['feed'] = RPM_FEED_URL
+        repo = client.post(REPOSITORY_PATH, body)
+        sync_path = urljoin(repo['_href'], 'actions/sync/')
+        client.post(sync_path, {'override_config': {}})
+
+        cls.num_orphans_pre_repo_del = _count_orphans(client)
+        client.delete(repo['_href'])
+        cls.num_orphans_post_repo_del = _count_orphans(client)
+        client.delete(ORPHANS_PATH)
+        cls.num_orphans_after_rm = _count_orphans(client)
+
+    def test_orphans_created(self):
+        """Ensure that orphans were created by deleting the repository.
+
+        Failure of this test indicates that other repositories may still exist
+        in the db that have associated the units, thus not creating orphans
+        as expected.
+        """
+        self.assertTrue(
+            self.num_orphans_pre_repo_del <= self.num_orphans_post_repo_del
+        )
+        self.assertTrue(self.num_orphans_post_repo_del >= 39)
+
+    def test_orphans_removed(self):
+        """Ensure that all orphans were removed."""
+        self.assertEqual(self.num_orphans_after_rm, 0)


### PR DESCRIPTION
These tests create and sync a repository, pulling down all content units
for that repository. The repo is deleted leaving orphaned units. The
added tests ensure that those orphans are removed by a call to the
orphan remove API endpoint.

Fix #134