### PR TITLE
Update OSTree test to use small repo on fedorapeople.

### DIFF
--- a/pulp_smash/tests/ostree/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/ostree/api_v2/test_sync_publish.py
@@ -32,7 +32,7 @@ import unittest2
 from pulp_smash import api, config, utils
 from pulp_smash.constants import PLUGIN_TYPES_PATH, REPOSITORY_PATH
 
-_FEED = 'http://dl.fedoraproject.org/pub/fedora/linux/atomic/21/'
+_FEED = 'https://repos.fedorapeople.org/pulp/pulp/demo_repos/test-ostree-small'
 _BRANCHES = (
     'fedora-atomic/f21/x86_64/updates/docker-host',
     'fedora-atomic/f21/x86_64/updates-testing/docker-host',


### PR DESCRIPTION
Using super small repository keeps the test from timing out and taking a ton of storage.  Also, nice that it runs much faster.