### PR TITLE
Test re-publish repository after unassociating content.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -45,6 +45,7 @@ developers, not a gospel.
     api/pulp_smash.tests.rpm.api_v2.test_duplicate_uploads
     api/pulp_smash.tests.rpm.api_v2.test_iso_crud
     api/pulp_smash.tests.rpm.api_v2.test_remove_unit
+    api/pulp_smash.tests.rpm.api_v2.test_republish
     api/pulp_smash.tests.rpm.api_v2.test_retain_old_count
     api/pulp_smash.tests.rpm.api_v2.test_sync_publish
     api/pulp_smash.tests.rpm.api_v2.utils

--- a/docs/api/pulp_smash.tests.rpm.api_v2.test_republish.rst
+++ b/docs/api/pulp_smash.tests.rpm.api_v2.test_republish.rst
@@ -1,0 +1,8 @@
+`pulp_smash.tests.rpm.api_v2.test_republish`
+============================================
+
+Location: :doc:`/index` → :doc:`/api` →
+:doc:`/api/pulp_smash.tests.rpm.api_v2.test_republish`
+
+.. automodule:: pulp_smash.tests.rpm.api_v2.test_republish
+

--- a/pulp_smash/tests/rpm/api_v2/test_republish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_republish.py
@@ -1,0 +1,148 @@
+# coding=utf-8
+"""Test re-publish repository after unassociating content.
+
+Following steps are executed in order to test correct functionality
+of repository created with valid feed.
+
+1. Create repository foo with valid feed, run sync, add distributor to it and
+   publish over http and https.
+2. Pick a unit X and and assert it is accessible.
+3. Remove unit X from repository foo and re-publish.
+5. Assert unit X is not accessible.
+
+"""
+
+from __future__ import unicode_literals
+
+import random
+try:  # try Python 3 import first
+    from urllib.parse import urljoin
+except ImportError:
+    from urlparse import urljoin  # pylint:disable=C0411,E0401
+
+from pulp_smash import api, utils
+from pulp_smash.constants import REPOSITORY_PATH, RPM_FEED_URL
+from pulp_smash.tests.rpm.api_v2.utils import gen_distributor, gen_repo
+
+_PUBLISH_DIR = 'pulp/repos/'
+
+
+def _sync_repo(server_config, repo_href):
+    """Sync the referenced repository. Return the raw server response."""
+    return api.Client(server_config).post(
+        urljoin(repo_href, 'actions/sync/'),
+        {'override_config': {}}
+    )
+
+
+class RepublishTestCase(utils.BaseAPITestCase):
+    """Test re-publish repository after unassociating content."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create one repository with feed, unassociate unit and re-publish.
+
+        Following steps are executed:
+
+        1. Create repository foo with feed, sync and publish it.
+        2. Get an unit X and assert it is accessible
+        3. Remove unit X from repository foo and re-publish foo.
+        4. Get same unit X and assert it is not accessible
+        """
+        super(RepublishTestCase, cls).setUpClass()
+        cls.responses = {}
+
+        # Create and sync a repository.
+        client = api.Client(cls.cfg)
+        body = gen_repo()
+        body['importer_config']['feed'] = RPM_FEED_URL
+        repo_href = client.post(REPOSITORY_PATH, body).json()['_href']
+        cls.resources.add(repo_href)  # mark for deletion
+        cls.responses['sync'] = _sync_repo(cls.cfg, repo_href)
+
+        # Add a distributor
+        cls.responses['distribute'] = client.post(
+            urljoin(repo_href, 'distributors/'),
+            gen_distributor(),
+        )
+        # Publish repo
+        cls.responses['first publish'] = client.post(
+            urljoin(repo_href, 'actions/publish/'),
+            {'id': cls.responses['distribute'].json()['id']},
+        )
+
+        # Get contents of repository
+        body = {'criteria': {}}
+        cls.responses['repo units'] = client.post(
+            urljoin(repo_href, 'search/units/'), body)
+
+        # Get random unit from repository to remove
+        cls.removed_unit = random.choice([
+            unit['metadata']['filename']
+            for unit in cls.responses['repo units'].json()
+            if unit['unit_type_id'] == 'rpm'
+        ])
+
+        # Download the RPM from repository.
+        url = urljoin(
+            '/pulp/repos/',
+            cls.responses['distribute'].json()['config']['relative_url']
+        )
+        url = urljoin(url, cls.removed_unit)
+        cls.responses['first get'] = client.get(url)
+
+        # Remove unit from the repo
+        cls.responses['remove unit'] = client.post(
+            urljoin(repo_href, 'actions/unassociate/'),
+            {
+                'criteria': {
+                    'fields': {
+                        'unit': [
+                            'arch',
+                            'checksum',
+                            'checksumtype',
+                            'epoch',
+                            'name',
+                            'release',
+                            'version',
+                        ]
+                    },
+                    'type_ids': ['rpm'],
+                    'filters': {
+                        'unit': {'filename': cls.removed_unit}
+                    }
+                }
+            },
+        )
+
+        # Publish the repo again
+        cls.responses['second publish'] = client.post(
+            urljoin(repo_href, 'actions/publish/'),
+            {'id': cls.responses['distribute'].json()['id']},
+        )
+
+        # Download the RPM from repository.
+        url = urljoin(
+            '/pulp/repos/',
+            cls.responses['distribute'].json()['config']['relative_url']
+        )
+        url = urljoin(url, cls.removed_unit)
+        client.response_handler = api.echo_handler
+        cls.responses['second get'] = client.get(url)
+
+    def test_publishes_succeed(self):
+        """Verify the HTTP status code of each publish."""
+        for step, code in (
+                ('first publish', 202),
+                ('second publish', 202),
+        ):
+            with self.subTest(step=step):
+                self.assertEqual(self.responses[step].status_code, code)
+
+    def test_rpm_can_be_accessed(self):
+        """Test rpm can be accessed after first publish."""
+        self.assertEqual(self.responses['first get'].status_code, 200)
+
+    def test_rpm_cannot_be_accessed(self):
+        """Test rpm cannot be accessed after its removal and re-publish."""
+        self.assertEqual(self.responses['second get'].status_code, 404)


### PR DESCRIPTION
Add and document a new module `pulp_smash.tests.rpm.api_v2.test_republish`.
The newly added 3 tests pass.

Fixes #118.