### PR TITLE
Move dynamic imports to compat module

### DIFF
--- a/pulp_smash/api.py
+++ b/pulp_smash/api.py
@@ -11,14 +11,11 @@ from __future__ import unicode_literals
 
 import warnings
 from time import sleep
-try:  # try Python 3 import first
-    from urllib.parse import urljoin
-except ImportError:  # pragma: no cover
-    from urlparse import urljoin  # pylint:disable=C0411,E0401
 
 import requests
 
 from pulp_smash import exceptions
+from pulp_smash.compat import urljoin
 
 
 _SENTINEL = object()

--- a/pulp_smash/compat.py
+++ b/pulp_smash/compat.py
@@ -1,0 +1,7 @@
+# coding=utf-8
+"""Compatibility imports."""
+
+try:  # try Python 3 import first
+    from urllib.parse import urljoin
+except ImportError:
+    from urlparse import urljoin  # pylint:disable=C0411,E0401,F0401 # noqa

--- a/pulp_smash/tests/ostree/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/ostree/api_v2/test_sync_publish.py
@@ -22,14 +22,10 @@ following trees of assumptions are explored in this module::
 """
 from __future__ import unicode_literals
 
-try:  # try Python 3 import first
-    from urllib.parse import urljoin
-except ImportError:
-    from urlparse import urljoin  # pylint:disable=C0411,E0401
-
 import unittest2
 
 from pulp_smash import api, config, utils
+from pulp_smash.compat import urljoin
 from pulp_smash.constants import PLUGIN_TYPES_PATH, REPOSITORY_PATH
 
 _FEED = 'https://repos.fedorapeople.org/pulp/pulp/demo_repos/test-ostree-small'

--- a/pulp_smash/tests/platform/api_v2/test_consumer.py
+++ b/pulp_smash/tests/platform/api_v2/test_consumer.py
@@ -6,12 +6,8 @@
 """
 from __future__ import unicode_literals
 
-try:  # try Python 3 first
-    from urllib.parse import urljoin
-except ImportError:
-    from urlparse import urljoin  # pylint:disable=C0411,E0401
-
 from pulp_smash import api, utils
+from pulp_smash.compat import urljoin
 from pulp_smash.constants import CONSUMER_PATH, REPOSITORY_PATH
 from pulp_smash.tests.rpm.api_v2.utils import gen_repo, gen_distributor
 

--- a/pulp_smash/tests/platform/api_v2/test_repository.py
+++ b/pulp_smash/tests/platform/api_v2/test_repository.py
@@ -16,14 +16,10 @@ The assumptions explored in this module have the following dependencies::
 """
 from __future__ import unicode_literals
 
-try:  # try Python 3 first
-    from urllib.parse import urljoin
-except ImportError:
-    from urlparse import urljoin  # pylint:disable=C0411,E0401
-
 from packaging.version import Version
 
 from pulp_smash import api, utils
+from pulp_smash.compat import urljoin
 from pulp_smash.constants import REPOSITORY_PATH, ERROR_KEYS
 from pulp_smash.selectors import bug_is_untestable, require
 

--- a/pulp_smash/tests/puppet/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/puppet/api_v2/test_sync_publish.py
@@ -35,14 +35,11 @@ Assertions not explored in this module include:
 from __future__ import unicode_literals
 
 from itertools import product
-try:  # try Python 3 first
-    from urllib.parse import urljoin
-except ImportError:
-    from urlparse import urljoin  # pylint:disable=C0411,E0401
 
 from packaging.version import Version
 
 from pulp_smash import api, selectors, utils
+from pulp_smash.compat import urljoin
 from pulp_smash.constants import (
     CALL_REPORT_KEYS,
     CONTENT_UPLOAD_PATH,

--- a/pulp_smash/tests/rpm/api_v2/test_broker.py
+++ b/pulp_smash/tests/rpm/api_v2/test_broker.py
@@ -26,14 +26,11 @@ Both scenarios are executed by
 from __future__ import unicode_literals
 
 import time
-try:  # try Python 3 import first
-    from urllib.parse import urljoin
-except ImportError:
-    from urlparse import urljoin  # pylint:disable=C0411,E0401
 
 import unittest2
 
 from pulp_smash import api, cli, config, selectors, utils
+from pulp_smash.compat import urljoin
 from pulp_smash.constants import (
     PULP_SERVICES,
     REPOSITORY_PATH,

--- a/pulp_smash/tests/rpm/api_v2/test_duplicate_uploads.py
+++ b/pulp_smash/tests/rpm/api_v2/test_duplicate_uploads.py
@@ -16,12 +16,8 @@ The second upload should silently fail for all Pulp releases in the 2.x series.
 """
 from __future__ import unicode_literals
 
-try:  # try Python 3 import first
-    from urllib.parse import urljoin
-except ImportError:
-    from urlparse import urljoin  # pylint:disable=C0411,E0401
-
 from pulp_smash import api, utils
+from pulp_smash.compat import urljoin
 from pulp_smash.constants import (
     CONTENT_UPLOAD_PATH,
     REPOSITORY_PATH,

--- a/pulp_smash/tests/rpm/api_v2/test_iso_crud.py
+++ b/pulp_smash/tests/rpm/api_v2/test_iso_crud.py
@@ -2,14 +2,10 @@
 """Test CRUD for ISO RPM repositories."""
 from __future__ import unicode_literals
 
-try:  # try Python 3 import first
-    from urllib.parse import urljoin
-except ImportError:
-    from urlparse import urljoin  # pylint:disable=C0411,E0401
-
 from packaging.version import Version
 
 from pulp_smash import api, selectors, utils
+from pulp_smash.compat import urljoin
 from pulp_smash.constants import REPOSITORY_PATH
 
 

--- a/pulp_smash/tests/rpm/api_v2/test_orphan_remove.py
+++ b/pulp_smash/tests/rpm/api_v2/test_orphan_remove.py
@@ -7,12 +7,8 @@ This module assumes that the tests in
 """
 from __future__ import unicode_literals
 
-try:
-    from urllib.parse import urljoin
-except ImportError:
-    from urlparse import urljoin  # pylint:disable=C0411,E0401
-
 from pulp_smash import api, utils
+from pulp_smash.compat import urljoin
 from pulp_smash.constants import ORPHANS_PATH, REPOSITORY_PATH, RPM_FEED_URL
 from pulp_smash.tests.rpm.api_v2.utils import gen_repo
 

--- a/pulp_smash/tests/rpm/api_v2/test_remove_unit.py
+++ b/pulp_smash/tests/rpm/api_v2/test_remove_unit.py
@@ -20,12 +20,9 @@ of repository created with valid feed and remove_missing option set.
 from __future__ import unicode_literals
 
 import random
-try:  # try Python 3 import first
-    from urllib.parse import urljoin
-except ImportError:
-    from urlparse import urljoin  # pylint:disable=C0411,E0401
 
 from pulp_smash import api, utils
+from pulp_smash.compat import urljoin
 from pulp_smash.constants import REPOSITORY_PATH, RPM_FEED_URL
 from pulp_smash.tests.rpm.api_v2.utils import gen_distributor, gen_repo
 

--- a/pulp_smash/tests/rpm/api_v2/test_retain_old_count.py
+++ b/pulp_smash/tests/rpm/api_v2/test_retain_old_count.py
@@ -16,12 +16,8 @@ repository created with valid feed and `retain_old_count`_ option set.
 """
 from __future__ import unicode_literals
 
-try:  # try Python 3 import first
-    from urllib.parse import urljoin
-except ImportError:
-    from urlparse import urljoin  # pylint:disable=C0411,E0401
-
 from pulp_smash import api, utils
+from pulp_smash.compat import urljoin
 from pulp_smash.constants import REPOSITORY_PATH, RPM_FEED_URL
 from pulp_smash.tests.rpm.api_v2.utils import gen_distributor, gen_repo
 

--- a/pulp_smash/tests/rpm/api_v2/test_schedule_sync.py
+++ b/pulp_smash/tests/rpm/api_v2/test_schedule_sync.py
@@ -10,14 +10,11 @@ This module assumes that the tests in
 from __future__ import unicode_literals
 
 import time
-try:  # try Python 3 import first
-    from urllib.parse import urljoin
-except ImportError:
-    from urlparse import urljoin  # pylint:disable=C0411,E0401
 
 from packaging.version import Version
 
 from pulp_smash import api, selectors, utils
+from pulp_smash.compat import urljoin
 from pulp_smash.constants import REPOSITORY_PATH, RPM_FEED_URL
 from pulp_smash.tests.rpm.api_v2.utils import gen_repo
 

--- a/pulp_smash/tests/rpm/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_sync_publish.py
@@ -33,15 +33,12 @@ from __future__ import unicode_literals
 
 import hashlib
 from itertools import product
-try:  # try Python 3 import first
-    from urllib.parse import urljoin
-except ImportError:
-    from urlparse import urljoin  # pylint:disable=C0411,E0401
 
 import unittest2
 from packaging.version import Version
 
 from pulp_smash import api, selectors, utils
+from pulp_smash.compat import urljoin
 from pulp_smash.constants import (
     CALL_REPORT_KEYS,
     CONTENT_UPLOAD_PATH,

--- a/pulp_smash/tests/rpm/api_v2/test_unassociate.py
+++ b/pulp_smash/tests/rpm/api_v2/test_unassociate.py
@@ -10,12 +10,8 @@ This module assumes that the tests in
 """
 from __future__ import unicode_literals
 
-try:  # try Python 3 import first
-    from urllib.parse import urljoin
-except ImportError:
-    from urlparse import urljoin  # pylint:disable=C0411,E0401
-
 from pulp_smash import api, utils
+from pulp_smash.compat import urljoin
 from pulp_smash.constants import REPOSITORY_PATH, RPM_FEED_URL
 from pulp_smash.tests.rpm.api_v2.utils import gen_repo
 


### PR DESCRIPTION
This commit creates a compat module that can be used to do any dynamic
importing (particularly to support both python 2 and 3) so it will not
need to be done everywhere.