### PR TITLE
Ostree refactor

### DIFF
--- a/pulp_smash/api.py
+++ b/pulp_smash/api.py
@@ -11,14 +11,11 @@ from __future__ import unicode_literals
 
 import warnings
 from time import sleep
-try:  # try Python 3 import first
-    from urllib.parse import urljoin
-except ImportError:  # pragma: no cover
-    from urlparse import urljoin  # pylint:disable=C0411,E0401
 
 import requests
 
 from pulp_smash import exceptions
+from pulp_smash.compat import urljoin
 
 
 _SENTINEL = object()

--- a/pulp_smash/compat.py
+++ b/pulp_smash/compat.py
@@ -1,0 +1,7 @@
+# coding=utf-8
+"""Compatibility imports."""
+
+try:  # try Python 3 import first
+    from urllib.parse import urljoin
+except ImportError:
+    from urlparse import urljoin  # pylint:disable=C0411,E0401,F0401 # noqa

--- a/pulp_smash/tests/ostree/api_v2/test_crud.py
+++ b/pulp_smash/tests/ostree/api_v2/test_crud.py
@@ -1,0 +1,76 @@
+# coding=utf-8
+"""Test the CRUD API endpoints `OSTree`_ `repositories`_.
+
+TODO (asmacdo) review what is where in the docs here
+
+
+This module assumes that the tests in
+:mod:`pulp_smash.tests.platform.api_v2.test_repository` hold true. The
+following trees of assumptions are explored in this module::
+
+    It is possible to create an OSTree repo with feed (CreateTestCase).
+    It is possible to create a repository without a feed (CreateTestCase).
+
+.. _OSTree:
+    http://pulp-ostree.readthedocs.org/en/latest/
+.. _repositories:
+   http://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/repo/cud.html
+"""
+from pulp_smash import api, utils
+from pulp_smash.compat import urljoin
+from pulp_smash.constants import REPOSITORY_PATH
+from pulp_smash.tests.ostree import ostree_utils
+
+
+def setUpModule():  # pylint:disable=invalid-name
+    """Skip tests if the OSTree plugin is not installed."""
+    ostree_utils.setUpModule()
+
+
+class CreateTestCase(utils.BaseAPITestCase):
+    """Create two OSTree repositories, with and without a feed."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create two repositories."""
+        super(CreateTestCase, cls).setUpClass()
+        client = api.Client(cls.cfg, api.json_handler)
+        cls.bodies = tuple((ostree_utils.gen_repo() for _ in range(2)))
+        cls.bodies[1]['importer_config'] = {'feed': utils.uuid4()}
+        cls.repos = [client.post(REPOSITORY_PATH, body) for body in cls.bodies]
+        cls.importers_iter = [
+            client.get(urljoin(repo['_href'], 'importers/'))
+            for repo in cls.repos
+        ]
+        for repo in cls.repos:
+            cls.resources.add(repo['_href'])  # mark for deletion
+
+    def test_id_notes(self):
+        """Validate the ``id`` and ``notes`` attributes for each repository."""
+        for body, repo in zip(self.bodies, self.repos):  # for input, output:
+            for key in {'id', 'notes'}:
+                with self.subTest(body=body):
+                    self.assertIn(key, repo)
+                    self.assertEqual(repo[key], body[key])
+
+    def test_number_importers(self):
+        """Assert each repository has one importer."""
+        for body, importers in zip(self.bodies, self.importers_iter):
+            with self.subTest(body=body):
+                self.assertEqual(len(importers), 1, importers)
+
+    def test_importer_type_id(self):
+        """Validate the ``importer_type_id`` attribute of each importer."""
+        key = 'importer_type_id'
+        for body, importers in zip(self.bodies, self.importers_iter):
+            with self.subTest(body=body):
+                self.assertIn(key, importers[0])
+                self.assertEqual(importers[0][key], body[key])
+
+    def test_importer_config(self):
+        """Validate the ``config`` attribute of each importer."""
+        key = 'config'
+        for body, importers in zip(self.bodies, self.importers_iter):
+            with self.subTest(body=body):
+                self.assertIn(key, importers[0])
+                self.assertEqual(importers[0][key], body['importer_' + key])

--- a/pulp_smash/tests/ostree/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/ostree/api_v2/test_sync_publish.py
@@ -22,14 +22,10 @@ following trees of assumptions are explored in this module::
 """
 from __future__ import unicode_literals
 
-try:  # try Python 3 import first
-    from urllib.parse import urljoin
-except ImportError:
-    from urlparse import urljoin  # pylint:disable=C0411,E0401
-
 import unittest2
 
 from pulp_smash import api, config, utils
+from pulp_smash.compat import urljoin
 from pulp_smash.constants import PLUGIN_TYPES_PATH, REPOSITORY_PATH
 
 _FEED = 'https://repos.fedorapeople.org/pulp/pulp/demo_repos/test-ostree-small'

--- a/pulp_smash/tests/ostree/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/ostree/api_v2/test_sync_publish.py
@@ -2,16 +2,17 @@
 """Test the API endpoints `OSTree`_ `repositories`_.
 
 This module assumes that the tests in
-:mod:`pulp_smash.tests.platform.api_v2.test_repository` hold true. The
-following trees of assumptions are explored in this module::
+:mod:`pulp_smash.tests.platform.api_v2.test_repository` and
+`pulp_smash.tests.ostree.api_v2.test_crud` hold true. The following trees of
+assumptions are explored in this module::
 
-    It is possible to create an OSTree repo with feed (CreateTestCase).
+    It is possible to create an OSTree repo with feed (test_crud).
     ├── When a valid feed and branch are given the repo syncs successfully
     │   without reporting errors (CreateValidFeedTestCase).
     └── When an invalid feed or branch is given, repo syncs fail and errors are
         reported (SyncInvalidFeedTestCase).
 
-    It is possible to create a repository without a feed (CreateTestCase).
+    It is possible to create a repository without a feed (test_crud).
     └── Running sync on this repository fails with errors reported
         (SyncWithoutFeedTestCase).
 
@@ -22,11 +23,8 @@ following trees of assumptions are explored in this module::
 """
 from __future__ import unicode_literals
 
-import unittest2
-
-from pulp_smash import api, config, utils
-from pulp_smash.compat import urljoin
-from pulp_smash.constants import PLUGIN_TYPES_PATH, REPOSITORY_PATH
+from pulp_smash import utils
+from pulp_smash.tests.ostree import ostree_utils
 
 _FEED = 'https://repos.fedorapeople.org/pulp/pulp/demo_repos/test-ostree-small'
 _BRANCHES = (
@@ -37,53 +35,7 @@ _BRANCHES = (
 
 def setUpModule():  # pylint:disable=invalid-name
     """Skip tests if the OSTree plugin is not installed."""
-    if 'ostree' not in _get_plugin_type_ids():
-        raise unittest2.SkipTest('These tests require the OSTree plugin.')
-
-
-def _get_plugin_type_ids():
-    """Get the ID of each of Pulp's plugins.
-
-    Each Pulp plugin adds one (or more?) content unit type to Pulp. Each of
-    these content unit types is identified by a certain unique identifier. For
-    example, the `Python type`_ has an ID of ``python_package``.
-
-    :returns: A set of plugin IDs. For example: ``{'ostree',
-        'python_package'}``.
-
-    .. _Python type:
-       http://pulp-python.readthedocs.org/en/latest/reference/python-type.html
-    """
-    client = api.Client(config.get_config(), api.json_handler)
-    plugin_types = client.get(PLUGIN_TYPES_PATH)
-    return {plugin_type['id'] for plugin_type in plugin_types}
-
-
-def _gen_repo():
-    """Return OSTree repo body."""
-    return {
-        'id': utils.uuid4(),
-        'importer_type_id': 'ostree_web_importer',
-        'importer_config': {},
-        'distributors': [],
-        'notes': {'_repo-type': 'OSTREE'},
-    }
-
-
-def _create_sync_repo(server_config, body):
-    # Create repository.
-    client = api.Client(server_config, api.json_handler)
-    repo = client.post(REPOSITORY_PATH, body)
-
-    # Sync repository and collect task statuses.
-    client.response_handler = api.echo_handler
-    response = client.post(
-        urljoin(repo['_href'], 'actions/sync/'),
-        {'override_config': {}},
-    )
-    response.raise_for_status()
-    tasks = tuple(api.poll_spawned_tasks(server_config, response.json()))
-    return repo['_href'], response, tasks
+    ostree_utils.setUpModule()
 
 
 class _SyncFailedMixin(object):
@@ -132,55 +84,6 @@ class _SyncImportFailedMixin(object):  # pylint:disable=too-few-public-methods
             self.assertGreater(num_error_details, 0)
 
 
-class CreateTestCase(utils.BaseAPITestCase):
-    """Create two OSTree repositories, with and without a feed."""
-
-    @classmethod
-    def setUpClass(cls):
-        """Create two repositories."""
-        super(CreateTestCase, cls).setUpClass()
-        client = api.Client(cls.cfg, api.json_handler)
-        cls.bodies = tuple((_gen_repo() for _ in range(2)))
-        cls.bodies[1]['importer_config'] = {'feed': utils.uuid4()}
-        cls.repos = [client.post(REPOSITORY_PATH, body) for body in cls.bodies]
-        cls.importers_iter = [
-            client.get(urljoin(repo['_href'], 'importers/'))
-            for repo in cls.repos
-        ]
-        for repo in cls.repos:
-            cls.resources.add(repo['_href'])  # mark for deletion
-
-    def test_id_notes(self):
-        """Validate the ``id`` and ``notes`` attributes for each repository."""
-        for body, repo in zip(self.bodies, self.repos):  # for input, output:
-            for key in {'id', 'notes'}:
-                with self.subTest(body=body):
-                    self.assertIn(key, repo)
-                    self.assertEqual(repo[key], body[key])
-
-    def test_number_importers(self):
-        """Assert each repository has one importer."""
-        for body, importers in zip(self.bodies, self.importers_iter):
-            with self.subTest(body=body):
-                self.assertEqual(len(importers), 1, importers)
-
-    def test_importer_type_id(self):
-        """Validate the ``importer_type_id`` attribute of each importer."""
-        key = 'importer_type_id'
-        for body, importers in zip(self.bodies, self.importers_iter):
-            with self.subTest(body=body):
-                self.assertIn(key, importers[0])
-                self.assertEqual(importers[0][key], body[key])
-
-    def test_importer_config(self):
-        """Validate the ``config`` attribute of each importer."""
-        key = 'config'
-        for body, importers in zip(self.bodies, self.importers_iter):
-            with self.subTest(body=body):
-                self.assertIn(key, importers[0])
-                self.assertEqual(importers[0][key], body['importer_' + key])
-
-
 class SyncTestCase(utils.BaseAPITestCase):
     """Create an OSTree repository with a valid feed and branch, and sync it.
 
@@ -191,10 +94,12 @@ class SyncTestCase(utils.BaseAPITestCase):
     def setUpClass(cls):
         """Create an OSTree repository with a valid feed and branch."""
         super(SyncTestCase, cls).setUpClass()
-        body = _gen_repo()
+        body = ostree_utils.gen_repo()
         body['importer_config']['feed'] = _FEED
         body['importer_config']['branches'] = [_BRANCHES[0]]
-        repo_href, cls.report, cls.tasks = _create_sync_repo(cls.cfg, body)
+        repo_href, cls.report, cls.tasks = ostree_utils.create_sync_repo(
+            cls.cfg, body
+        )
         cls.resources.add(repo_href)
 
     def test_start_sync_code(self):
@@ -226,10 +131,12 @@ class SyncInvalidFeedTestCase(
     def setUpClass(cls):
         """Set ``cls.body``."""
         super(SyncInvalidFeedTestCase, cls).setUpClass()
-        body = _gen_repo()
+        body = ostree_utils.gen_repo()
         body['importer_config']['feed'] = utils.uuid4()
         body['importer_config']['branches'] = [_BRANCHES[0]]
-        repo_href, cls.report, cls.tasks = _create_sync_repo(cls.cfg, body)
+        repo_href, cls.report, cls.tasks = ostree_utils.create_sync_repo(
+            cls.cfg, body
+        )
         cls.resources.add(repo_href)
 
 
@@ -243,10 +150,12 @@ class SyncInvalidBranchesTestCase(
     def setUpClass(cls):
         """Set ``cls.body``."""
         super(SyncInvalidBranchesTestCase, cls).setUpClass()
-        body = _gen_repo()
+        body = ostree_utils.gen_repo()
         body['importer_config']['feed'] = _FEED
         body['importer_config']['branches'] = [utils.uuid4()]
-        repo_href, cls.report, cls.tasks = _create_sync_repo(cls.cfg, body)
+        repo_href, cls.report, cls.tasks = ostree_utils.create_sync_repo(
+            cls.cfg, body
+        )
         cls.resources.add(repo_href)
 
 
@@ -257,6 +166,8 @@ class SyncMissingAttrsTestCase(_SyncFailedMixin, utils.BaseAPITestCase):
     def setUpClass(cls):
         """Set ``cls.body``."""
         super(SyncMissingAttrsTestCase, cls).setUpClass()
-        body = _gen_repo()
-        repo_href, cls.report, cls.tasks = _create_sync_repo(cls.cfg, body)
+        body = ostree_utils.gen_repo()
+        repo_href, cls.report, cls.tasks = ostree_utils.create_sync_repo(
+            cls.cfg, body
+        )
         cls.resources.add(repo_href)

--- a/pulp_smash/tests/ostree/ostree_utils.py
+++ b/pulp_smash/tests/ostree/ostree_utils.py
@@ -1,0 +1,41 @@
+# coding=utf-8
+"""Utilities for interacting with OS tree."""
+
+import unittest2
+
+from pulp_smash import api, utils
+from pulp_smash.compat import urljoin
+from pulp_smash.constants import REPOSITORY_PATH
+
+
+def setUpModule():  # pylint:disable=invalid-name
+    """Skip tests if the OSTree plugin is not installed."""
+    if 'ostree' not in utils.get_plugin_type_ids():
+        raise unittest2.SkipTest('These tests require the OSTree plugin.')
+
+
+def gen_repo():
+    """Return OSTree repo body."""
+    return {
+        'id': utils.uuid4(),
+        'importer_type_id': 'ostree_web_importer',
+        'importer_config': {},
+        'distributors': [],
+        'notes': {'_repo-type': 'OSTREE'},
+    }
+
+
+def create_sync_repo(server_config, body):
+    """Create repository."""
+    client = api.Client(server_config, api.json_handler)
+    repo = client.post(REPOSITORY_PATH, body)
+
+    # Sync repository and collect task statuses.
+    client.response_handler = api.echo_handler
+    response = client.post(
+        urljoin(repo['_href'], 'actions/sync/'),
+        {'override_config': {}},
+    )
+    response.raise_for_status()
+    tasks = tuple(api.poll_spawned_tasks(server_config, response.json()))
+    return repo['_href'], response, tasks

--- a/pulp_smash/tests/platform/api_v2/test_consumer.py
+++ b/pulp_smash/tests/platform/api_v2/test_consumer.py
@@ -6,12 +6,8 @@
 """
 from __future__ import unicode_literals
 
-try:  # try Python 3 first
-    from urllib.parse import urljoin
-except ImportError:
-    from urlparse import urljoin  # pylint:disable=C0411,E0401
-
 from pulp_smash import api, utils
+from pulp_smash.compat import urljoin
 from pulp_smash.constants import CONSUMER_PATH, REPOSITORY_PATH
 from pulp_smash.tests.rpm.api_v2.utils import gen_repo, gen_distributor
 

--- a/pulp_smash/tests/platform/api_v2/test_repository.py
+++ b/pulp_smash/tests/platform/api_v2/test_repository.py
@@ -16,14 +16,10 @@ The assumptions explored in this module have the following dependencies::
 """
 from __future__ import unicode_literals
 
-try:  # try Python 3 first
-    from urllib.parse import urljoin
-except ImportError:
-    from urlparse import urljoin  # pylint:disable=C0411,E0401
-
 from packaging.version import Version
 
 from pulp_smash import api, utils
+from pulp_smash.compat import urljoin
 from pulp_smash.constants import REPOSITORY_PATH, ERROR_KEYS
 from pulp_smash.selectors import bug_is_untestable, require
 

--- a/pulp_smash/tests/puppet/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/puppet/api_v2/test_sync_publish.py
@@ -35,14 +35,11 @@ Assertions not explored in this module include:
 from __future__ import unicode_literals
 
 from itertools import product
-try:  # try Python 3 first
-    from urllib.parse import urljoin
-except ImportError:
-    from urlparse import urljoin  # pylint:disable=C0411,E0401
 
 from packaging.version import Version
 
 from pulp_smash import api, selectors, utils
+from pulp_smash.compat import urljoin
 from pulp_smash.constants import (
     CALL_REPORT_KEYS,
     CONTENT_UPLOAD_PATH,

--- a/pulp_smash/tests/rpm/api_v2/test_broker.py
+++ b/pulp_smash/tests/rpm/api_v2/test_broker.py
@@ -26,14 +26,11 @@ Both scenarios are executed by
 from __future__ import unicode_literals
 
 import time
-try:  # try Python 3 import first
-    from urllib.parse import urljoin
-except ImportError:
-    from urlparse import urljoin  # pylint:disable=C0411,E0401
 
 import unittest2
 
 from pulp_smash import api, cli, config, selectors, utils
+from pulp_smash.compat import urljoin
 from pulp_smash.constants import (
     PULP_SERVICES,
     REPOSITORY_PATH,

--- a/pulp_smash/tests/rpm/api_v2/test_duplicate_uploads.py
+++ b/pulp_smash/tests/rpm/api_v2/test_duplicate_uploads.py
@@ -16,12 +16,8 @@ The second upload should silently fail for all Pulp releases in the 2.x series.
 """
 from __future__ import unicode_literals
 
-try:  # try Python 3 import first
-    from urllib.parse import urljoin
-except ImportError:
-    from urlparse import urljoin  # pylint:disable=C0411,E0401
-
 from pulp_smash import api, utils
+from pulp_smash.compat import urljoin
 from pulp_smash.constants import (
     CONTENT_UPLOAD_PATH,
     REPOSITORY_PATH,

--- a/pulp_smash/tests/rpm/api_v2/test_iso_crud.py
+++ b/pulp_smash/tests/rpm/api_v2/test_iso_crud.py
@@ -2,14 +2,10 @@
 """Test CRUD for ISO RPM repositories."""
 from __future__ import unicode_literals
 
-try:  # try Python 3 import first
-    from urllib.parse import urljoin
-except ImportError:
-    from urlparse import urljoin  # pylint:disable=C0411,E0401
-
 from packaging.version import Version
 
 from pulp_smash import api, selectors, utils
+from pulp_smash.compat import urljoin
 from pulp_smash.constants import REPOSITORY_PATH
 
 

--- a/pulp_smash/tests/rpm/api_v2/test_orphan_remove.py
+++ b/pulp_smash/tests/rpm/api_v2/test_orphan_remove.py
@@ -7,12 +7,8 @@ This module assumes that the tests in
 """
 from __future__ import unicode_literals
 
-try:
-    from urllib.parse import urljoin
-except ImportError:
-    from urlparse import urljoin  # pylint:disable=C0411,E0401
-
 from pulp_smash import api, utils
+from pulp_smash.compat import urljoin
 from pulp_smash.constants import ORPHANS_PATH, REPOSITORY_PATH, RPM_FEED_URL
 from pulp_smash.tests.rpm.api_v2.utils import gen_repo
 

--- a/pulp_smash/tests/rpm/api_v2/test_remove_unit.py
+++ b/pulp_smash/tests/rpm/api_v2/test_remove_unit.py
@@ -20,12 +20,9 @@ of repository created with valid feed and remove_missing option set.
 from __future__ import unicode_literals
 
 import random
-try:  # try Python 3 import first
-    from urllib.parse import urljoin
-except ImportError:
-    from urlparse import urljoin  # pylint:disable=C0411,E0401
 
 from pulp_smash import api, utils
+from pulp_smash.compat import urljoin
 from pulp_smash.constants import REPOSITORY_PATH, RPM_FEED_URL
 from pulp_smash.tests.rpm.api_v2.utils import gen_distributor, gen_repo
 

--- a/pulp_smash/tests/rpm/api_v2/test_retain_old_count.py
+++ b/pulp_smash/tests/rpm/api_v2/test_retain_old_count.py
@@ -16,12 +16,8 @@ repository created with valid feed and `retain_old_count`_ option set.
 """
 from __future__ import unicode_literals
 
-try:  # try Python 3 import first
-    from urllib.parse import urljoin
-except ImportError:
-    from urlparse import urljoin  # pylint:disable=C0411,E0401
-
 from pulp_smash import api, utils
+from pulp_smash.compat import urljoin
 from pulp_smash.constants import REPOSITORY_PATH, RPM_FEED_URL
 from pulp_smash.tests.rpm.api_v2.utils import gen_distributor, gen_repo
 

--- a/pulp_smash/tests/rpm/api_v2/test_schedule_sync.py
+++ b/pulp_smash/tests/rpm/api_v2/test_schedule_sync.py
@@ -10,14 +10,11 @@ This module assumes that the tests in
 from __future__ import unicode_literals
 
 import time
-try:  # try Python 3 import first
-    from urllib.parse import urljoin
-except ImportError:
-    from urlparse import urljoin  # pylint:disable=C0411,E0401
 
 from packaging.version import Version
 
 from pulp_smash import api, selectors, utils
+from pulp_smash.compat import urljoin
 from pulp_smash.constants import REPOSITORY_PATH, RPM_FEED_URL
 from pulp_smash.tests.rpm.api_v2.utils import gen_repo
 

--- a/pulp_smash/tests/rpm/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_sync_publish.py
@@ -33,15 +33,12 @@ from __future__ import unicode_literals
 
 import hashlib
 from itertools import product
-try:  # try Python 3 import first
-    from urllib.parse import urljoin
-except ImportError:
-    from urlparse import urljoin  # pylint:disable=C0411,E0401
 
 import unittest2
 from packaging.version import Version
 
 from pulp_smash import api, selectors, utils
+from pulp_smash.compat import urljoin
 from pulp_smash.constants import (
     CALL_REPORT_KEYS,
     CONTENT_UPLOAD_PATH,

--- a/pulp_smash/tests/rpm/api_v2/test_unassociate.py
+++ b/pulp_smash/tests/rpm/api_v2/test_unassociate.py
@@ -10,12 +10,8 @@ This module assumes that the tests in
 """
 from __future__ import unicode_literals
 
-try:  # try Python 3 import first
-    from urllib.parse import urljoin
-except ImportError:
-    from urlparse import urljoin  # pylint:disable=C0411,E0401
-
 from pulp_smash import api, utils
+from pulp_smash.compat import urljoin
 from pulp_smash.constants import REPOSITORY_PATH, RPM_FEED_URL
 from pulp_smash.tests.rpm.api_v2.utils import gen_repo
 

--- a/pulp_smash/utils.py
+++ b/pulp_smash/utils.py
@@ -11,7 +11,7 @@ import uuid
 import unittest2
 
 from pulp_smash import api, cli, config, exceptions
-from pulp_smash.constants import PULP_SERVICES
+from pulp_smash.constants import PLUGIN_TYPES_PATH, PULP_SERVICES
 
 
 def uuid4():
@@ -128,3 +128,21 @@ def reset_squid(server_config):
     client.run((prefix + 'squid -z').split())
 
     squid_service.start()
+
+
+def get_plugin_type_ids():
+    """Get the ID of each of Pulp's plugins.
+
+    Each Pulp plugin adds one (or more?) content unit type to Pulp. Each of
+    these content unit types is identified by a certain unique identifier. For
+    example, the `Python type`_ has an ID of ``python_package``.
+
+    :returns: A set of plugin IDs. For example: ``{'ostree',
+        'python_package'}``.
+
+    .. _Python type:
+       http://pulp-python.readthedocs.org/en/latest/reference/python-type.html
+    """
+    client = api.Client(config.get_config(), api.json_handler)
+    plugin_types = client.get(PLUGIN_TYPES_PATH)
+    return {plugin_type['id'] for plugin_type in plugin_types}


### PR DESCRIPTION
@Ichimonji10, I branched from https://github.com/PulpQE/pulp-smash/pull/164, I made 2 PR's to keep the comments separate, and I figured since you won't be clicking the merge button, it would be easier to do it this way. If I am wrong and this is a pain, let me know and I'll keep 1 commit to 1 PR.

This PR sets me up to fill in the OSTree tests a little more easily (https://github.com/PulpQE/pulp-smash/issues/61). I did this work as a setup to adding a test for https://pulp.plan.io/issues/1106. 

@Ichimonji10, please pay extra attention to the docstrings, I am pretty sure they aren't what you want :)