### PR TITLE
Permanently skip an RPM test under Pulp 2.7

### DIFF
--- a/pulp_smash/tests/rpm/api_v2/test_schedule_sync.py
+++ b/pulp_smash/tests/rpm/api_v2/test_schedule_sync.py
@@ -13,7 +13,7 @@ import time
 
 from packaging.version import Version
 
-from pulp_smash import api, selectors, utils
+from pulp_smash import api, utils
 from pulp_smash.compat import urljoin
 from pulp_smash.constants import REPOSITORY_PATH, RPM_FEED_URL
 from pulp_smash.tests.rpm.api_v2.utils import gen_repo
@@ -140,9 +140,8 @@ class CreateFailureTestCase(CreateRepoMixin, utils.BaseAPITestCase):
                 self.responses,
                 self.status_codes):
             if (body == ['Incorrect data type'] and
-                    self.cfg.version < Version('2.8') and
-                    selectors.bug_is_untestable(1745)):
-                continue
+                    self.cfg.version < Version('2.8')):
+                continue  # https://pulp.plan.io/issues/1745
             with self.subTest(body=body):
                 self.assertEqual(response.status_code, status_code)
 


### PR DESCRIPTION
According to Pulp issue 1745 [1]:

> If an incorrect JSON data type is provided when creating a sync
> schedule (say an array rather than an object), Pulp returns an HTTP
> 500 rather than HTTP 400. […] This issue affects Pulp 2.7, but not
> Pulp 2.8.

This issue is likely to be marked as WONTFIX. Permanently skip the
relevant assertion. Test suite results do not change. Test suite results
generated with:

    python -m unittest2 \
      pulp_smash.tests.rpm.api_v2.test_schedule_sync.CreateFailureTestCase

[1] https://pulp.plan.io/issues/1745