### PR TITLE
Respect target_platform_release bug tracker field

### DIFF
--- a/pulp_smash/exceptions.py
+++ b/pulp_smash/exceptions.py
@@ -11,6 +11,13 @@ class BugStatusUnknownError(Exception):
     """
 
 
+class BugTPRMissingError(Exception):
+    """We have encountered a bug with no "Target Platform Release" field.
+
+    See :mod:`pulp_smash.selectors` for more information.
+    """
+
+
 class CallReportError(Exception):
     """A call report contains an error.
 

--- a/pulp_smash/selectors.py
+++ b/pulp_smash/selectors.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 
 import warnings
+from collections import namedtuple
 from functools import wraps
 
 import requests
@@ -32,62 +33,122 @@ _TESTABLE_BUGS = frozenset((
     'CLOSED - WORKSFORME',
 ))
 
-# A mapping between bug IDs and bug statuses. Used by `_get_bug_status`.
+# A mapping between bug IDs and bug statuses. Used by `_get_bug`.
 #
 # Bug IDs and statuses should be integers and strings, respectively. Example:
 #
-#     _BUG_STATUS_CACHE[1356] → 'NEW'
+#     _BUG_STATUS_CACHE[1356] → _Bug(status='NEW', target_platform_release=…)
 #     _BUG_STATUS_CACHE['1356'] → KeyError
 #
 _BUG_STATUS_CACHE = {}
 
 
-def _get_bug_status(bug_id):
-    """Fetch information about bug ``bug_id`` from https://pulp.plan.io."""
-    # Declaring as global right before assignment triggers: `SyntaxWarning:
-    # name '_BUG_STATUS_CACHE' is used prior to global declaration`
-    global _BUG_STATUS_CACHE  # pylint:disable=global-variable-not-assigned
+# Information about a Pulp bug. (See: https://pulp.plan.io)
+#
+# The 'status' attribute is a string, such as 'NEW' or 'ASSIGNED'. The
+# 'target_platform_release' attribute is a Version() object.
+_Bug = namedtuple('_Bug', ('status', 'target_platform_release'))
 
+
+def _get_tpr(bug_json):
+    """Return a bug's Target Platform Release (TPR) field.
+
+    :param bug_json: A JSON representation of a Pulp bug. (For example, see:
+        https://pulp.plan.io/issues/1.json)
+    :returns: A ``packaging.version.Version`` object.
+    :raises pulp_smash.exceptions.BugTPRMissingError: If no "Target Platform
+        Release" field is found in ``bug_json``.
+    """
+    custom_field_id = 4
+    custom_fields = bug_json['issue']['custom_fields']
+    for custom_field in custom_fields:
+        if custom_field['id'] == custom_field_id:
+            return custom_field['value']
+    raise exceptions.BugTPRMissingError(
+        'Bug {} has no custom field with ID {} ("Target Platform Release"). '
+        'Custom fields: {}'
+        .format(bug_json['issue']['id'], custom_field_id, custom_fields)
+    )
+
+
+def _convert_tpr(version_string):
+    """Convert a Target Platform Release (TPR) string to a ``Version`` object.
+
+    By default, a bug's TPR string is an empty string. It is unlikely to be set
+    until a fix has been implemented, and even then, it is quite possible that
+    the field will be left as an empty string. (Perhaps the user forgot to set
+    it, or set it to the wrong value.)
+
+    If ``version_string == ''``, this method pretends that ``version_string ==
+    '0'``. Why is this useful? Let's imagine that a bug has a status of
+    MODIFIED and a TPR of "": we can now assume that this bug is fixed in all
+    versions of Pulp. More generally, any time a bug is marked as fixed and no
+    TPR listed, we assume that the bug is fixed for all versions of Pulp.
+
+    :param version_string: A version string like "2.8.1" or "".
+    :returns: A ``packaging.version.Version`` object.
+    :raises: ``packaging.version.InvalidVersion`` if ``version_string`` is
+        invalid and not "".
+    """
+    if version_string == '':
+        return Version('0')
+    return Version(version_string)
+
+
+def _get_bug(bug_id):
+    """Fetch information about bug ``bug_id`` from https://pulp.plan.io.
+
+    Return a ``_Bug`` instance.
+    """
     # It's rarely a good idea to do type checking in a duck-typed language.
     # However, efficiency dictates we do so here. Without this type check, the
     # following will cause us to talk to the bug tracker twice and store two
     # values in the cache:
     #
-    #     _get_bug_status(1356)
-    #     _get_bug_status('1356')
+    #     _get_bug(1356)
+    #     _get_bug('1356')
     #
     if not isinstance(bug_id, int):
         raise TypeError(
             'Bug IDs should be integers. The given ID, {} is a {}.'
             .format(bug_id, type(bug_id))
         )
+
+    # Let's return the bug from the cache if possible. ¶ We shouldn't need to
+    # declare a global until we want to assign to it, but waiting causes Python
+    # itself to emit a SyntaxWarning.
+    global _BUG_STATUS_CACHE  # pylint:disable=global-variable-not-assigned
     try:
         return _BUG_STATUS_CACHE[bug_id]
     except KeyError:
         pass
 
-    # Get, cache and return bug status.
+    # The bug is not cached. Let's fetch, cache and return it.
     response = requests.get(
         'https://pulp.plan.io/issues/{}.json'.format(bug_id)
     )
     response.raise_for_status()
-    _BUG_STATUS_CACHE[bug_id] = response.json()['issue']['status']['name']
+    bug_json = response.json()
+    _BUG_STATUS_CACHE[bug_id] = _Bug(
+        bug_json['issue']['status']['name'],
+        _convert_tpr(_get_tpr(bug_json)),
+    )
     return _BUG_STATUS_CACHE[bug_id]
 
 
-def bug_is_testable(bug_id):
+def bug_is_testable(bug_id, pulp_version):
     """Tell the caller whether bug ``bug_id`` should be tested.
 
     :param bug_id: An integer bug ID, taken from https://pulp.plan.io.
+    :param pulp_version: A ``packaging.version.Version`` object telling the
+        version of the Pulp server we are testing.
     :returns: ``True`` if the bug is testable, or ``False`` otherwise.
     :raises: ``TypeError`` if ``bug_id`` is not an integer.
     :raises pulp_smash.exceptions.BugStatusUnknownError: If the bug has a
         status Pulp Smash does not recognize.
-    :raises: BugTrackerUnavailableWarning: If the bug tracker cannot be
-        contacted.
     """
     try:
-        status = _get_bug_status(bug_id)
+        bug = _get_bug(bug_id)
     except requests.exceptions.ConnectionError as err:
         message = (
             'Cannot contact the bug tracker. Pulp Smash will assume that the '
@@ -96,22 +157,24 @@ def bug_is_testable(bug_id):
         warnings.warn(message, RuntimeWarning)
         return True
 
-    if status in _TESTABLE_BUGS:
-        return True
-    elif status in _UNTESTABLE_BUGS:
-        return False
-    else:
-        # Alternately, we could raise a warning and `return True`.
+    # bug.target_platform_release has already been verified by Version().
+    if bug.status not in _TESTABLE_BUGS | _UNTESTABLE_BUGS:
         raise exceptions.BugStatusUnknownError(
             'Bug {} has a status of {}. Pulp Smash only knows how to handle '
             'the following statuses: {}'
-            .format(bug_id, status, _TESTABLE_BUGS | _UNTESTABLE_BUGS)
+            .format(bug_id, bug.status, _TESTABLE_BUGS | _UNTESTABLE_BUGS)
         )
 
+    # Finally, we have good data!
+    if (bug.status in _TESTABLE_BUGS and
+            bug.target_platform_release <= pulp_version):
+        return True
+    return False
 
-def bug_is_untestable(bug_id):
+
+def bug_is_untestable(bug_id, pulp_version):
     """Return the inverse of :meth:`bug_is_testable`."""
-    return not bug_is_testable(bug_id)
+    return not bug_is_testable(bug_id, pulp_version)
 
 
 def require(version_string):

--- a/pulp_smash/tests/docker/cli/test_crud.py
+++ b/pulp_smash/tests/docker/cli/test_crud.py
@@ -127,7 +127,7 @@ class UpdateEnableV1TestCase(unittest2.TestCase):
 
         if cls.cfg.version < version.Version('2.8'):
             raise unittest2.SkipTest('These tests require Pulp 2.8 or above.')
-        if selectors.bug_is_untestable(1710):
+        if selectors.bug_is_untestable(1710, cls.cfg.version):
             raise unittest2.SkipTest('https://pulp.plan.io/issues/1710')
 
         docker_utils.login(cls.cfg)
@@ -181,7 +181,7 @@ class UpdateEnableV2TestCase(unittest2.TestCase):
 
         if cls.cfg.version < version.Version('2.8'):
             raise unittest2.SkipTest('These tests require Pulp 2.8 or above.')
-        if selectors.bug_is_untestable(1710):
+        if selectors.bug_is_untestable(1710, cls.cfg.version):
             raise unittest2.SkipTest('https://pulp.plan.io/issues/1710')
 
         docker_utils.login(cls.cfg)
@@ -235,7 +235,7 @@ class UpdateDistributorTestCase(unittest2.TestCase):
         cls.cfg = config.get_config()
         if cls.cfg.version < version.Version('2.8'):
             raise unittest2.SkipTest('These tests require Pulp 2.8 or above.')
-        if selectors.bug_is_untestable(1710):
+        if selectors.bug_is_untestable(1710, cls.cfg.version):
             raise unittest2.SkipTest('https://pulp.plan.io/issues/1710')
 
         docker_utils.login(cls.cfg)

--- a/pulp_smash/tests/docker/cli/test_sync_publish.py
+++ b/pulp_smash/tests/docker/cli/test_sync_publish.py
@@ -252,7 +252,7 @@ class InvalidFeedTestCase(_BaseTestCase):
 
     def test_return_code(self):
         """Assert the "sync" command has a non-zero return code."""
-        if selectors.bug_is_untestable(427):
+        if selectors.bug_is_untestable(427, self.cfg.version):
             self.skipTest('https://pulp.plan.io/issues/427')
         self.assertNotEqual(self.completed_proc.returncode, 0)
 

--- a/pulp_smash/tests/platform/api_v2/test_login.py
+++ b/pulp_smash/tests/platform/api_v2/test_login.py
@@ -6,19 +6,18 @@
 """
 from __future__ import unicode_literals
 
-from unittest2 import TestCase
-
-from pulp_smash import api, config, selectors
+from pulp_smash import api, selectors, utils
 from pulp_smash.constants import ERROR_KEYS, LOGIN_KEYS, LOGIN_PATH
 
 
-class LoginSuccessTestCase(TestCase):
+class LoginSuccessTestCase(utils.BaseAPITestCase):
     """Tests for successfully logging in."""
 
     @classmethod
     def setUpClass(cls):
         """Successfully log in to the server."""
-        cls.response = api.Client(config.get_config()).post(LOGIN_PATH)
+        super(LoginSuccessTestCase, cls).setUpClass()
+        cls.response = api.Client(cls.cfg).post(LOGIN_PATH)
 
     def test_status_code(self):
         """Assert that the response has an HTTP 200 status code."""
@@ -29,13 +28,14 @@ class LoginSuccessTestCase(TestCase):
         self.assertEqual(frozenset(self.response.json().keys()), LOGIN_KEYS)
 
 
-class LoginFailureTestCase(TestCase):
+class LoginFailureTestCase(utils.BaseAPITestCase):
     """Tests for unsuccessfully logging in."""
 
     @classmethod
     def setUpClass(cls):
         """Unsuccessfully log in to the server."""
-        client = api.Client(config.get_config(), api.echo_handler)
+        super(LoginFailureTestCase, cls).setUpClass()
+        client = api.Client(cls.cfg, api.echo_handler)
         cls.response = client.post(LOGIN_PATH, auth=('', ''))
 
     def test_status_code(self):
@@ -44,6 +44,6 @@ class LoginFailureTestCase(TestCase):
 
     def test_body(self):
         """Assert that the response is valid JSON and has correct keys."""
-        if selectors.bug_is_untestable(1412):
+        if selectors.bug_is_untestable(1412, self.cfg.version):
             self.skipTest('https://pulp.plan.io/issues/1412')
         self.assertEqual(frozenset(self.response.json().keys()), ERROR_KEYS)

--- a/pulp_smash/tests/platform/api_v2/test_repository.py
+++ b/pulp_smash/tests/platform/api_v2/test_repository.py
@@ -131,7 +131,7 @@ class CreateFailureTestCase(utils.BaseAPITestCase):
         """Assert the JSON body returned contains the correct keys."""
         for body, response in zip(self.bodies, self.responses):
             with self.subTest(body=body):
-                if bug_is_untestable(1413):  # fails for all bodies
+                if bug_is_untestable(1413, self.cfg.version):
                     self.skipTest('https://pulp.plan.io/issues/1413')
                 response_keys = frozenset(response.json().keys())
                 self.assertEqual(response_keys, ERROR_KEYS)

--- a/pulp_smash/tests/puppet/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/puppet/api_v2/test_sync_publish.py
@@ -344,8 +344,7 @@ class PublishTestCase(utils.BaseAPITestCase):
         cls.responses['puppet releases'] = []
         author_name = _PUPPET_MODULE['author'] + '/' + _PUPPET_MODULE['name']
         for repo in repos:
-            if (cls.cfg.version >= Version('2.8') and
-                    selectors.bug_is_untestable(1440)):
+            if selectors.bug_is_untestable(1440, cls.cfg.version):
                 continue
             cls.responses['puppet releases'].append(client.get(
                 '/api/v1/releases.json',

--- a/pulp_smash/tests/rpm/api_v2/test_broker.py
+++ b/pulp_smash/tests/rpm/api_v2/test_broker.py
@@ -93,7 +93,7 @@ class BrokerTestCase(unittest2.TestCase):
         3. Test Pulp's health. Create an RPM repository, sync it, add a
            distributor, publish it, and download an RPM.
         """
-        if selectors.bug_is_untestable(1635):
+        if selectors.bug_is_untestable(1635, self.cfg.version):
             self.skipTest('https://pulp.plan.io/issues/1635')
         # We assume that the broker and other services are already running. As
         # a result, we skip step 1 and go straight to step 2.

--- a/pulp_smash/tests/rpm/api_v2/test_iso_crud.py
+++ b/pulp_smash/tests/rpm/api_v2/test_iso_crud.py
@@ -179,7 +179,7 @@ class ReadUpdateDeleteTestCase(utils.BaseAPITestCase):
     def test_read_distributors(self):
         """Assert each read w/distributors contains info about distributors."""
         if (self.cfg.version < Version('2.8') and
-                selectors.bug_is_untestable(1452)):
+                selectors.bug_is_untestable(1452, self.cfg.version)):
             self.skipTest('https://pulp.plan.io/issues/1452')
         for key in {'read_distributors', 'read_details'}:
             with self.subTest(key=key):

--- a/pulp_smash/tests/rpm/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_sync_publish.py
@@ -131,8 +131,7 @@ class SyncValidFeedTestCase(utils.BaseAPITestCase):
 
     def test_task_error_traceback(self):
         """Assert each task's "error" and "traceback" fields are null."""
-        if (self.cfg.version >= Version('2.8') and
-                selectors.bug_is_untestable(1455)):
+        if selectors.bug_is_untestable(1455, self.cfg.version):
             self.skipTest('https://pulp.plan.io/issues/1455')
         for i, task in enumerate(self.tasks):
             for key in {'error', 'traceback'}:
@@ -155,8 +154,7 @@ class SyncValidFeedTestCase(utils.BaseAPITestCase):
         Compare these attributes to metadata from the remote repository.
         Expected values are currently hard-coded into this test.
         """
-        if (self.cfg.version >= Version('2.8') and
-                selectors.bug_is_untestable(1455)):
+        if selectors.bug_is_untestable(1455, self.cfg.version):
             self.skipTest('https://pulp.plan.io/issues/1455')
         counts = self.repo.get('content_unit_counts', {})
         for unit_type, count in {
@@ -165,8 +163,8 @@ class SyncValidFeedTestCase(utils.BaseAPITestCase):
                 'package_group': 2,
                 'package_category': 1,
         }.items():
-            if (unit_type == 'rpm' and self.cfg.version >= Version('2.8') and
-                    selectors.bug_is_untestable(1570)):
+            if (unit_type == 'rpm' and
+                    selectors.bug_is_untestable(1570, self.cfg.version)):
                 continue
             with self.subTest(unit_type=unit_type):
                 self.assertEqual(counts.get(unit_type), count)
@@ -199,8 +197,7 @@ class SyncInvalidFeedTestCase(utils.BaseAPITestCase):
 
     def test_task_error_traceback(self):
         """Assert each task's "error" and "traceback" fields are non-null."""
-        if (self.cfg.version >= Version('2.8') and
-                selectors.bug_is_untestable(1455)):
+        if selectors.bug_is_untestable(1455, self.cfg.version):
             self.skipTest('https://pulp.plan.io/issues/1455')
         for i, task in enumerate(self.tasks):
             for key in {'error', 'traceback'}:
@@ -597,7 +594,7 @@ class RedundantPublishSameMetadataTestCase(utils.BaseAPITestCase):
         3. Publish the repo a second time, without any changes
         """
         super(RedundantPublishSameMetadataTestCase, cls).setUpClass()
-        if selectors.bug_is_untestable(1724):
+        if selectors.bug_is_untestable(1724, cls.cfg.version):
             raise unittest2.SkipTest('https://pulp.plan.io/issues/1724')
 
         client = api.Client(cls.cfg, api.json_handler)
@@ -632,7 +629,7 @@ class RedundantPublishSameMetadataTestCase(utils.BaseAPITestCase):
 
     def test_compare_repomd(self):
         """Assert identical metadata on redundant publish."""
-        if selectors.bug_is_untestable(1724):
+        if selectors.bug_is_untestable(1724, self.cfg.version):
             self.skipTest('https://pulp.plan.io/issues/1724')
         self.assertEqual(
             self.publish_repomd_data[0].content,

--- a/pulp_smash/tests/rpm/api_v2/test_updateinfo.py
+++ b/pulp_smash/tests/rpm/api_v2/test_updateinfo.py
@@ -240,7 +240,7 @@ class UpdateInfoTestCase(utils.BaseAPITestCase):
         This test may be skipped if `Pulp #1782
         <https://pulp.plan.io/issues/1782>`_ is open.
         """
-        if selectors.bug_is_untestable(1782):
+        if selectors.bug_is_untestable(1782, self.cfg.version):
             self.skipTest('https://pulp.plan.io/issues/1782')
         erratum_id = self.errata['import_typical']['id']
         update_element = _get_updates_by_id(self.root_element)[erratum_id]

--- a/tests/test_selectors.py
+++ b/tests/test_selectors.py
@@ -7,55 +7,108 @@ import random
 import mock
 import requests
 import unittest2
+from packaging.version import InvalidVersion, Version
 
-from pulp_smash import exceptions, selectors
+from pulp_smash import exceptions, selectors, utils
+
+# It makes sense for unit tests to access otherwise private data.
+# pylint:disable=protected-access
+
+
+class GetTPRTestCase(unittest2.TestCase):
+    """Test method ``_get_tpr``."""
+
+    def test_success(self):
+        """Assert the method returns the target platform release if present."""
+        version_str = utils.uuid4()
+        bug_json = {'issue': {'custom_fields': [
+            {'id': 1, 'value': 'foo'},
+            {'id': 4, 'value': version_str},
+            {'id': 9, 'value': 'bar'},
+        ]}}
+        random.shuffle(bug_json['issue']['custom_fields'])
+        self.assertEqual(selectors._get_tpr(bug_json), version_str)
+
+    def test_failure(self):
+        """Assert the method raises the correct exception no TPR is present."""
+        bug_json = {'issue': {
+            'custom_fields': [
+                {'id': 1, 'value': 'foo'},
+                {'id': 3, 'value': 'bar'},
+                {'id': 9, 'value': 'biz'},
+            ],
+            'id': 1234,
+        }}
+        with self.assertRaises(exceptions.BugTPRMissingError):
+            selectors._get_tpr(bug_json)
+
+
+class ConvertTPRTestCase(unittest2.TestCase):
+    """Test method ``_convert_tpr``."""
+
+    def test_valid_version_string(self):
+        """Assert ``version_string`` is converted if it is valid."""
+        for version_str in ('0', '0.1', '0.1.2', '0.1.2.3', '1!0'):
+            with self.subTest(version_str=version_str):
+                version = Version(version_str)
+                self.assertEqual(selectors._convert_tpr(version_str), version)
+
+    def test_empty_version_string(self):
+        """Assert ``version_string`` is converted if it is an empty string."""
+        self.assertEqual(selectors._convert_tpr(''), Version('0'))
+
+    def test_invalid_version_string(self):
+        """Assert an exception is raised if ``version_string`` is invalid."""
+        with self.assertRaises(InvalidVersion):
+            selectors._convert_tpr('foo')
+
+
+class GetBugTestCase(unittest2.TestCase):
+    """Test method ``_get_bug``."""
+
+    def test_invalid_bug_id(self):
+        """Assert an exception is raised if ``bug_id`` isn't an integer."""
+        with self.assertRaises(TypeError):
+            selectors._get_bug('1')
 
 
 class BugIsTestableTestCase(unittest2.TestCase):
     """Test :meth:`pulp_smash.selectors.bug_is_testable` and its partner."""
 
     def test_testable_status(self):
-        """Make the dependent function return a "testable" bug status."""
-        with mock.patch.object(
-            selectors,
-            '_get_bug_status',
-            # pylint:disable=protected-access
-            return_value=random.sample(selectors._TESTABLE_BUGS, 1)[0]
-        ):
-            with self.subTest():
-                self.assertTrue(selectors.bug_is_testable(None))
-            with self.subTest():
-                self.assertFalse(selectors.bug_is_untestable(None))
+        """Assert the method correctly handles "testable" bug statuses."""
+        ver = Version('0')
+        for bug_status in selectors._TESTABLE_BUGS:
+            bug = selectors._Bug(bug_status, ver)
+            with mock.patch.object(selectors, '_get_bug', return_value=bug):
+                with self.subTest(bug_status=bug_status):
+                    self.assertTrue(selectors.bug_is_testable(None, ver))
+                    self.assertFalse(selectors.bug_is_untestable(None, ver))
 
     def test_untestable_status(self):
-        """Make the dependent function return a "untestable" bug status."""
-        with mock.patch.object(
-            selectors,
-            '_get_bug_status',
-            # pylint:disable=protected-access
-            return_value=random.sample(selectors._UNTESTABLE_BUGS, 1)[0]
-        ):
-            with self.subTest():
-                self.assertFalse(selectors.bug_is_testable(None))
-            with self.subTest():
-                self.assertTrue(selectors.bug_is_untestable(None))
+        """Assert the method correctly handles "untestable" bug statuses."""
+        ver = Version('0')
+        for bug_status in selectors._UNTESTABLE_BUGS:
+            bug = selectors._Bug(bug_status, ver)
+            with mock.patch.object(selectors, '_get_bug', return_value=bug):
+                with self.subTest(bug_status=bug_status):
+                    self.assertFalse(selectors.bug_is_testable(None, ver))
+                    self.assertTrue(selectors.bug_is_untestable(None, ver))
 
     def test_unknown_status(self):
-        """Make the dependent function return an unknown bug status."""
-        with mock.patch.object(
-            selectors,
-            '_get_bug_status',
-            return_value=None,
-        ):
+        """Assert the method correctly handles an unknown bug status."""
+        ver = Version('0')
+        bug = selectors._Bug('foo', ver)
+        with mock.patch.object(selectors, '_get_bug', return_value=bug):
             with self.assertRaises(exceptions.BugStatusUnknownError):
-                selectors.bug_is_testable(None)
+                selectors.bug_is_testable(None, ver)
 
     def test_connection_error(self):
         """Make the dependent function raise a connection error."""
-        with mock.patch.object(
-            selectors,
-            '_get_bug_status',
-            side_effect=requests.exceptions.ConnectionError
-        ):
+        ver = Version('0')
+        with mock.patch.object(selectors, '_get_bug') as get_bug:
+            get_bug.side_effect = requests.exceptions.ConnectionError
             with self.assertWarns(RuntimeWarning):
-                self.assertTrue(selectors.bug_is_testable(None))
+                selectors.bug_is_testable(None, ver)
+            with self.assertWarns(RuntimeWarning):
+                selectors.bug_is_untestable(None, ver)


### PR DESCRIPTION
Change the signatures of `bug_is_testable` and `bug_is_untestable` in module `pulp_smash.selectors`, from this:

```python
bug_is_testable(bug_id)
bug_is_untestable(bug_id)
```

To this:

```python
bug_is_testable(bug_id, pulp_version)
bug_is_untestable(bug_id, pulp_version)
```

The new `pulp_version` parameter is "A ``packaging.version.Version`` object telling the version of the Pulp server we are testing." It lets the function determine whether a bug is testable or not based not only on the state of a bug, but the Pulp version in which the bug was fixed relative to the Pulp version we're testing against. Sample usage:

```python
>>> from packaging.version import Version
>>> from pulp_smash.selectors import bug_is_testable
>>> bug_is_testable(1743, Version('2.7.0'))
False
>>> bug_is_testable(1743, Version('2.7.99999'))
False
>>> bug_is_testable(1743, Version('2.8'))
True
>>> bug_is_testable(1743, Version('2.8.0'))
True
>>> bug_is_testable(1743, Version('2.8.0.0'))
True
>>> bug_is_testable(1743, Version('2.8.1'))
True
>>> bug_is_testable(1743, Version('3'))
True
```

If a bug's "Target Platform Release" field is unset, the field is effectively ignored. [1] For example:

```python
>>> from packaging.version import Version
>>> from pulp_smash.selectors import bug_is_testable
>>> bug_is_testable(1744, Version('2'))
True
>>> bug_is_testable(1744, Version('3'))
True
```

Test suite results do not change as a result of this commit. Results generated with:

```sh
python -m unittest2 discover pulp_smash.tests
```

Fix #173.

[1] More precisely, we assume that the bug has been fixed in Pulp version 0.