### PR TITLE
Rewrite "Installation" documentation section

### DIFF
--- a/docs/about.rst
+++ b/docs/about.rst
@@ -54,14 +54,9 @@ Contributing
 Contributions are encouraged. The easiest way to contribute is to submit a pull
 request on GitHub, but patches are welcome no matter how they arrive.
 
-You can create a development environment and verify its sanity like so::
-
-    virtualenv env  # or `python -m virtualenv env` is using Python >= 3.3
-    source env/bin/activate
-    git clone https://github.com/PulpQE/pulp-smash.git
-    cd pulp-smash
-    pip install -r requirements.txt -r requirements-dev.txt
-    make all
+A strategy for creating a development environment is listed in
+:doc:`/installation`. To verify the sanity of your development environment,
+``cd`` into the Pulp Smash source code directory and execute ``make all``.
 
 Please adhere to the following guidelines:
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -3,79 +3,39 @@ Installation
 
 Location: :doc:`/index` → :doc:`/installation`
 
-There are several ways to install Pulp Smash.
+Installing Pulp Smash into a virtual environment [1]_ is recommended. To create
+and activate a virtual environment::
 
-.. contents::
-    :local:
+    pyvenv env  # or `virtualenv env` if using Python 2
+    source env/bin/activate  # run `deactivate` to exit environment
 
-From Source
------------
+To install Pulp Smash from `PyPi`_::
 
-This is the most universal installation procedure, but it is also the most
-kludgy. You must install updates yourself, and you may need to deal with
-dependency hell. To install from source:
+    pip install pulp-smash  # prepend `python -m` on Python 3.3
 
-1. Download a copy of the Pulp Smash source code. There are several ways to get
-   the source code:
+To install Pulp Smash from source (`GitHub`_)::
 
-   * Visit the `Pulp Smash GitHub page`_ and click on the "Download ZIP" button.
-     Extract the archive.
-   * Execute ``git clone https://github.com/PulpQE/pulp-smash.git``.
+    git clone https://github.com/PulpQE/pulp-smash.git
+    cd pulp-smash
+    python setup.py install
 
-2. Execute ``python setup.py install``.
+To install Pulp Smash from source in "develop mode," where changes to source
+files are reflected in the working environment::
 
-Pulp Smash's dependencies are listed in ``setup.py``. Look for the
-``install_requires`` section.
+    git clone https://github.com/PulpQE/pulp-smash.git
+    cd pulp-smash
+    pip install -r requirements.txt -r requirements-dev.txt
 
-Pip
----
+For an explanation of key concepts and more installation strategies, see
+`Installing Python Modules`_.
 
-If you use Pip, you will be lifted out of dependency hell. However, updating is
-left to you, and installing Pip may be a challenge depending on your platform.
-If Pip is already available, installing Pulp Smash is as simple as::
+.. [1] See `Virtual Environments and Packages`_ for an explanation of virtual
+    environments. If using Python 2, see `Virtualenv`_ instead. The ``pyvenv``
+    and ``virtualenv`` tools are similar, but the former ships with Python as of
+    Python 3.3, whereas the latter is a third party tool.
 
-    pip install pulp-smash
-
-Or::
-
-    pip install git+https://github.com/PulpQE/pulp-smash.git#egg=pulp-smash
-
-The former will install the current stable version from PyPi, and the latter
-will install the current development version directly from source. There are
-many more use cases for Pip, and they are covered in the Python Packaging User
-Guide section entitled `Installing Packages`_.
-
-Other
------
-
-The installation strategies listed above assume that you'd like to install Pulp
-Smash system-wide. However, it's possible to install in a more targeted manner.
-For example, you can install a package only for the current user::
-
-    wget https://github.com/PulpQE/pulp-smash/archive/master.zip
-    unzip master.zip
-    cd pulp-smash-master
-    python setup.py install --user --record files.txt
-
-This records the installed files in ``files.txt``. You can uninstall the package
-by manually removing the files.
-
-A second option is to create a `virtualenv`_::
-
-    python -m virtualenv env
-    source env/bin/activate
-    pip install git+https://github.com/PulpQE/pulp-smash.git#egg=pulp-smash
-
-If you are using a version of Python older than 3.4, you must install virtualenv
-separately. In that case, the first command changes to ``virtualenv env``.
-
-If you *do* want to install system-wide, then all of the strategies listed above
-are non-optimal, as you will not receive automatic updates. A better solution is
-to install a package using your system package manager. (yum, apt-get, pacman,
-emerge, etc) At present, no packages are known to exist. If you create a
-package, please get in touch (#pulp on `freenode`_)!
-
-.. _Installing Packages: https://packaging.python.org/en/latest/installing/
-.. _Pulp Smash GitHub page: https://github.com/PulpQE/pulp-smash
-.. _freenode: https://freenode.net/
-.. _virtualenv: http://virtualenv.readthedocs.org/en/latest/
+.. _GitHub: https://github.com/PulpQE/pulp-smash
+.. _Installing Python Modules: https://docs.python.org/3/installing/
+.. _PyPi: https://pypi.python.org/pypi/pulp-smash
+.. _Virtual Environments and Packages: https://docs.python.org/3/tutorial/venv.html
+.. _Virtualenv: http://virtualenv.readthedocs.org/en/latest/


### PR DESCRIPTION
Do not attempt to lay out a comprehensive set of installation strategies with wordy explanations. Instead, list a recipe for creating a virtualenv, followed by three strategies for installing Pulp Smash, followed by a link to the official Python documentation.

Drop a redundant set of instructions in the "About" page, and reference the recipes in the "Installation" page instead.

This change is made on the theory that those people who need instructions for installing a Python package will benefit from a concise recipe-oriented approach, and those people who are interested in more in-depth explanations of Python packaging are (should be!) looking elsewhere.