### PR TITLE
Document best practices for collaboration

### DIFF
--- a/docs/about.rst
+++ b/docs/about.rst
@@ -24,8 +24,10 @@ Pulp Smash should be usable in any environment that supports:
 * one of the Python versions listed in ``.travis.yml``,
 * the dependencies listed in ``setup.py``,
 * a \*nix-like shell,
-* `GNU Make`_ (or a compatible clone),
-* and the `XDG Base Directory Specification`_.
+* the `XDG Base Directory Specification`_,
+* and `OpenSSH`_ or a compatible clone.
+
+In addition, we recommend that `GNU Make`_ or a compatible clone be available.
 
 This level of portability [1]_ allows Pulp Smash to be accessible [2]_.
 
@@ -60,19 +62,42 @@ A strategy for creating a development environment is listed in
 
 Please adhere to the following guidelines:
 
-* Pull requests should pass continuous integration steps. You can verify your
-  change(s) locally by executing ``make all``.
-* If adding a new test for Pulp, please run the test and communicate the
-  results in the commit message or as a pull request comment.
-* Adhere to typical commit guidelines:
+* Pull requests must pass the `Travis CI`_ continuous integration tests. These
+  tests are automatically run whenever a pull request is submitted. If you want
+  to locally verify your changes before submitting a pull request, execute
+  ``make all``.
+* Test failures must not be introduced. Consider running all new and modified
+  tests and copy-pasting the output from the test run as a comment in the GitHub
+  pull request. The simplest way to run the test suite is with ``python -m
+  unittest2 pulp_smash.tests``. See the unittest `Command-Line Interface`_ and
+  ``python -m pulp_smash`` for more information.
+* Each commit in a pull request must be atomic and address a single issue. Try
+  asking yourself: "can I revert this commit?" Knowing how to `rewrite history`_
+  may help. In addition, please take the time to write a `good
+  <http://stopwritingramblingcommitmessages.com/>`_ `commit
+  <https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message>`_
+  `message <http://chris.beams.io/posts/git-commit/>`_. While not *strictly*
+  necessary, consider: commits are (nearly) immutable, and getting commit
+  messages right makes for a more pleasant review process, better release notes,
+  and easier use of tools like ``git log``, ``git blame`` or ``git bisect``.
+* The pull request must not raise any other outstanding concerns. For example,
+  do not author a commit that adds a 10MB binary blob without exceedingly good
+  reason. As another example, do not add a test that makes dozens of concurrent
+  requests to a public service such as docker hub.
 
-    * Commits should be small and coherent. One commit should address one issue.
-      Ask yourself: "can I revert this commit?"
-    * Commits should have `good commit messages`_.
-    * `Rebasing`_ is encouraged. Rebasing produces a much nicer commit history
-      than merging.
+Your changes will eventually be reviewed and merged if they meet these
+requirements. Join the #pulp IRC channel on `freenode`_ if you have further
+questions.
 
-* When in doubt, ask on IRC. Join the #pulp channel on `freenode`_.
+Though commits are accepted as-is, they are frequently accompanied by a
+follow-up commit in which the reviewer makes a variety of changes, ranging from
+simple typo corrections and formatting adjustments to whole-sale restructuring
+of tests. This can take quite a bit of effort and time. If you'd like to make
+the review process faster and have more assurance your changes are being
+accepted with little to no modifications, take the time to really make your
+changes shine: ensure your code is DRY, matches existing formatting conventions,
+is organized into easy-to-read blocks, has isolated unit test assertions, and so
+on.
 
 .. [1] Portable software cannot make assumptions about its environment. It
     cannot reference ``/etc/pki/tls/certs/ca-bundle.crt``  or call ``yum``.
@@ -86,8 +111,11 @@ Please adhere to the following guidelines:
 .. [3] The "pets vs cattle" analogy is widely attributed to Bill Baker of
     Microsoft.
 
+.. _Command-Line Interface: https://docs.python.org/3/library/unittest.html#command-line-interface
 .. _GNU Make: https://www.gnu.org/software/make/
-.. _Rebasing: http://www.git-scm.com/book/en/v2/Git-Branching-Rebasing
+.. _OpenSSH: http://www.openssh.com/
+.. _Travis CI: https://travis-ci.org/PulpQE/pulp-smash
 .. _XDG Base Directory Specification: http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
 .. _freenode: https://freenode.net/
 .. _good commit messages: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
+.. _rewrite history: https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History


### PR DESCRIPTION
Fix #131.

Rewrite `docs/about.rst`, with a focus on the "Contributing" section.