### PR TITLE
Add function pulp_smash.utils.is_root

### DIFF
--- a/pulp_smash/tests/rpm/api_v2/test_download.py
+++ b/pulp_smash/tests/rpm/api_v2/test_download.py
@@ -20,13 +20,6 @@ from pulp_smash.constants import REPOSITORY_PATH, RPM_ABS_PATH, RPM_FEED_URL
 from pulp_smash.tests.rpm.api_v2.utils import gen_distributor, gen_repo
 
 
-def _is_root(server_config):
-    """Tell if we are root on the target Pulp system."""
-    if cli.Client(server_config).run(('id', '-u')).stdout.strip() == '0':
-        return True
-    return False
-
-
 class SyncDownloadTestCase(utils.BaseAPITestCase):
     """Assert the RPM plugin supports on-demand syncing of yum repositories.
 
@@ -84,7 +77,7 @@ class SyncDownloadTestCase(utils.BaseAPITestCase):
 
         # Corrupt an RPM. The file is there, but the checksum isn't right.
         cli_client = cli.Client(cls.cfg)
-        sudo = '' if _is_root(cls.cfg) else 'sudo '
+        sudo = '' if utils.is_root(cls.cfg) else 'sudo '
         checksum_cmd = (sudo + 'sha256sum ' + RPM_ABS_PATH).split()
         cls.pre_corruption_sha = cli_client.run(checksum_cmd).stdout.strip()
         cli_client.run((sudo + 'rm ' + RPM_ABS_PATH).split())

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -97,3 +97,19 @@ class BaseAPITestCase(unittest2.TestCase):
             client.return_value.delete.call_count,
             len(self.child.resources) + 1,
         )
+
+
+class IsRootTestCase(unittest2.TestCase):
+    """Test :func:`pulp_smash.utils.is_root`."""
+
+    def test_true(self):
+        """Assert the method returns ``True`` when root."""
+        with mock.patch.object(cli, 'Client') as clien:
+            clien.return_value.run.return_value.stdout.strip.return_value = '0'
+            self.assertTrue(utils.is_root(None))
+
+    def test_false(self):
+        """Assert the method returns ``False`` when non-root."""
+        with mock.patch.object(cli, 'Client') as clien:
+            clien.return_value.run.return_value.stdout.strip.return_value = '1'
+            self.assertFalse(utils.is_root(None))


### PR DESCRIPTION
When called, this new function will "tell if we are root on the target
system." Test suite results don't change as a result of this commit.
Test results generated with:

    python -m unittest2 discover pulp_smash.tests