### PR TITLE
Increase task polling timeout

### DIFF
--- a/pulp_smash/api.py
+++ b/pulp_smash/api.py
@@ -327,7 +327,7 @@ def poll_task(server_config, href):
     :raises pulp_smash.exceptions.TaskTimedOutError: If a task takes too
         long to complete.
     """
-    poll_limit = 24  # 24 * 5s == 120s
+    poll_limit = 36  # 36 * 5s == 180s
     poll_counter = 0
     while True:
         response = requests.get(


### PR DESCRIPTION
When Pulp Smash receives an HTTP 202 "accepted" response from Pulp, it
polls each of the spawned tasks and waits for them to complete. (This is
the default behaviour.) Pulp Smash gives each individual task roughly
two minutes to complete before timing out and raising a
`TaskTimedOutError`. Timing out in this manner has value: we don't want
to let a single misbehaved task to block the test suite from executing,
and if a single task takes excessively long, this can be considered a
bug in its own right.

Unfortunately, real world test results show that a wide variety of tasks
occasionally take longer than two minutes. The failures occur at a low
rate, but are widely spread through the test suite. In one especially
bad test run, five of roughly eighty test cases failed.

There are at least two ways to deal with time-outs. One is to expand the
`poll_task` and `poll_spawned_tasks` methods, and make it possible to
specify a time-out when calling the method. For example:

    poll_spawned_tasks(server_config, call_report, timeout)

This is a good solution if we have a task or series of tasks that we
know will be especially long running. For example, if we ask Pulp to
calculate content applicability for ten hosts, we will want to extend
the timeout for that one series of tasks.

Another solution is to extend the default time-out for all task polling.
This latter solution has risks, as can be gleaned from the first
paragraph of this commit message. However, it is more appropriate if the
default time-out is too short in a wide variety of cases.

Extend the default timeout from two to three minutes.