### PR TITLE
Skip tests for which a plugin is not installed

### DIFF
--- a/pulp_smash/tests/docker/api_v2/test_crud.py
+++ b/pulp_smash/tests/docker/api_v2/test_crud.py
@@ -15,6 +15,11 @@ from pulp_smash.compat import urljoin
 from pulp_smash.constants import REPOSITORY_PATH
 
 
+def setUpModule():  # pylint:disable=invalid-name
+    """Skip tests if the Docker plugin is not installed."""
+    utils.skip_if_type_is_unsupported('docker_image')
+
+
 def _gen_docker_repo_body():
     """Generate a Docker repo create body.
 

--- a/pulp_smash/tests/docker/cli/test_copy.py
+++ b/pulp_smash/tests/docker/cli/test_copy.py
@@ -18,6 +18,11 @@ _UNIT_ID_RE = r'(?:Unit Id:)\s*(.*)'
 _UPSTREAM_NAME = 'library/busybox'
 
 
+def setUpModule():  # pylint:disable=invalid-name
+    """Skip tests if the Docker plugin is not installed."""
+    utils.skip_if_type_is_unsupported('docker_image')
+
+
 def _get_unit_ids(server_config, repo_id, unit_type, regex):
     """Search for content units in a docker repository and return their IDs.
 

--- a/pulp_smash/tests/docker/cli/test_crud.py
+++ b/pulp_smash/tests/docker/cli/test_crud.py
@@ -17,6 +17,11 @@ _FEED = 'https://example.com'
 _UPSTREAM_NAME = 'foo/bar'
 
 
+def setUpModule():  # pylint:disable=invalid-name
+    """Skip tests if the Docker plugin is not installed."""
+    utils.skip_if_type_is_unsupported('docker_image')
+
+
 class CreateTestCase(unittest2.TestCase):
     """Create docker repositories, both successfully and unsuccessfully."""
 

--- a/pulp_smash/tests/docker/cli/test_sync_publish.py
+++ b/pulp_smash/tests/docker/cli/test_sync_publish.py
@@ -16,6 +16,11 @@ _BYTE_UNICODE = (type(b''), type(u''))
 _UPSTREAM_NAME = 'library/busybox'
 
 
+def setUpModule():  # pylint:disable=invalid-name
+    """Skip tests if the Docker plugin is not installed."""
+    utils.skip_if_type_is_unsupported('docker_image')
+
+
 class _BaseTestCase(unittest2.TestCase):
 
     @classmethod

--- a/pulp_smash/tests/ostree/api_v2/test_crud.py
+++ b/pulp_smash/tests/ostree/api_v2/test_crud.py
@@ -21,12 +21,12 @@ from __future__ import unicode_literals
 from pulp_smash import api, selectors, utils
 from pulp_smash.compat import urljoin
 from pulp_smash.constants import REPOSITORY_PATH
-from pulp_smash.tests.ostree.utils import gen_repo, skip_if_no_plugin
+from pulp_smash.tests.ostree.utils import gen_repo
 
 
 def setUpModule():  # pylint:disable=invalid-name
     """Skip tests if the OSTree plugin is not installed."""
-    skip_if_no_plugin()
+    utils.skip_if_type_is_unsupported('ostree')
 
 
 def _gen_distributor(relative_path):

--- a/pulp_smash/tests/ostree/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/ostree/api_v2/test_sync_publish.py
@@ -26,11 +26,7 @@ from __future__ import unicode_literals
 from pulp_smash import api, utils
 from pulp_smash.compat import urljoin
 from pulp_smash.constants import REPOSITORY_PATH
-from pulp_smash.tests.ostree.utils import (
-    create_sync_repo,
-    gen_repo,
-    skip_if_no_plugin,
-)
+from pulp_smash.tests.ostree.utils import create_sync_repo, gen_repo
 
 _FEED = 'https://repos.fedorapeople.org/pulp/pulp/demo_repos/test-ostree-small'
 _BRANCHES = (
@@ -41,7 +37,7 @@ _BRANCHES = (
 
 def setUpModule():  # pylint:disable=invalid-name
     """Skip tests if the OSTree plugin is not installed."""
-    skip_if_no_plugin()
+    utils.skip_if_type_is_unsupported('ostree')
 
 
 def _sync_repo(server_config, href):

--- a/pulp_smash/tests/ostree/utils.py
+++ b/pulp_smash/tests/ostree/utils.py
@@ -2,22 +2,9 @@
 """Utilities for interacting with OS tree."""
 from __future__ import unicode_literals
 
-import unittest2
-
 from pulp_smash import api, utils
 from pulp_smash.compat import urljoin
 from pulp_smash.constants import REPOSITORY_PATH
-
-
-def skip_if_no_plugin():
-    """Skip tests if the OSTree plugin is not installed.
-
-    :raises: ``unittest2.SkipTest`` if the OSTree plugin is not installed on
-        the default Pulp server.
-    :returns: Nothing.
-    """
-    if 'ostree' not in utils.get_plugin_type_ids():
-        raise unittest2.SkipTest('These tests require the OSTree plugin.')
 
 
 def gen_repo():

--- a/pulp_smash/tests/puppet/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/puppet/api_v2/test_sync_publish.py
@@ -63,6 +63,11 @@ _PUPPET_MODULE_URL = (
 _PUPPET_QUERY = _PUPPET_MODULE['author'] + '-' + _PUPPET_MODULE['name']
 
 
+def setUpModule():  # pylint:disable=invalid-name
+    """Skip tests if the Puppet plugin is not installed."""
+    utils.skip_if_type_is_unsupported('puppet_module')
+
+
 def _gen_repo():
     """Return a semi-random dict that used for creating a puppet repo."""
     return {

--- a/pulp_smash/tests/rpm/api_v2/test_broker.py
+++ b/pulp_smash/tests/rpm/api_v2/test_broker.py
@@ -40,6 +40,11 @@ from pulp_smash.constants import (
 from pulp_smash.tests.rpm.api_v2.utils import gen_distributor, gen_repo
 
 
+def setUpModule():  # pylint:disable=invalid-name
+    """Skip tests if the RPM plugin is not installed."""
+    utils.skip_if_type_is_unsupported('rpm')
+
+
 class BrokerTestCase(unittest2.TestCase):
     """Test Pulp's support for broker connections and reconnections."""
 

--- a/pulp_smash/tests/rpm/api_v2/test_comps_groups.py
+++ b/pulp_smash/tests/rpm/api_v2/test_comps_groups.py
@@ -12,6 +12,11 @@ from pulp_smash.tests.rpm.api_v2.utils import (
 )
 
 
+def setUpModule():  # pylint:disable=invalid-name
+    """Skip tests if the RPM plugin is not installed."""
+    utils.skip_if_type_is_unsupported('rpm')
+
+
 def _gen_realistic_group():
     """Return a realistic, typical group unit.
 

--- a/pulp_smash/tests/rpm/api_v2/test_download.py
+++ b/pulp_smash/tests/rpm/api_v2/test_download.py
@@ -20,6 +20,11 @@ from pulp_smash.constants import REPOSITORY_PATH, RPM_ABS_PATH, RPM_FEED_URL
 from pulp_smash.tests.rpm.api_v2.utils import gen_distributor, gen_repo
 
 
+def setUpModule():  # pylint:disable=invalid-name
+    """Skip tests if the RPM plugin is not installed."""
+    utils.skip_if_type_is_unsupported('rpm')
+
+
 class SyncDownloadTestCase(utils.BaseAPITestCase):
     """Assert the RPM plugin supports on-demand syncing of yum repositories.
 

--- a/pulp_smash/tests/rpm/api_v2/test_duplicate_uploads.py
+++ b/pulp_smash/tests/rpm/api_v2/test_duplicate_uploads.py
@@ -26,6 +26,11 @@ from pulp_smash.constants import (
 )
 
 
+def setUpModule():  # pylint:disable=invalid-name
+    """Skip tests if the RPM plugin is not installed."""
+    utils.skip_if_type_is_unsupported('rpm')
+
+
 def _upload_import_rpm(server_config, rpm, repo_href):
     """Upload an RPM to a Pulp server and import it into a repository.
 

--- a/pulp_smash/tests/rpm/api_v2/test_export.py
+++ b/pulp_smash/tests/rpm/api_v2/test_export.py
@@ -29,6 +29,11 @@ from pulp_smash.tests.rpm.api_v2.utils import (
 )
 
 
+def setUpModule():  # pylint:disable=invalid-name
+    """Skip tests if the RPM plugin is not installed."""
+    utils.skip_if_type_is_unsupported('rpm')
+
+
 def _has_getenforce(server_config):
     """Tell whether the ``getenforce`` executable is on the target system."""
     # When executing commands over SSH, in a non-login shell, and as a non-root

--- a/pulp_smash/tests/rpm/api_v2/test_iso_crud.py
+++ b/pulp_smash/tests/rpm/api_v2/test_iso_crud.py
@@ -30,6 +30,11 @@ _ISO_DISTRIBUTOR = {
 }
 
 
+def setUpModule():  # pylint:disable=invalid-name
+    """Skip tests if the RPM plugin is not installed."""
+    utils.skip_if_type_is_unsupported('rpm')
+
+
 def _customize_template(template, repository_id):
     """Copy ``template`` and interpolate a repository ID into its ``_href``."""
     template = template.copy()

--- a/pulp_smash/tests/rpm/api_v2/test_orphan_remove.py
+++ b/pulp_smash/tests/rpm/api_v2/test_orphan_remove.py
@@ -13,6 +13,11 @@ from pulp_smash.constants import ORPHANS_PATH, REPOSITORY_PATH, RPM_FEED_URL
 from pulp_smash.tests.rpm.api_v2.utils import gen_repo
 
 
+def setUpModule():  # pylint:disable=invalid-name
+    """Skip tests if the RPM plugin is not installed."""
+    utils.skip_if_type_is_unsupported('rpm')
+
+
 def _count_orphans(client):
     """Count the number of orphans."""
     orphan_dict = client.get(ORPHANS_PATH)

--- a/pulp_smash/tests/rpm/api_v2/test_remove_unit.py
+++ b/pulp_smash/tests/rpm/api_v2/test_remove_unit.py
@@ -33,6 +33,11 @@ from pulp_smash.tests.rpm.api_v2.utils import (
 _PUBLISH_DIR = 'pulp/repos/'
 
 
+def setUpModule():  # pylint:disable=invalid-name
+    """Skip tests if the RPM plugin is not installed."""
+    utils.skip_if_type_is_unsupported('rpm')
+
+
 def _get_rpm_ids(search_body):
     """Get RPM unit IDs from search results. Return a set."""
     return {

--- a/pulp_smash/tests/rpm/api_v2/test_repomd.py
+++ b/pulp_smash/tests/rpm/api_v2/test_repomd.py
@@ -16,6 +16,11 @@ from pulp_smash.tests.rpm.api_v2.utils import (
 )
 
 
+def setUpModule():  # pylint:disable=invalid-name
+    """Skip tests if the RPM plugin is not installed."""
+    utils.skip_if_type_is_unsupported('rpm')
+
+
 class RepoMDTestCase(utils.BaseAPITestCase):
     """Tests to ensure ``repomd.xml`` can be created and is valid."""
 

--- a/pulp_smash/tests/rpm/api_v2/test_republish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_republish.py
@@ -26,6 +26,11 @@ from pulp_smash.tests.rpm.api_v2.utils import (
 _PUBLISH_DIR = 'pulp/repos/'
 
 
+def setUpModule():  # pylint:disable=invalid-name
+    """Skip tests if the RPM plugin is not installed."""
+    utils.skip_if_type_is_unsupported('rpm')
+
+
 class RepublishTestCase(utils.BaseAPITestCase):
     """Test re-publish repository after unassociating content."""
 

--- a/pulp_smash/tests/rpm/api_v2/test_retain_old_count.py
+++ b/pulp_smash/tests/rpm/api_v2/test_retain_old_count.py
@@ -24,6 +24,11 @@ from pulp_smash.tests.rpm.api_v2.utils import gen_distributor, gen_repo
 _PUBLISH_DIR = 'pulp/repos/'
 
 
+def setUpModule():  # pylint:disable=invalid-name
+    """Skip tests if the RPM plugin is not installed."""
+    utils.skip_if_type_is_unsupported('rpm')
+
+
 class RetainOldCountTestCase(utils.BaseAPITestCase):
     """Test functionality of --retain-old-count option specified."""
 

--- a/pulp_smash/tests/rpm/api_v2/test_schedule_publish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_schedule_publish.py
@@ -19,6 +19,11 @@ from pulp_smash.constants import REPOSITORY_PATH, RPM_FEED_URL
 from pulp_smash.tests.rpm.api_v2.utils import gen_repo, gen_distributor
 
 
+def setUpModule():  # pylint:disable=invalid-name
+    """Skip tests if the RPM plugin is not installed."""
+    utils.skip_if_type_is_unsupported('rpm')
+
+
 class CreateSuccessTestCase(utils.BaseAPITestCase):
     """Establish that we can create a schedule to publish the repository."""
 

--- a/pulp_smash/tests/rpm/api_v2/test_schedule_sync.py
+++ b/pulp_smash/tests/rpm/api_v2/test_schedule_sync.py
@@ -36,6 +36,11 @@ _SCHEDULE_PATH = 'importers/{}/schedules/sync/'
 # Usage: urljoin(repo['_href'], _SCHEDULE_PATH.format(importer_type_id))
 
 
+def setUpModule():  # pylint:disable=invalid-name
+    """Skip tests if the RPM plugin is not installed."""
+    utils.skip_if_type_is_unsupported('rpm')
+
+
 # It's OK that this class has one method. It's an intentionally small class.
 class CreateRepoMixin(object):  # pylint:disable=too-few-public-methods
     """Provide a method for creating a repository."""

--- a/pulp_smash/tests/rpm/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_sync_publish.py
@@ -53,6 +53,11 @@ from pulp_smash.tests.rpm.api_v2.utils import gen_distributor, gen_repo
 _REPO_PUBLISH_PATH = '/pulp/repos/'  # + relative_url + unit_name.rpm.arch
 
 
+def setUpModule():  # pylint:disable=invalid-name
+    """Skip tests if the RPM plugin is not installed."""
+    utils.skip_if_type_is_unsupported('rpm')
+
+
 class CreateTestCase(utils.BaseAPITestCase):
     """Create two RPM repositories, with and without feed URLs respectively."""
 

--- a/pulp_smash/tests/rpm/api_v2/test_unassociate.py
+++ b/pulp_smash/tests/rpm/api_v2/test_unassociate.py
@@ -32,6 +32,11 @@ _RPM_ID_FIELD = 'checksum'
 # constant attempts to name a substitute for an ID.
 
 
+def setUpModule():  # pylint:disable=invalid-name
+    """Skip tests if the RPM plugin is not installed."""
+    utils.skip_if_type_is_unsupported('rpm')
+
+
 def _get_unit_id(unit):
     """Return the unit's _RPM_ID_FIELD if an RPM. Otherwise, return ID."""
     if unit['unit_type_id'] == 'rpm':

--- a/pulp_smash/tests/rpm/api_v2/test_updateinfo.py
+++ b/pulp_smash/tests/rpm/api_v2/test_updateinfo.py
@@ -12,6 +12,11 @@ from pulp_smash.tests.rpm.api_v2.utils import (
 )
 
 
+def setUpModule():  # pylint:disable=invalid-name
+    """Skip tests if the RPM plugin is not installed."""
+    utils.skip_if_type_is_unsupported('rpm')
+
+
 def _gen_errata_typical():
     """Generate and return a typical erratum with a unique ID."""
     return {


### PR DESCRIPTION
This pull request contains two commits. The first commit rewrites existing logic for skipping tests based on whether or not a plugin is installed. It doesn't expand that logic to any new modules. It just takes what's already in place and shuffles around the pieces. This makes it easy to verify: one need only run tests for two test modules and verify that nothing has broken. The second commit expands the per-plugin test skipping logic to the entire test suite.