### PR TITLE
Let linter check imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ lint-flake8:
 	flake8 . --ignore D203
 
 lint-pylint:
-	pylint -j $(CPU_COUNT) --reports=n --ignore-imports=y --disable=I \
+	pylint -j $(CPU_COUNT) --reports=n --disable=I \
 		docs/conf.py \
 		setup.py \
 		tests \


### PR DESCRIPTION
The `lint-pylint` make target runs the Pylint linter over the code base.
A small number of checks are disabled, including import checks. Why are
import checks disabled? The import checks will issue a warning in the
case where four or more import lines are identical, and it will
therefore catch the following:

```python
try:  # try Python 3 first
    from urllib.parse import urljoin
except ImportError:
    from urlparse import urljoin
```

This was considered a low-priority issue for some time. However, the
introduction of module `pulp_smash.compat` has solved this issue, and
there is now much less reason to ignore this check.

Update the `lint-pylint` make target and let Pylint check for
import-related issues.