### PR TITLE
Deduplicate test skipping logic

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -27,6 +27,7 @@ developers, not a gospel.
     api/pulp_smash.tests.docker.cli.test_crud
     api/pulp_smash.tests.docker.cli.test_sync_publish
     api/pulp_smash.tests.docker.cli.utils
+    api/pulp_smash.tests.docker.utils
     api/pulp_smash.tests.ostree
     api/pulp_smash.tests.ostree.api_v2
     api/pulp_smash.tests.ostree.api_v2.test_crud
@@ -43,6 +44,7 @@ developers, not a gospel.
     api/pulp_smash.tests.puppet
     api/pulp_smash.tests.puppet.api_v2
     api/pulp_smash.tests.puppet.api_v2.test_sync_publish
+    api/pulp_smash.tests.puppet.utils
     api/pulp_smash.tests.rpm
     api/pulp_smash.tests.rpm.api_v2
     api/pulp_smash.tests.rpm.api_v2.test_broker
@@ -62,6 +64,7 @@ developers, not a gospel.
     api/pulp_smash.tests.rpm.api_v2.test_unassociate
     api/pulp_smash.tests.rpm.api_v2.test_updateinfo
     api/pulp_smash.tests.rpm.api_v2.utils
+    api/pulp_smash.tests.rpm.utils
     api/pulp_smash.utils
     api/tests
     api/tests.test_api

--- a/docs/api/pulp_smash.tests.docker.utils.rst
+++ b/docs/api/pulp_smash.tests.docker.utils.rst
@@ -1,0 +1,6 @@
+`pulp_smash.tests.docker.utils`
+===============================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.docker.utils`
+
+.. automodule:: pulp_smash.tests.docker.utils

--- a/docs/api/pulp_smash.tests.puppet.utils.rst
+++ b/docs/api/pulp_smash.tests.puppet.utils.rst
@@ -1,0 +1,6 @@
+`pulp_smash.tests.puppet.utils`
+===============================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.puppet.utils`
+
+.. automodule:: pulp_smash.tests.puppet.utils

--- a/docs/api/pulp_smash.tests.rpm.utils.rst
+++ b/docs/api/pulp_smash.tests.rpm.utils.rst
@@ -1,0 +1,6 @@
+`pulp_smash.tests.rpm.utils`
+===============================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.rpm.utils`
+
+.. automodule:: pulp_smash.tests.rpm.utils

--- a/pulp_smash/tests/__init__.py
+++ b/pulp_smash/tests/__init__.py
@@ -1,11 +1,31 @@
 # coding=utf-8
+# flake8:noqa
 """Tests for Pulp.
 
-This package and its sub-packages contain tests for Pulp. These tests should be
-run against live Pulp systems. These tests may target all of the different
-interfaces exposed by Pulp, including its API and CLI.
+This package and its sub-packages contain functional tests for Pulp. These
+tests should be run against live Pulp systems. These tests may target all of
+the different interfaces exposed by Pulp, including its API and CLI. These
+tests are entirely different from the unit tests in :mod:`tests`.
 
-These tests are entirely different from the tests in :mod:`tests`.
+A given Pulp server may have an arbitrary set of plugins installed. As a
+result, not all of the tests in Pulp Smash should be run against a given Pulp
+server. Consequently, tests are organized on a per-plugin basis. Tests for the
+Docker plugin are in :mod:`pulp_smash.tests.docker`, tests for the OSTree
+plugin are in :mod:`pulp_smash.tests.ostree`, and so on. Several other factors
+also determine whether a test should be run, such as whether a given bug has
+been fixed in the version of Pulp under test. However, plugins are the broadest
+determinant of which tests should be run, so they direct the test suite
+structure.
+
+Selecting and deselecting tests is a common task, and module
+:mod:`pulp_smash.selectors` has a collection of tools for this problem area. At
+a minimum, *every* ``test*`` module should define a `setUpModule`_ function
+that checks for the presence of needed Pulp plugins and raises a `SkipTest`_
+exception if needed. For convenience, functions such as
+:func:`pulp_smash.tests.docker.utils.set_up_module` can be used for this
+purpose. For example::
+
+    >>> from pulp_smash.tests.docker.utils import set_up_module as setUpModule
 
 -----
 
@@ -33,6 +53,9 @@ the other library generates ``InsecureRequestWarning`` warnings. The warnings
 raised by that application are suppressed by the filter created here. The
 ``warnings.catch_warnings`` context manager is not a good solution to this
 problem, as it is thread-unsafe.
+
+.. _SkipTest: https://docs.python.org/3.5/library/unittest.html#unittest.SkipTest
+.. _setUpModule: https://docs.python.org/3.5/library/unittest.html#setupmodule-and-teardownmodule
 """
 from __future__ import unicode_literals
 

--- a/pulp_smash/tests/docker/api_v2/test_crud.py
+++ b/pulp_smash/tests/docker/api_v2/test_crud.py
@@ -13,11 +13,7 @@ from packaging.version import Version
 from pulp_smash import api, utils
 from pulp_smash.compat import urljoin
 from pulp_smash.constants import REPOSITORY_PATH
-
-
-def setUpModule():  # pylint:disable=invalid-name
-    """Skip tests if the Docker plugin is not installed."""
-    utils.skip_if_type_is_unsupported('docker_image')
+from pulp_smash.tests.docker.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 
 def _gen_docker_repo_body():

--- a/pulp_smash/tests/docker/cli/test_copy.py
+++ b/pulp_smash/tests/docker/cli/test_copy.py
@@ -10,17 +10,13 @@ from packaging.version import Version
 from pulp_smash import config, utils
 from pulp_smash.constants import DOCKER_V1_FEED_URL, DOCKER_V2_FEED_URL
 from pulp_smash.tests.docker.cli import utils as docker_utils
+from pulp_smash.tests.docker.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 _DIGEST_RE = r'(?:Digest:)\s*(.*)'
 _IMAGE_ID_RE = r'(?:Image Id:)\s*(.*)'
 _NAME_RE = r'(?:Name:)\s*(.*)'
 _UNIT_ID_RE = r'(?:Unit Id:)\s*(.*)'
 _UPSTREAM_NAME = 'library/busybox'
-
-
-def setUpModule():  # pylint:disable=invalid-name
-    """Skip tests if the Docker plugin is not installed."""
-    utils.skip_if_type_is_unsupported('docker_image')
 
 
 def _get_unit_ids(server_config, repo_id, unit_type, regex):

--- a/pulp_smash/tests/docker/cli/test_crud.py
+++ b/pulp_smash/tests/docker/cli/test_crud.py
@@ -12,14 +12,10 @@ from packaging import version
 
 from pulp_smash import api, cli, config, selectors, utils
 from pulp_smash.tests.docker.cli import utils as docker_utils
+from pulp_smash.tests.docker.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 _FEED = 'https://example.com'
 _UPSTREAM_NAME = 'foo/bar'
-
-
-def setUpModule():  # pylint:disable=invalid-name
-    """Skip tests if the Docker plugin is not installed."""
-    utils.skip_if_type_is_unsupported('docker_image')
 
 
 class CreateTestCase(unittest2.TestCase):

--- a/pulp_smash/tests/docker/cli/test_sync_publish.py
+++ b/pulp_smash/tests/docker/cli/test_sync_publish.py
@@ -11,14 +11,10 @@ from packaging.version import Version
 from pulp_smash import api, cli, config, selectors, utils
 from pulp_smash.constants import DOCKER_V1_FEED_URL, DOCKER_V2_FEED_URL
 from pulp_smash.tests.docker.cli import utils as docker_utils
+from pulp_smash.tests.docker.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 _BYTE_UNICODE = (type(b''), type(u''))
 _UPSTREAM_NAME = 'library/busybox'
-
-
-def setUpModule():  # pylint:disable=invalid-name
-    """Skip tests if the Docker plugin is not installed."""
-    utils.skip_if_type_is_unsupported('docker_image')
 
 
 class _BaseTestCase(unittest2.TestCase):

--- a/pulp_smash/tests/docker/utils.py
+++ b/pulp_smash/tests/docker/utils.py
@@ -1,0 +1,13 @@
+# coding=utf-8
+"""Utilities for Docker tests."""
+from __future__ import unicode_literals
+
+from pulp_smash import utils
+
+
+def set_up_module():
+    """Skip tests if the Docker plugin is not installed.
+
+    See :mod:`pulp_smash.tests` for more information.
+    """
+    utils.skip_if_type_is_unsupported('docker_image')

--- a/pulp_smash/tests/ostree/api_v2/test_crud.py
+++ b/pulp_smash/tests/ostree/api_v2/test_crud.py
@@ -22,11 +22,7 @@ from pulp_smash import api, selectors, utils
 from pulp_smash.compat import urljoin
 from pulp_smash.constants import REPOSITORY_PATH
 from pulp_smash.tests.ostree.utils import gen_repo
-
-
-def setUpModule():  # pylint:disable=invalid-name
-    """Skip tests if the OSTree plugin is not installed."""
-    utils.skip_if_type_is_unsupported('ostree')
+from pulp_smash.tests.ostree.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 
 def _gen_distributor(relative_path):

--- a/pulp_smash/tests/ostree/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/ostree/api_v2/test_sync_publish.py
@@ -27,17 +27,13 @@ from pulp_smash import api, utils
 from pulp_smash.compat import urljoin
 from pulp_smash.constants import REPOSITORY_PATH
 from pulp_smash.tests.ostree.utils import create_sync_repo, gen_repo
+from pulp_smash.tests.ostree.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 _FEED = 'https://repos.fedorapeople.org/pulp/pulp/demo_repos/test-ostree-small'
 _BRANCHES = (
     'fedora-atomic/f21/x86_64/updates/docker-host',
     'fedora-atomic/f21/x86_64/updates-testing/docker-host',
 )
-
-
-def setUpModule():  # pylint:disable=invalid-name
-    """Skip tests if the OSTree plugin is not installed."""
-    utils.skip_if_type_is_unsupported('ostree')
 
 
 def _sync_repo(server_config, href):

--- a/pulp_smash/tests/ostree/utils.py
+++ b/pulp_smash/tests/ostree/utils.py
@@ -7,6 +7,14 @@ from pulp_smash.compat import urljoin
 from pulp_smash.constants import REPOSITORY_PATH
 
 
+def set_up_module():
+    """Skip tests if the OSTree plugin is not installed.
+
+    See :mod:`pulp_smash.tests` for more information.
+    """
+    utils.skip_if_type_is_unsupported('ostree')
+
+
 def gen_repo():
     """Return a semi-random dict for use in creating an OSTree repository."""
     return {

--- a/pulp_smash/tests/puppet/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/puppet/api_v2/test_sync_publish.py
@@ -45,6 +45,7 @@ from pulp_smash.constants import (
     CONTENT_UPLOAD_PATH,
     REPOSITORY_PATH,
 )
+from pulp_smash.tests.puppet.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 _PUPPET_FEED = 'http://forge.puppetlabs.com'
 _PUPPET_MODULE = {
@@ -61,11 +62,6 @@ _PUPPET_MODULE_URL = (
     )
 )
 _PUPPET_QUERY = _PUPPET_MODULE['author'] + '-' + _PUPPET_MODULE['name']
-
-
-def setUpModule():  # pylint:disable=invalid-name
-    """Skip tests if the Puppet plugin is not installed."""
-    utils.skip_if_type_is_unsupported('puppet_module')
 
 
 def _gen_repo():

--- a/pulp_smash/tests/puppet/utils.py
+++ b/pulp_smash/tests/puppet/utils.py
@@ -1,0 +1,13 @@
+# coding=utf-8
+"""Utilities for Puppet tests."""
+from __future__ import unicode_literals
+
+from pulp_smash import utils
+
+
+def set_up_module():
+    """Skip tests if the Puppet plugin is not installed.
+
+    See :mod:`pulp_smash.tests` for more information.
+    """
+    utils.skip_if_type_is_unsupported('puppet_module')

--- a/pulp_smash/tests/rpm/api_v2/test_broker.py
+++ b/pulp_smash/tests/rpm/api_v2/test_broker.py
@@ -38,11 +38,7 @@ from pulp_smash.constants import (
     RPM_FEED_URL,
 )
 from pulp_smash.tests.rpm.api_v2.utils import gen_distributor, gen_repo
-
-
-def setUpModule():  # pylint:disable=invalid-name
-    """Skip tests if the RPM plugin is not installed."""
-    utils.skip_if_type_is_unsupported('rpm')
+from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 
 class BrokerTestCase(unittest2.TestCase):

--- a/pulp_smash/tests/rpm/api_v2/test_comps_groups.py
+++ b/pulp_smash/tests/rpm/api_v2/test_comps_groups.py
@@ -10,11 +10,7 @@ from pulp_smash.tests.rpm.api_v2.utils import (
     gen_repo,
     get_repomd_xml,
 )
-
-
-def setUpModule():  # pylint:disable=invalid-name
-    """Skip tests if the RPM plugin is not installed."""
-    utils.skip_if_type_is_unsupported('rpm')
+from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 
 def _gen_realistic_group():

--- a/pulp_smash/tests/rpm/api_v2/test_download.py
+++ b/pulp_smash/tests/rpm/api_v2/test_download.py
@@ -18,11 +18,7 @@ from pulp_smash import api, utils, cli
 from pulp_smash.compat import urljoin
 from pulp_smash.constants import REPOSITORY_PATH, RPM_ABS_PATH, RPM_FEED_URL
 from pulp_smash.tests.rpm.api_v2.utils import gen_distributor, gen_repo
-
-
-def setUpModule():  # pylint:disable=invalid-name
-    """Skip tests if the RPM plugin is not installed."""
-    utils.skip_if_type_is_unsupported('rpm')
+from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 
 class SyncDownloadTestCase(utils.BaseAPITestCase):

--- a/pulp_smash/tests/rpm/api_v2/test_duplicate_uploads.py
+++ b/pulp_smash/tests/rpm/api_v2/test_duplicate_uploads.py
@@ -24,11 +24,7 @@ from pulp_smash.constants import (
     RPM,
     RPM_FEED_URL,
 )
-
-
-def setUpModule():  # pylint:disable=invalid-name
-    """Skip tests if the RPM plugin is not installed."""
-    utils.skip_if_type_is_unsupported('rpm')
+from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 
 def _upload_import_rpm(server_config, rpm, repo_href):

--- a/pulp_smash/tests/rpm/api_v2/test_export.py
+++ b/pulp_smash/tests/rpm/api_v2/test_export.py
@@ -27,11 +27,7 @@ from pulp_smash.tests.rpm.api_v2.utils import (
     gen_repo,
     sync_repo,
 )
-
-
-def setUpModule():  # pylint:disable=invalid-name
-    """Skip tests if the RPM plugin is not installed."""
-    utils.skip_if_type_is_unsupported('rpm')
+from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 
 def _has_getenforce(server_config):

--- a/pulp_smash/tests/rpm/api_v2/test_iso_crud.py
+++ b/pulp_smash/tests/rpm/api_v2/test_iso_crud.py
@@ -7,6 +7,7 @@ from packaging.version import Version
 from pulp_smash import api, selectors, utils
 from pulp_smash.compat import urljoin, urlparse
 from pulp_smash.constants import REPOSITORY_PATH
+from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 
 _DISTRIBUTOR = {
@@ -28,11 +29,6 @@ _ISO_DISTRIBUTOR = {
     'id': 'iso_distributor',
     'last_publish': None,
 }
-
-
-def setUpModule():  # pylint:disable=invalid-name
-    """Skip tests if the RPM plugin is not installed."""
-    utils.skip_if_type_is_unsupported('rpm')
 
 
 def _customize_template(template, repository_id):

--- a/pulp_smash/tests/rpm/api_v2/test_orphan_remove.py
+++ b/pulp_smash/tests/rpm/api_v2/test_orphan_remove.py
@@ -11,11 +11,7 @@ from pulp_smash import api, utils
 from pulp_smash.compat import urljoin
 from pulp_smash.constants import ORPHANS_PATH, REPOSITORY_PATH, RPM_FEED_URL
 from pulp_smash.tests.rpm.api_v2.utils import gen_repo
-
-
-def setUpModule():  # pylint:disable=invalid-name
-    """Skip tests if the RPM plugin is not installed."""
-    utils.skip_if_type_is_unsupported('rpm')
+from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 
 def _count_orphans(client):

--- a/pulp_smash/tests/rpm/api_v2/test_remove_unit.py
+++ b/pulp_smash/tests/rpm/api_v2/test_remove_unit.py
@@ -29,13 +29,9 @@ from pulp_smash.tests.rpm.api_v2.utils import (
     gen_repo,
     sync_repo,
 )
+from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 _PUBLISH_DIR = 'pulp/repos/'
-
-
-def setUpModule():  # pylint:disable=invalid-name
-    """Skip tests if the RPM plugin is not installed."""
-    utils.skip_if_type_is_unsupported('rpm')
 
 
 def _get_rpm_ids(search_body):

--- a/pulp_smash/tests/rpm/api_v2/test_repomd.py
+++ b/pulp_smash/tests/rpm/api_v2/test_repomd.py
@@ -14,11 +14,7 @@ from pulp_smash.tests.rpm.api_v2.utils import (
     gen_repo,
     xml_handler,
 )
-
-
-def setUpModule():  # pylint:disable=invalid-name
-    """Skip tests if the RPM plugin is not installed."""
-    utils.skip_if_type_is_unsupported('rpm')
+from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 
 class RepoMDTestCase(utils.BaseAPITestCase):

--- a/pulp_smash/tests/rpm/api_v2/test_republish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_republish.py
@@ -22,13 +22,9 @@ from pulp_smash.tests.rpm.api_v2.utils import (
     gen_repo,
     sync_repo,
 )
+from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 _PUBLISH_DIR = 'pulp/repos/'
-
-
-def setUpModule():  # pylint:disable=invalid-name
-    """Skip tests if the RPM plugin is not installed."""
-    utils.skip_if_type_is_unsupported('rpm')
 
 
 class RepublishTestCase(utils.BaseAPITestCase):

--- a/pulp_smash/tests/rpm/api_v2/test_retain_old_count.py
+++ b/pulp_smash/tests/rpm/api_v2/test_retain_old_count.py
@@ -20,13 +20,9 @@ from pulp_smash import api, utils
 from pulp_smash.compat import urljoin
 from pulp_smash.constants import REPOSITORY_PATH, RPM_FEED_URL
 from pulp_smash.tests.rpm.api_v2.utils import gen_distributor, gen_repo
+from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 _PUBLISH_DIR = 'pulp/repos/'
-
-
-def setUpModule():  # pylint:disable=invalid-name
-    """Skip tests if the RPM plugin is not installed."""
-    utils.skip_if_type_is_unsupported('rpm')
 
 
 class RetainOldCountTestCase(utils.BaseAPITestCase):

--- a/pulp_smash/tests/rpm/api_v2/test_schedule_publish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_schedule_publish.py
@@ -17,11 +17,7 @@ from pulp_smash import api, utils
 from pulp_smash.compat import urljoin
 from pulp_smash.constants import REPOSITORY_PATH, RPM_FEED_URL
 from pulp_smash.tests.rpm.api_v2.utils import gen_repo, gen_distributor
-
-
-def setUpModule():  # pylint:disable=invalid-name
-    """Skip tests if the RPM plugin is not installed."""
-    utils.skip_if_type_is_unsupported('rpm')
+from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 
 class CreateSuccessTestCase(utils.BaseAPITestCase):

--- a/pulp_smash/tests/rpm/api_v2/test_schedule_sync.py
+++ b/pulp_smash/tests/rpm/api_v2/test_schedule_sync.py
@@ -17,6 +17,7 @@ from pulp_smash import api, utils
 from pulp_smash.compat import urljoin
 from pulp_smash.constants import REPOSITORY_PATH, RPM_FEED_URL
 from pulp_smash.tests.rpm.api_v2.utils import gen_repo
+from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 _MUTABLE_ATTRS = {
     'consecutive_failures',
@@ -34,11 +35,6 @@ _SCHEDULE = {'schedule': 'PT30S'}
 
 _SCHEDULE_PATH = 'importers/{}/schedules/sync/'
 # Usage: urljoin(repo['_href'], _SCHEDULE_PATH.format(importer_type_id))
-
-
-def setUpModule():  # pylint:disable=invalid-name
-    """Skip tests if the RPM plugin is not installed."""
-    utils.skip_if_type_is_unsupported('rpm')
 
 
 # It's OK that this class has one method. It's an intentionally small class.

--- a/pulp_smash/tests/rpm/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_sync_publish.py
@@ -48,14 +48,10 @@ from pulp_smash.constants import (
     RPM_SHA256_CHECKSUM,
 )
 from pulp_smash.tests.rpm.api_v2.utils import gen_distributor, gen_repo
+from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 
 _REPO_PUBLISH_PATH = '/pulp/repos/'  # + relative_url + unit_name.rpm.arch
-
-
-def setUpModule():  # pylint:disable=invalid-name
-    """Skip tests if the RPM plugin is not installed."""
-    utils.skip_if_type_is_unsupported('rpm')
 
 
 class CreateTestCase(utils.BaseAPITestCase):

--- a/pulp_smash/tests/rpm/api_v2/test_unassociate.py
+++ b/pulp_smash/tests/rpm/api_v2/test_unassociate.py
@@ -23,6 +23,7 @@ from pulp_smash.tests.rpm.api_v2.utils import (
     gen_repo,
     sync_repo,
 )
+from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 _RPM_ID_FIELD = 'checksum'
 # RPM units do not have an ``id`` metadata field. This is problematic when
@@ -30,11 +31,6 @@ _RPM_ID_FIELD = 'checksum'
 # fields may be non-unique. For example, two different RPM content units may
 # both have a name of "walrus" — they just provide different versions. This
 # constant attempts to name a substitute for an ID.
-
-
-def setUpModule():  # pylint:disable=invalid-name
-    """Skip tests if the RPM plugin is not installed."""
-    utils.skip_if_type_is_unsupported('rpm')
 
 
 def _get_unit_id(unit):

--- a/pulp_smash/tests/rpm/api_v2/test_updateinfo.py
+++ b/pulp_smash/tests/rpm/api_v2/test_updateinfo.py
@@ -10,11 +10,7 @@ from pulp_smash.tests.rpm.api_v2.utils import (
     gen_repo,
     get_repomd_xml,
 )
-
-
-def setUpModule():  # pylint:disable=invalid-name
-    """Skip tests if the RPM plugin is not installed."""
-    utils.skip_if_type_is_unsupported('rpm')
+from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 
 def _gen_errata_typical():

--- a/pulp_smash/tests/rpm/utils.py
+++ b/pulp_smash/tests/rpm/utils.py
@@ -1,0 +1,13 @@
+# coding=utf-8
+"""Utilities for RPM tests."""
+from __future__ import unicode_literals
+
+from pulp_smash import utils
+
+
+def set_up_module():
+    """Skip tests if the RPM plugin is not installed.
+
+    See :mod:`pulp_smash.tests` for more information.
+    """
+    utils.skip_if_type_is_unsupported('rpm')


### PR DESCRIPTION
A given Pulp server may have an arbitrary set of plugins installed.
Consequently, not all tests in Pulp Smash apply to a given Pulp server.
Pulp Smash chooses which tests to run by executing a `setUpModule`
function in each `test*` module, and this function talks to the Pulp
server and checks to see if the relevant plugin is installed.

This works, but it's not DRY. Every single `test*` module must define a
nearly identical function, and each of these functions contains a magic
keyword like "docker_image" or "rpm". Address this by defining one
`set_up_module` function in each of the following:

* pulp_smash.tests.docker.utils
* pulp_smash.tests.ostree.utils
* pulp_smash.tests.puppet.utils
* pulp_smash.tests.rpm.utils

Then, `import set_up_module as setUpModule` as needed. This change does
not change test results. Test results gathered with the following
commands:

    nose pulp_smash.tests
    nose2 pulp_smash.tests
    py.test --pyargs pulp_smash.tests
    python -m unittest2 discover pulp_smash.tests

(Note that nose treats `SkipTest` exceptions as errors.)

Related to https://github.com/PulpQE/pulp-smash/issues/182.