### PR TITLE
Auto-generate API documentation stub files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 
 # Generated documentation
 /docs/_build/
+/docs/api/*.rst
 
 # Created by `make package`. `pulp_smash.egg_info` is also used when another
 # package does a `pip install -e …/pulp_smash`.

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ help:
 all: test-coverage lint docs-clean docs-html package-clean package
 
 docs-html:
+	./gen_api_docs.sh
 	@cd docs; $(MAKE) html
 
 docs-clean:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -11,6 +11,7 @@ developers, not a gospel.
 .. toctree::
 
     api/pulp_smash
+    api/pulp_smash.__main__
     api/pulp_smash.api
     api/pulp_smash.cli
     api/pulp_smash.compat

--- a/docs/api/pulp_smash.api.rst
+++ b/docs/api/pulp_smash.api.rst
@@ -1,6 +1,0 @@
-`pulp_smash.api`
-================
-
-Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.api`
-
-.. automodule:: pulp_smash.api

--- a/docs/api/pulp_smash.cli.rst
+++ b/docs/api/pulp_smash.cli.rst
@@ -1,6 +1,0 @@
-`pulp_smash.cli`
-================
-
-Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.cli`
-
-.. automodule:: pulp_smash.cli

--- a/docs/api/pulp_smash.compat.rst
+++ b/docs/api/pulp_smash.compat.rst
@@ -1,6 +1,0 @@
-`pulp_smash.compat`
-===================
-
-Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.compat`
-
-.. automodule:: pulp_smash.compat

--- a/docs/api/pulp_smash.config.rst
+++ b/docs/api/pulp_smash.config.rst
@@ -1,7 +1,0 @@
-`pulp_smash.config`
-===================
-
-Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.config`
-
-.. automodule:: pulp_smash.config
-    :private-members:

--- a/docs/api/pulp_smash.constants.rst
+++ b/docs/api/pulp_smash.constants.rst
@@ -1,6 +1,0 @@
-`pulp_smash.constants`
-======================
-
-Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.constants`
-
-.. automodule:: pulp_smash.constants

--- a/docs/api/pulp_smash.exceptions.rst
+++ b/docs/api/pulp_smash.exceptions.rst
@@ -1,6 +1,0 @@
-`pulp_smash.exceptions`
-=======================
-
-Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.exceptions`
-
-.. automodule:: pulp_smash.exceptions

--- a/docs/api/pulp_smash.rst
+++ b/docs/api/pulp_smash.rst
@@ -1,6 +1,0 @@
-`pulp_smash`
-============
-
-Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash`
-
-.. automodule:: pulp_smash

--- a/docs/api/pulp_smash.selectors.rst
+++ b/docs/api/pulp_smash.selectors.rst
@@ -1,6 +1,0 @@
-`pulp_smash.selectors`
-======================
-
-Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.selectors`
-
-.. automodule:: pulp_smash.selectors

--- a/docs/api/pulp_smash.tests.docker.api_v2.rst
+++ b/docs/api/pulp_smash.tests.docker.api_v2.rst
@@ -1,6 +1,0 @@
-`pulp_smash.tests.docker.api_v2`
-================================
-
-Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.docker.api_v2`
-
-.. automodule:: pulp_smash.tests.docker.api_v2

--- a/docs/api/pulp_smash.tests.docker.api_v2.test_crud.rst
+++ b/docs/api/pulp_smash.tests.docker.api_v2.test_crud.rst
@@ -1,7 +1,0 @@
-`pulp_smash.tests.docker.api_v2.test_crud`
-==========================================
-
-Location: :doc:`/index` → :doc:`/api` →
-:doc:`/api/pulp_smash.tests.docker.api_v2.test_crud`
-
-.. automodule:: pulp_smash.tests.docker.api_v2.test_crud

--- a/docs/api/pulp_smash.tests.docker.cli.rst
+++ b/docs/api/pulp_smash.tests.docker.cli.rst
@@ -1,6 +1,0 @@
-`pulp_smash.tests.docker.cli`
-=============================
-
-Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.docker.cli`
-
-.. automodule:: pulp_smash.tests.docker.cli

--- a/docs/api/pulp_smash.tests.docker.cli.test_copy.rst
+++ b/docs/api/pulp_smash.tests.docker.cli.test_copy.rst
@@ -1,7 +1,0 @@
-`pulp_smash.tests.docker.cli.test_copy`
-=======================================
-
-Location: :doc:`/index` → :doc:`/api` →
-:doc:`/api/pulp_smash.tests.docker.cli.test_copy`
-
-.. automodule:: pulp_smash.tests.docker.cli.test_copy

--- a/docs/api/pulp_smash.tests.docker.cli.test_crud.rst
+++ b/docs/api/pulp_smash.tests.docker.cli.test_crud.rst
@@ -1,7 +1,0 @@
-`pulp_smash.tests.docker.cli.test_crud`
-=======================================
-
-Location: :doc:`/index` → :doc:`/api` →
-:doc:`/api/pulp_smash.tests.docker.cli.test_crud`
-
-.. automodule:: pulp_smash.tests.docker.cli.test_crud

--- a/docs/api/pulp_smash.tests.docker.cli.test_sync_publish.rst
+++ b/docs/api/pulp_smash.tests.docker.cli.test_sync_publish.rst
@@ -1,7 +1,0 @@
-`pulp_smash.tests.docker.cli.test_sync_publish`
-===============================================
-
-Location: :doc:`/index` → :doc:`/api` →
-:doc:`/api/pulp_smash.tests.docker.cli.test_sync_publish`
-
-.. automodule:: pulp_smash.tests.docker.cli.test_sync_publish

--- a/docs/api/pulp_smash.tests.docker.cli.utils.rst
+++ b/docs/api/pulp_smash.tests.docker.cli.utils.rst
@@ -1,7 +1,0 @@
-`pulp_smash.tests.docker.cli.utils`
-===================================
-
-Location: :doc:`/index` → :doc:`/api` →
-:doc:`/api/pulp_smash.tests.docker.cli.utils`
-
-.. automodule:: pulp_smash.tests.docker.cli.utils

--- a/docs/api/pulp_smash.tests.docker.rst
+++ b/docs/api/pulp_smash.tests.docker.rst
@@ -1,6 +1,0 @@
-`pulp_smash.tests.docker`
-=========================
-
-Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.docker`
-
-.. automodule:: pulp_smash.tests.docker

--- a/docs/api/pulp_smash.tests.docker.utils.rst
+++ b/docs/api/pulp_smash.tests.docker.utils.rst
@@ -1,6 +1,0 @@
-`pulp_smash.tests.docker.utils`
-===============================
-
-Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.docker.utils`
-
-.. automodule:: pulp_smash.tests.docker.utils

--- a/docs/api/pulp_smash.tests.ostree.api_v2.rst
+++ b/docs/api/pulp_smash.tests.ostree.api_v2.rst
@@ -1,6 +1,0 @@
-`pulp_smash.tests.ostree.api_v2`
-================================
-
-Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.ostree.api_v2`
-
-.. automodule:: pulp_smash.tests.ostree.api_v2

--- a/docs/api/pulp_smash.tests.ostree.api_v2.test_crud.rst
+++ b/docs/api/pulp_smash.tests.ostree.api_v2.test_crud.rst
@@ -1,7 +1,0 @@
-`pulp_smash.tests.ostree.api_v2.test_crud`
-==========================================
-
-Location: :doc:`/index` → :doc:`/api` →
-:doc:`/api/pulp_smash.tests.ostree.api_v2.test_crud`
-
-.. automodule:: pulp_smash.tests.ostree.api_v2.test_crud

--- a/docs/api/pulp_smash.tests.ostree.api_v2.test_sync_publish.rst
+++ b/docs/api/pulp_smash.tests.ostree.api_v2.test_sync_publish.rst
@@ -1,7 +1,0 @@
-`pulp_smash.tests.ostree.api_v2.test_sync_publish`
-==================================================
-
-Location: :doc:`/index` → :doc:`/api` →
-:doc:`/api/pulp_smash.tests.ostree.api_v2.test_sync_publish`
-
-.. automodule:: pulp_smash.tests.ostree.api_v2.test_sync_publish

--- a/docs/api/pulp_smash.tests.ostree.rst
+++ b/docs/api/pulp_smash.tests.ostree.rst
@@ -1,6 +1,0 @@
-`pulp_smash.tests.ostree`
-=========================
-
-Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.ostree`
-
-.. automodule:: pulp_smash.tests.ostree

--- a/docs/api/pulp_smash.tests.ostree.utils.rst
+++ b/docs/api/pulp_smash.tests.ostree.utils.rst
@@ -1,6 +1,0 @@
-`pulp_smash.tests.ostree.utils`
-===============================
-
-Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.ostree.utils`
-
-.. automodule:: pulp_smash.tests.ostree.utils

--- a/docs/api/pulp_smash.tests.platform.api_v2.rst
+++ b/docs/api/pulp_smash.tests.platform.api_v2.rst
@@ -1,7 +1,0 @@
-`pulp_smash.tests.platform.api_v2`
-==================================
-
-Location: :doc:`/index` → :doc:`/api` →
-:doc:`/api/pulp_smash.tests.platform.api_v2`
-
-.. automodule:: pulp_smash.tests.platform.api_v2

--- a/docs/api/pulp_smash.tests.platform.api_v2.test_consumer.rst
+++ b/docs/api/pulp_smash.tests.platform.api_v2.test_consumer.rst
@@ -1,7 +1,0 @@
-`pulp_smash.tests.platform.api_v2.test_consumer`
-================================================
-
-Location: :doc:`/index` → :doc:`/api` →
-:doc:`/api/pulp_smash.tests.platform.api_v2.test_consumer`
-
-.. automodule:: pulp_smash.tests.platform.api_v2.test_consumer

--- a/docs/api/pulp_smash.tests.platform.api_v2.test_content_applicability.rst
+++ b/docs/api/pulp_smash.tests.platform.api_v2.test_content_applicability.rst
@@ -1,7 +1,0 @@
-`pulp_smash.tests.platform.api_v2.test_content_applicability`
-=============================================================
-
-Location: :doc:`/index` → :doc:`/api` →
-:doc:`/api/pulp_smash.tests.platform.api_v2.test_content_applicability`
-
-.. automodule:: pulp_smash.tests.platform.api_v2.test_content_applicability

--- a/docs/api/pulp_smash.tests.platform.api_v2.test_login.rst
+++ b/docs/api/pulp_smash.tests.platform.api_v2.test_login.rst
@@ -1,7 +1,0 @@
-`pulp_smash.tests.platform.api_v2.test_login`
-=============================================
-
-Location: :doc:`/index` → :doc:`/api` →
-:doc:`pulp_smash.tests.platform.api_v2.test_login`
-
-.. automodule:: pulp_smash.tests.platform.api_v2.test_login

--- a/docs/api/pulp_smash.tests.platform.api_v2.test_repository.rst
+++ b/docs/api/pulp_smash.tests.platform.api_v2.test_repository.rst
@@ -1,7 +1,0 @@
-`pulp_smash.tests.platform.api_v2.test_repository`
-==================================================
-
-Location: :doc:`/index` → :doc:`/api` →
-:doc:`pulp_smash.tests.platform.api_v2.test_repository`
-
-.. automodule:: pulp_smash.tests.platform.api_v2.test_repository

--- a/docs/api/pulp_smash.tests.platform.api_v2.test_search.rst
+++ b/docs/api/pulp_smash.tests.platform.api_v2.test_search.rst
@@ -1,7 +1,0 @@
-`pulp_smash.tests.platform.api_v2.test_search`
-==============================================
-
-Location: :doc:`/index` → :doc:`/api` →
-:doc:`pulp_smash.tests.platform.api_v2.test_search`
-
-.. automodule:: pulp_smash.tests.platform.api_v2.test_search

--- a/docs/api/pulp_smash.tests.platform.api_v2.test_user.rst
+++ b/docs/api/pulp_smash.tests.platform.api_v2.test_user.rst
@@ -1,7 +1,0 @@
-`pulp_smash.tests.platform.api_v2.test_user`
-============================================
-
-Location: :doc:`/index` → :doc:`/api` →
-:doc:`pulp_smash.tests.platform.api_v2.test_user`
-
-.. automodule:: pulp_smash.tests.platform.api_v2.test_user

--- a/docs/api/pulp_smash.tests.platform.rst
+++ b/docs/api/pulp_smash.tests.platform.rst
@@ -1,6 +1,0 @@
-`pulp_smash.tests.platform`
-===========================
-
-Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.platform`
-
-.. automodule:: pulp_smash.tests.platform

--- a/docs/api/pulp_smash.tests.puppet.api_v2.rst
+++ b/docs/api/pulp_smash.tests.puppet.api_v2.rst
@@ -1,6 +1,0 @@
-`pulp_smash.tests.puppet.api_v2`
-================================
-
-Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.puppet.api_v2`
-
-.. automodule:: pulp_smash.tests.puppet.api_v2

--- a/docs/api/pulp_smash.tests.puppet.api_v2.test_sync_publish.rst
+++ b/docs/api/pulp_smash.tests.puppet.api_v2.test_sync_publish.rst
@@ -1,7 +1,0 @@
-`pulp_smash.tests.puppet.api_v2.test_sync_publish`
-==================================================
-
-Location: :doc:`/index` → :doc:`/api` →
-:doc:`/api/pulp_smash.tests.puppet.api_v2.test_sync_publish`
-
-.. automodule:: pulp_smash.tests.puppet.api_v2.test_sync_publish

--- a/docs/api/pulp_smash.tests.puppet.rst
+++ b/docs/api/pulp_smash.tests.puppet.rst
@@ -1,6 +1,0 @@
-`pulp_smash.tests.puppet`
-=========================
-
-Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.puppet`
-
-.. automodule:: pulp_smash.tests.puppet

--- a/docs/api/pulp_smash.tests.puppet.utils.rst
+++ b/docs/api/pulp_smash.tests.puppet.utils.rst
@@ -1,6 +1,0 @@
-`pulp_smash.tests.puppet.utils`
-===============================
-
-Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.puppet.utils`
-
-.. automodule:: pulp_smash.tests.puppet.utils

--- a/docs/api/pulp_smash.tests.rpm.api_v2.rst
+++ b/docs/api/pulp_smash.tests.rpm.api_v2.rst
@@ -1,6 +1,0 @@
-`pulp_smash.tests.rpm.api_v2`
-=============================
-
-Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.rpm.api_v2`
-
-.. automodule:: pulp_smash.tests.rpm.api_v2

--- a/docs/api/pulp_smash.tests.rpm.api_v2.test_broker.rst
+++ b/docs/api/pulp_smash.tests.rpm.api_v2.test_broker.rst
@@ -1,7 +1,0 @@
-`pulp_smash.tests.rpm.api_v2.test_broker`
-=========================================
-
-Location: :doc:`/index` → :doc:`/api` →
-:doc:`/api/pulp_smash.tests.rpm.api_v2.test_broker`
-
-.. automodule:: pulp_smash.tests.rpm.api_v2.test_broker

--- a/docs/api/pulp_smash.tests.rpm.api_v2.test_comps_groups.rst
+++ b/docs/api/pulp_smash.tests.rpm.api_v2.test_comps_groups.rst
@@ -1,7 +1,0 @@
-`pulp_smash.tests.rpm.api_v2.test_comps_groups`
-===============================================
-
-Location: :doc:`/index` → :doc:`/api` →
-:doc:`/api/pulp_smash.tests.rpm.api_v2.test_comps_groups`
-
-.. automodule:: pulp_smash.tests.rpm.api_v2.test_comps_groups

--- a/docs/api/pulp_smash.tests.rpm.api_v2.test_download_policies.rst
+++ b/docs/api/pulp_smash.tests.rpm.api_v2.test_download_policies.rst
@@ -1,7 +1,0 @@
-`pulp_smash.tests.rpm.api_v2.test_download_policies`
-====================================================
-
-Location: :doc:`/index` → :doc:`/api` →
-:doc:`/api/pulp_smash.tests.rpm.api_v2.test_download_policies`
-
-.. automodule:: pulp_smash.tests.rpm.api_v2.test_download_policies

--- a/docs/api/pulp_smash.tests.rpm.api_v2.test_duplicate_uploads.rst
+++ b/docs/api/pulp_smash.tests.rpm.api_v2.test_duplicate_uploads.rst
@@ -1,7 +1,0 @@
-`pulp_smash.tests.rpm.api_v2.test_duplicate_uploads`
-====================================================
-
-Location: :doc:`/index` → :doc:`/api` →
-:doc:`/api/pulp_smash.tests.rpm.api_v2.test_duplicate_uploads`
-
-.. automodule:: pulp_smash.tests.rpm.api_v2.test_duplicate_uploads

--- a/docs/api/pulp_smash.tests.rpm.api_v2.test_export.rst
+++ b/docs/api/pulp_smash.tests.rpm.api_v2.test_export.rst
@@ -1,7 +1,0 @@
-`pulp_smash.tests.rpm.api_v2.test_export`
-=========================================
-
-Location: :doc:`/index` → :doc:`/api` →
-:doc:`/api/pulp_smash.tests.rpm.api_v2.test_export`
-
-.. automodule:: pulp_smash.tests.rpm.api_v2.test_export

--- a/docs/api/pulp_smash.tests.rpm.api_v2.test_iso_crud.rst
+++ b/docs/api/pulp_smash.tests.rpm.api_v2.test_iso_crud.rst
@@ -1,7 +1,0 @@
-`pulp_smash.tests.rpm.api_v2.test_iso_crud`
-===========================================
-
-Location: :doc:`/index` → :doc:`/api` →
-:doc:`/api/pulp_smash.tests.rpm.api_v2.test_iso_crud`
-
-.. automodule:: pulp_smash.tests.rpm.api_v2.test_iso_crud

--- a/docs/api/pulp_smash.tests.rpm.api_v2.test_orphan_remove.rst
+++ b/docs/api/pulp_smash.tests.rpm.api_v2.test_orphan_remove.rst
@@ -1,7 +1,0 @@
-`pulp_smash.tests.rpm.api_v2.test_orphan_remove`
-================================================
-
-Location: :doc:`/index` → :doc:`/api` →
-:doc:`/api/pulp_smash.tests.rpm.api_v2.test_orphan_remove`
-
-.. automodule:: pulp_smash.tests.rpm.api_v2.test_orphan_remove

--- a/docs/api/pulp_smash.tests.rpm.api_v2.test_remove_unit.rst
+++ b/docs/api/pulp_smash.tests.rpm.api_v2.test_remove_unit.rst
@@ -1,7 +1,0 @@
-`pulp_smash.tests.rpm.api_v2.test_remove_unit`
-==============================================
-
-Location: :doc:`/index` → :doc:`/api` →
-:doc:`/api/pulp_smash.tests.rpm.api_v2.test_remove_unit`
-
-.. automodule:: pulp_smash.tests.rpm.api_v2.test_remove_unit

--- a/docs/api/pulp_smash.tests.rpm.api_v2.test_repomd.rst
+++ b/docs/api/pulp_smash.tests.rpm.api_v2.test_repomd.rst
@@ -1,7 +1,0 @@
-`pulp_smash.tests.rpm.api_v2.test_repomd`
-=========================================
-
-Location: :doc:`/index` → :doc:`/api` →
-:doc:`/api/pulp_smash.tests.rpm.api_v2.test_repomd`
-
-.. automodule:: pulp_smash.tests.rpm.api_v2.test_repomd

--- a/docs/api/pulp_smash.tests.rpm.api_v2.test_republish.rst
+++ b/docs/api/pulp_smash.tests.rpm.api_v2.test_republish.rst
@@ -1,7 +1,0 @@
-`pulp_smash.tests.rpm.api_v2.test_republish`
-============================================
-
-Location: :doc:`/index` → :doc:`/api` →
-:doc:`/api/pulp_smash.tests.rpm.api_v2.test_republish`
-
-.. automodule:: pulp_smash.tests.rpm.api_v2.test_republish

--- a/docs/api/pulp_smash.tests.rpm.api_v2.test_retain_old_count.rst
+++ b/docs/api/pulp_smash.tests.rpm.api_v2.test_retain_old_count.rst
@@ -1,7 +1,0 @@
-`pulp_smash.tests.rpm.api_v2.test_retain_old_count`
-===================================================
-
-Location: :doc:`/index` → :doc:`/api` →
-:doc:`/api/pulp_smash.tests.rpm.api_v2.test_retain_old_count`
-
-.. automodule:: pulp_smash.tests.rpm.api_v2.test_retain_old_count

--- a/docs/api/pulp_smash.tests.rpm.api_v2.test_schedule_publish.rst
+++ b/docs/api/pulp_smash.tests.rpm.api_v2.test_schedule_publish.rst
@@ -1,7 +1,0 @@
-`pulp_smash.tests.rpm.api_v2.test_schedule_publish`
-===================================================
-
-Location: :doc:`/index` → :doc:`/api` →
-:doc:`/api/pulp_smash.tests.rpm.api_v2.test_schedule_publish`
-
-.. automodule:: pulp_smash.tests.rpm.api_v2.test_schedule_publish

--- a/docs/api/pulp_smash.tests.rpm.api_v2.test_schedule_sync.rst
+++ b/docs/api/pulp_smash.tests.rpm.api_v2.test_schedule_sync.rst
@@ -1,7 +1,0 @@
-`pulp_smash.tests.rpm.api_v2.test_schedule_sync`
-================================================
-
-Location: :doc:`/index` → :doc:`/api` →
-:doc:`/api/pulp_smash.tests.rpm.api_v2.test_schedule_sync`
-
-.. automodule:: pulp_smash.tests.rpm.api_v2.test_schedule_sync

--- a/docs/api/pulp_smash.tests.rpm.api_v2.test_sync_publish.rst
+++ b/docs/api/pulp_smash.tests.rpm.api_v2.test_sync_publish.rst
@@ -1,7 +1,0 @@
-`pulp_smash.tests.rpm.api_v2.test_sync_publish`
-===============================================
-
-Location: :doc:`/index` → :doc:`/api` →
-:doc:`/api/pulp_smash.tests.rpm.api_v2.test_sync_publish`
-
-.. automodule:: pulp_smash.tests.rpm.api_v2.test_sync_publish

--- a/docs/api/pulp_smash.tests.rpm.api_v2.test_unassociate.rst
+++ b/docs/api/pulp_smash.tests.rpm.api_v2.test_unassociate.rst
@@ -1,7 +1,0 @@
-`pulp_smash.tests.rpm.api_v2.test_unassociate`
-==============================================
-
-Location: :doc:`/index` → :doc:`/api` →
-:doc:`/api/pulp_smash.tests.rpm.api_v2.test_unassociate`
-
-.. automodule:: pulp_smash.tests.rpm.api_v2.test_unassociate

--- a/docs/api/pulp_smash.tests.rpm.api_v2.test_updateinfo.rst
+++ b/docs/api/pulp_smash.tests.rpm.api_v2.test_updateinfo.rst
@@ -1,7 +1,0 @@
-`pulp_smash.tests.rpm.api_v2.test_updateinfo`
-=============================================
-
-Location: :doc:`/index` → :doc:`/api` →
-:doc:`/api/pulp_smash.tests.rpm.api_v2.test_updateinfo`
-
-.. automodule:: pulp_smash.tests.rpm.api_v2.test_updateinfo

--- a/docs/api/pulp_smash.tests.rpm.api_v2.utils.rst
+++ b/docs/api/pulp_smash.tests.rpm.api_v2.utils.rst
@@ -1,7 +1,0 @@
-`pulp_smash.tests.rpm.api_v2.utils`
-===================================
-
-Location: :doc:`/index` → :doc:`/api` →
-:doc:`/api/pulp_smash.tests.rpm.api_v2.utils`
-
-.. automodule:: pulp_smash.tests.rpm.api_v2.utils

--- a/docs/api/pulp_smash.tests.rpm.rst
+++ b/docs/api/pulp_smash.tests.rpm.rst
@@ -1,6 +1,0 @@
-`pulp_smash.tests.rpm`
-======================
-
-Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.rpm`
-
-.. automodule:: pulp_smash.tests.rpm

--- a/docs/api/pulp_smash.tests.rpm.utils.rst
+++ b/docs/api/pulp_smash.tests.rpm.utils.rst
@@ -1,6 +1,0 @@
-`pulp_smash.tests.rpm.utils`
-===============================
-
-Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.rpm.utils`
-
-.. automodule:: pulp_smash.tests.rpm.utils

--- a/docs/api/pulp_smash.tests.rst
+++ b/docs/api/pulp_smash.tests.rst
@@ -1,6 +1,0 @@
-`pulp_smash.tests`
-==================
-
-Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests`
-
-.. automodule:: pulp_smash.tests

--- a/docs/api/pulp_smash.utils.rst
+++ b/docs/api/pulp_smash.utils.rst
@@ -1,6 +1,0 @@
-`pulp_smash.utils`
-==================
-
-Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.utils`
-
-.. automodule:: pulp_smash.utils

--- a/docs/api/tests.rst
+++ b/docs/api/tests.rst
@@ -1,6 +1,0 @@
-`tests`
-=======
-
-Location: :doc:`/index` → :doc:`/api` → :doc:`/api/tests`
-
-.. automodule:: tests

--- a/docs/api/tests.test_api.rst
+++ b/docs/api/tests.test_api.rst
@@ -1,6 +1,0 @@
-`tests.test_api`
-================
-
-Location: :doc:`/index` → :doc:`/api` → :doc:`/api/tests.test_api`
-
-.. automodule:: tests.test_api

--- a/docs/api/tests.test_cli.rst
+++ b/docs/api/tests.test_cli.rst
@@ -1,6 +1,0 @@
-`tests.test_cli`
-================
-
-Location: :doc:`/index` → :doc:`/api` → :doc:`/api/tests.test_cli`
-
-.. automodule:: tests.test_cli

--- a/docs/api/tests.test_config.rst
+++ b/docs/api/tests.test_config.rst
@@ -1,6 +1,0 @@
-`tests.test_config`
-===================
-
-Location: :doc:`/index` → :doc:`/api` → :doc:`/api/tests.test_config`
-
-.. automodule:: tests.test_config

--- a/docs/api/tests.test_selectors.rst
+++ b/docs/api/tests.test_selectors.rst
@@ -1,6 +1,0 @@
-`tests.test_selectors`
-======================
-
-Location: :doc:`/index` → :doc:`/api` → :doc:`/api/tests.test_selectors`
-
-.. automodule:: tests.test_selectors

--- a/docs/api/tests.test_utils.rst
+++ b/docs/api/tests.test_utils.rst
@@ -1,6 +1,0 @@
-`tests.test_utils`
-==================
-
-Location: :doc:`/index` → :doc:`/api` → :doc:`/api/tests.test_utils`
-
-.. automodule:: tests.test_utils

--- a/gen_api_docs.sh
+++ b/gen_api_docs.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# For each file found by `find`, generate a reStructuredText document in
+# `docs/api/`.
+#
+set -euo pipefail
+
+find pulp_smash/ tests/ -type f -name '*.py' | while read file_name; do
+    # Transform file names to python module names. For example:
+    #
+    #     tests/__init__.py → tests
+    #     tests/test_api.py → tests.test_api
+    #
+    # Note that file_name has no leading "./", as we omit it in find, above.
+    module_name="${file_name%.py}"
+    module_name="${module_name%/__init__}"
+    module_name="${module_name//\//.}"
+
+    # Generate stub *.rst file. (Tip: ${#foo} returns the length of foo.)
+    cat >"docs/api/${module_name}.rst" <<EOF
+\`${module_name}\`
+$(printf %${#module_name}s | tr ' ' =)==
+
+Location: :doc:\`/index\` → :doc:\`/api\` → :doc:\`/api/${module_name}\`
+
+.. automodule:: ${module_name}
+EOF
+done


### PR DESCRIPTION
Create script `gen_api_docs.sh`. It uses the "find" utility to search
through the `pulp_smash` and `tests` directories and, for each file
found, generates a reStructuredText document in `docs/api/`. The
generated documents are semantically identical to what is present in
`docs/api/` already.

Also:

* Update the `docs-html` make target, and make it call this new script
  before Sphinx itself.
* Make git keep the `docs/api/` directory.
* Make git ignore the reST files the script places in `docs/api/`.
* Add module `pulp_smash.__main__` to the API documentation.

How does this solution compare the current state of affairs? One
downside is that developers still must maintain the index, in
`docs/api.rst`, of all modules to be included in the API documentation.
However, there are several benefits:

* reST files no longer need to be maintained in `docs/api/*`.
* Sphinx issues a warning if the index (in `docs/api.rst`) is out of
  sync with the set of reST stubs and, therefore, the set of modules in
  the application. This has already come in to play: module
  `pulp_smash/__main__` was missing from the API documentation, and it
  has been added in response to this warning.
* It is now much easier to update the API documentation pages, as there
  is now only one template, instead of dozens.

Two alternative solutions were considered. One option is to use
`sphinx-apidoc` to generate reST files, instead of this custom script.
Unfortunately, the reST files emitted by this script are unsatisfactory,
and it is impossible to make this script use a custom template. A second
option is to use the `autosummary` Sphinx directive in `docs/api.rst`
like so:

    .. autosummary::
        :toctree: api

        pulp_smash
        pulp_smash.__main__
        pulp_smash.api
        pulp_smash.cli
        …

One can then ask the `sphinx-autogen` script to generate one reST file
for each module listed. While this works, there are more downsides:

* The `sphinx-autogen` script names imports (!) in the reST files it
  generates. This is nonsensical and generates a tremendous number of
  warnings.
* The `autosummary` Sphinx directive emits tables, instead of lists.
  While arguably useful, tabulated output is much more verbose, which
  reduces legibility and makes it harder to scan through the list of
  modules. In addition, this cannot be overridden.
* Because the `autosummary` directive drives which reST files are
  generated, it is easy for the documentation to become out of sync with
  the actual set of modules which should be documented.

Fix https://github.com/PulpQE/pulp-smash/issues/18