### PR TITLE
Add module to API docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -45,6 +45,7 @@ developers, not a gospel.
     api/pulp_smash.tests.puppet
     api/pulp_smash.tests.puppet.api_v2
     api/pulp_smash.tests.puppet.api_v2.test_sync_publish
+    api/pulp_smash.tests.puppet.api_v2.utils
     api/pulp_smash.tests.puppet.utils
     api/pulp_smash.tests.rpm
     api/pulp_smash.tests.rpm.api_v2


### PR DESCRIPTION
Add module `pulp_smash.tests.puppet.api_v2.utils` to API docs. This
should have been done in 6cd0dae698ac44d8b31281d38267421c7eb66e5d.