### PR TITLE
Unify and expand CRUD testing

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -44,6 +44,7 @@ developers, not a gospel.
     api/pulp_smash.tests.platform.api_v2.test_user
     api/pulp_smash.tests.puppet
     api/pulp_smash.tests.puppet.api_v2
+    api/pulp_smash.tests.puppet.api_v2.test_crud
     api/pulp_smash.tests.puppet.api_v2.test_duplicate_uploads
     api/pulp_smash.tests.puppet.api_v2.test_sync_publish
     api/pulp_smash.tests.puppet.api_v2.utils

--- a/docs/api/pulp_smash.tests.puppet.api_v2.test_crud.rst
+++ b/docs/api/pulp_smash.tests.puppet.api_v2.test_crud.rst
@@ -1,0 +1,6 @@
+`pulp_smash.tests.puppet.api_v2.test_crud`
+==========================================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.puppet.api_v2.test_crud`
+
+.. automodule:: pulp_smash.tests.puppet.api_v2.test_crud

--- a/pulp_smash/tests/docker/api_v2/test_crud.py
+++ b/pulp_smash/tests/docker/api_v2/test_crud.py
@@ -10,10 +10,17 @@ import unittest2
 
 from packaging.version import Version
 
-from pulp_smash import api, utils
+from pulp_smash import api, config, utils
 from pulp_smash.compat import urljoin
 from pulp_smash.constants import REPOSITORY_PATH
-from pulp_smash.tests.docker.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.docker.utils import set_up_module
+
+
+def setUpModule():  # pylint:disable=invalid-name
+    """Skip tests on Pulp versions lower than 2.8."""
+    set_up_module()
+    if config.get_config().version < Version('2.8'):
+        raise unittest2.SkipTest('These tests require at least Pulp 2.8.')
 
 
 def _gen_docker_repo_body():
@@ -41,18 +48,7 @@ def _gen_distributor():
     }
 
 
-class _BaseTestCase(utils.BaseAPITestCase):
-    """Provide logic common to docker test cases."""
-
-    @classmethod
-    def setUpClass(cls):
-        """Skip tests if the targeted Pulp system is older than version 2.8."""
-        super(_BaseTestCase, cls).setUpClass()
-        if cls.cfg.version < Version('2.8'):
-            raise unittest2.SkipTest('These tests require at least Pulp 2.8.')
-
-
-class CreateTestCase(_BaseTestCase):
+class CreateTestCase(utils.BaseAPITestCase):
     """Create two Docker repos, with and without feed URLs respectively."""
 
     @classmethod
@@ -102,7 +98,7 @@ class CreateTestCase(_BaseTestCase):
                 self.assertEqual(body['importer_' + key], importers[0][key])
 
 
-class UpdateTestCase(_BaseTestCase):
+class UpdateTestCase(utils.BaseAPITestCase):
     """Show it is possible to update a distributor for a docker repository."""
 
     @classmethod

--- a/pulp_smash/tests/puppet/api_v2/test_crud.py
+++ b/pulp_smash/tests/puppet/api_v2/test_crud.py
@@ -1,0 +1,21 @@
+# coding=utf-8
+"""Tests that CRUD Puppet repositories."""
+from __future__ import unicode_literals
+
+from pulp_smash import utils
+from pulp_smash.tests.puppet.api_v2.utils import gen_repo
+from pulp_smash.tests.puppet.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+
+
+class CRUDTestCase(utils.BaseAPICrudTestCase):
+    """Test that one can create, update, read and delete a test case."""
+
+    @staticmethod
+    def create_body():
+        """Return a dict for creating a repository."""
+        return gen_repo()
+
+    @staticmethod
+    def update_body():
+        """Return a dict for creating a repository."""
+        return {'delta': {'display_name': utils.uuid4()}}

--- a/pulp_smash/tests/python/api_v2/test_crud.py
+++ b/pulp_smash/tests/python/api_v2/test_crud.py
@@ -2,67 +2,20 @@
 """Tests that CRUD Python repositories."""
 from __future__ import unicode_literals
 
-from pulp_smash import api, utils
-from pulp_smash.constants import REPOSITORY_PATH
+from pulp_smash import utils
 from pulp_smash.tests.python.api_v2.utils import gen_repo
 from pulp_smash.tests.python.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 
-class CRUDTestCase(utils.BaseAPITestCase):
-    """Test that one can create, read, update and delete a test case.
+class CRUDTestCase(utils.BaseAPICrudTestCase):
+    """Test that one can create, update, read and delete a test case."""
 
-    See:
+    @staticmethod
+    def create_body():
+        """Return a dict for creating a repository."""
+        return gen_repo()
 
-    Create
-        http://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/repo/cud.html#create-a-repository
-    Read
-        http://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/repo/retrieval.html#retrieve-a-single-repository
-    Update
-        http://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/repo/cud.html#update-a-repository
-    Delete
-        http://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/repo/cud.html#delete-a-repository
-    """
-
-    @classmethod
-    def setUpClass(cls):
-        """Create, update, read and delete a minimal Python repository."""
-        super(CRUDTestCase, cls).setUpClass()
-        client = api.Client(cls.cfg)
-        cls.bodies = (gen_repo(), {'delta': {'display_name': utils.uuid4()}})
-        cls.responses = {}
-        cls.responses['create'] = client.post(REPOSITORY_PATH, cls.bodies[0])
-        repo_href = cls.responses['create'].json()['_href']
-        cls.responses['update'] = client.put(repo_href, cls.bodies[1])
-        cls.responses['read'] = client.get(repo_href)
-        cls.responses['delete'] = client.delete(repo_href)
-
-    def test_status_codes(self):
-        """Assert each response has a correct status code."""
-        for response, code in (
-                ('create', 201),
-                ('update', 200),
-                ('read', 200),
-                ('delete', 202)):
-            with self.subTest((response, code)):
-                self.assertEqual(self.responses[response].status_code, code)
-
-    def test_create(self):
-        """Assert the repo create response has a correct repo ID."""
-        self.assertEqual(
-            self.bodies[0]['id'],
-            self.responses['create'].json()['id'],
-        )
-
-    def test_update(self):
-        """Assert the repo update response has the requested changes."""
-        self.assertEqual(
-            self.bodies[1]['delta']['display_name'],
-            self.responses['update'].json()['result']['display_name'],
-        )
-
-    def test_read(self):
-        """Assert the repo update response has the requested changes."""
-        self.assertEqual(
-            self.bodies[1]['delta']['display_name'],
-            self.responses['read'].json()['display_name'],
-        )
+    @staticmethod
+    def update_body():
+        """Return a dict for creating a repository."""
+        return {'delta': {'display_name': utils.uuid4()}}


### PR DESCRIPTION
Create a new class, `pulp_smash.utils.BaseAPICrudTestCase`, use it for all CRUD tests, and add Puppet CRUD tests. This new base test case ships with seven test methods, so the number of tests is greatly expanded. And if we want to add any new test coverage or edit the existing test, it'll be much easier to do so now.

This PR is split in to three commits for the purpose of logically separating several different tasks.