### PR TITLE
Add http_get util function

### DIFF
--- a/pulp_smash/api.py
+++ b/pulp_smash/api.py
@@ -15,7 +15,7 @@ from time import sleep
 import requests
 
 from pulp_smash import exceptions
-from pulp_smash.compat import urljoin
+from pulp_smash.compat import urljoin, urlparse
 
 
 _SENTINEL = object()
@@ -287,6 +287,18 @@ class Client(object):
         request_kwargs = self.request_kwargs.copy()
         request_kwargs['url'] = urljoin(request_kwargs['url'], url)
         request_kwargs.update(kwargs)
+        config_host = urlparse(self._cfg.base_url).netloc
+        request_host = urlparse(request_kwargs['url']).netloc
+        if request_host != config_host:
+            warnings.warn(
+                'This client is configured to make HTTP requests to {0}, but '
+                'a request is being made to {1}. The request will be made, '
+                'but some options may be incorrect. For example, an incorrect '
+                'SSL certificate may be specified with the `verify` option. '
+                'Request options: {2}'
+                .format(config_host, request_host, request_kwargs),
+                RuntimeWarning
+            )
         return self.response_handler(
             self._cfg,
             requests.request(method, **request_kwargs),

--- a/pulp_smash/tests/puppet/api_v2/test_duplicate_uploads.py
+++ b/pulp_smash/tests/puppet/api_v2/test_duplicate_uploads.py
@@ -54,7 +54,7 @@ class DuplicateUploadsTestCase(utils.BaseAPITestCase):
 
         # Download content.
         client = api.Client(cls.cfg)
-        puppet_module = client.get(PUPPET_MODULE_URL).content
+        puppet_module = utils.http_get(PUPPET_MODULE_URL)
 
         # Create a feed-less repository.
         client.response_handler = api.json_handler

--- a/pulp_smash/tests/puppet/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/puppet/api_v2/test_sync_publish.py
@@ -270,7 +270,7 @@ class PublishTestCase(utils.BaseAPITestCase):
         for repo in repos:
             cls.resources.add(repo['_href'])
         client.response_handler = api.safe_handler
-        cls.modules.append(client.get(PUPPET_MODULE_URL).content)
+        cls.modules.append(utils.http_get(PUPPET_MODULE_URL))
 
         # Begin an upload request, upload a puppet module, move the puppet
         # module into a repository, and end the upload request.

--- a/pulp_smash/tests/python/api_v2/test_duplicate_uploads.py
+++ b/pulp_smash/tests/python/api_v2/test_duplicate_uploads.py
@@ -54,7 +54,7 @@ class DuplicateUploadsTestCase(utils.BaseAPITestCase):
 
         # Download content.
         client = api.Client(cls.cfg)
-        python_package = client.get(PYTHON_EGG_URL).content
+        python_package = utils.http_get(PYTHON_EGG_URL)
 
         # Create a feed-less repository.
         client.response_handler = api.json_handler

--- a/pulp_smash/tests/rpm/api_v2/test_broker.py
+++ b/pulp_smash/tests/rpm/api_v2/test_broker.py
@@ -125,5 +125,5 @@ class BrokerTestCase(unittest2.TestCase):
         pulp_rpm = client.get(url).content
 
         # Does this RPM match the original RPM?
-        rpm = client.get(urljoin(RPM_FEED_URL, RPM)).content
+        rpm = utils.http_get(urljoin(RPM_FEED_URL, RPM))
         self.assertEqual(rpm, pulp_rpm)

--- a/pulp_smash/tests/rpm/api_v2/test_duplicate_uploads.py
+++ b/pulp_smash/tests/rpm/api_v2/test_duplicate_uploads.py
@@ -58,7 +58,7 @@ class DuplicateUploadsTestCase(utils.BaseAPITestCase):
 
         # Download content.
         client = api.Client(cls.cfg)
-        cls.rpm = client.get(urljoin(RPM_FEED_URL, RPM)).content
+        cls.rpm = utils.http_get(urljoin(RPM_FEED_URL, RPM))
 
         # Create a feed-less repository.
         client = api.Client(cls.cfg, api.json_handler)

--- a/pulp_smash/tests/rpm/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_sync_publish.py
@@ -240,7 +240,7 @@ class PublishTestCase(utils.BaseAPITestCase):
         for repo in repos:
             cls.resources.add(repo['_href'])
         client.response_handler = api.safe_handler
-        cls.rpms.append(client.get(urljoin(RPM_FEED_URL, RPM)).content)
+        cls.rpms.append(utils.http_get(urljoin(RPM_FEED_URL, RPM)))
 
         # Begin an upload request, upload an RPM, move the RPM into a
         # repository, and end the upload request.

--- a/pulp_smash/utils.py
+++ b/pulp_smash/utils.py
@@ -8,6 +8,7 @@ from __future__ import unicode_literals
 
 import uuid
 
+import requests
 import unittest2
 
 from pulp_smash import api, cli, config, exceptions
@@ -50,6 +51,20 @@ def get_broker(server_config):
         'to be any of {}.'
         .format(server_config.base_url, executables)
     )
+
+
+def http_get(url, **kwargs):
+    """Issue a HTTP request to the ``url`` and return the response content.
+
+    This is useful for downloading file contents over HTTP[S].
+
+    :param url: the URL where the content should be get.
+    :param kwargs: additional kwargs to be passed to ``requests.get``.
+    :returns: the response content of a GET request to ``url``.
+    """
+    response = requests.get(url, **kwargs)
+    response.raise_for_status()
+    return response.content
 
 
 def reset_pulp(server_config):


### PR DESCRIPTION
The http_get function helps on getting files over HTTP[S], for example getting
the contents of a RPM published over HTTP[S].

Also refactor places where API client was used to get the files. This will
avoid SSL issue when the default server configuration specifies a verify
certificate.

Finally issue a warning on the API client when the user is doing requests to
other host than the one specified by its server config.