### PR TITLE
Test whether updateinfo.xml suggests a reboot

### DIFF
--- a/pulp_smash/tests/rpm/api_v2/test_updateinfo.py
+++ b/pulp_smash/tests/rpm/api_v2/test_updateinfo.py
@@ -241,3 +241,4 @@ class UpdateInfoTestCase(utils.BaseAPITestCase):
         update_element = _get_updates_by_id(self.root_element)[erratum_id]
         reboot_elements = update_element.findall('reboot_suggested')
         self.assertEqual(len(reboot_elements), 1, reboot_elements)
+        self.assertEqual(reboot_elements[0].text, 'False')


### PR DESCRIPTION
If no value is specified for an errata's `reboot_suggested` field, the
errata is uploaded into a repository, and the repository is published,
the repository's `updateinfo.xml` file should not suggest a reboot. The
file's `<reboot_suggested>` tag should have a value of "False".

Add a test for: https://pulp.plan.io/issues/1782

Fix: https://github.com/PulpQE/pulp-smash/issues/214