### PR TITLE
Add missing page to API documentation

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -52,6 +52,7 @@ developers, not a gospel.
     api/pulp_smash.tests.python
     api/pulp_smash.tests.python.api_v2
     api/pulp_smash.tests.python.api_v2.test_crud
+    api/pulp_smash.tests.python.api_v2.test_duplicate_uploads
     api/pulp_smash.tests.python.api_v2.utils
     api/pulp_smash.tests.python.utils
     api/pulp_smash.tests.rpm

--- a/docs/api/pulp_smash.tests.python.api_v2.test_duplicate_uploads.rst
+++ b/docs/api/pulp_smash.tests.python.api_v2.test_duplicate_uploads.rst
@@ -1,0 +1,6 @@
+`pulp_smash.tests.python.api_v2.test_duplicate_uploads`
+=======================================================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.python.api_v2.test_duplicate_uploads`
+
+.. automodule:: pulp_smash.tests.python.api_v2.test_duplicate_uploads


### PR DESCRIPTION
Add module `pulp_smash.test.python.api_v2.test_duplicate_uploads` to the
API documentation. This commit corrects
6dfa9294a6c63a0724e0b5d2dbb68bf7ca885757.