### PR TITLE
Refactor Duplicate Upload Test Cases

### DIFF
--- a/pulp_smash/constants.py
+++ b/pulp_smash/constants.py
@@ -2,6 +2,8 @@
 """Values usable by multiple test modules."""
 from __future__ import unicode_literals
 
+from pulp_smash.compat import urljoin
+
 
 CALL_REPORT_KEYS = frozenset(('error', 'result', 'spawned_tasks'))
 """See: `Call Report`_.
@@ -153,7 +155,7 @@ CONSUMER_PATH = '/pulp/api/v2/consumers/'
 """
 
 RPM = 'bear-4.1-1.noarch.rpm'
-"""The name of an RPM file. See :data:`pulp_smash.constants.RPM_FEED_URL`."""
+"""The name of an RPM file. See :data:`pulp_smash.constants.RPM_URL`."""
 
 RPM_ABS_PATH = (
     '/var/lib/pulp/content/units/rpm/76/78177c241777af22235092f21c3932d'
@@ -162,16 +164,15 @@ RPM_ABS_PATH = (
 """The absolute path to :data:`pulp_smash.constants.RPM` in the filesystem."""
 
 RPM_FEED_URL = 'https://repos.fedorapeople.org/repos/pulp/pulp/demo_repos/zoo/'
-"""The URL to an RPM feed.
-
-This URL, plus :data:`pulp_smash.constants.RPM`, is a URL to an RPM file. (Use
-``urllib.parse.urlparse``.)
-"""
+"""The URL to an RPM feed. See :data:`RPM_URL`."""
 
 RPM_SHA256_CHECKSUM = (
     '7a831f9f90bf4d21027572cb503d20b702de8e8785b02c0397445c2e481d81b3'
 )
 """The sha256 checksum of :data:`pulp_smash.constants.RPM`."""
+
+RPM_URL = urljoin(RPM_FEED_URL, RPM)
+"""The URL to an RPM file. Built from :data:`RPM_FEED_URL` and :data:`RPM`."""
 
 USER_PATH = '/pulp/api/v2/users/'
 """See: `User APIs`_.

--- a/pulp_smash/tests/puppet/api_v2/test_duplicate_uploads.py
+++ b/pulp_smash/tests/puppet/api_v2/test_duplicate_uploads.py
@@ -21,40 +21,21 @@ from pulp_smash.constants import PUPPET_MODULE_URL, REPOSITORY_PATH
 from pulp_smash.tests.puppet.api_v2.utils import gen_repo
 
 
-class DuplicateUploadsTestCase(utils.BaseAPITestCase):
-    """Test how well Pulp can deal with duplicate uploads."""
+class DuplicateUploadsTestCase(
+        utils.BaseAPITestCase,
+        utils.DuplicateUploadsMixin):
+    """Test how well Pulp can deal with duplicate content unit uploads."""
 
     @classmethod
     def setUpClass(cls):
         """Create a Puppet repository. Upload a Puppet module into it twice."""
         super(DuplicateUploadsTestCase, cls).setUpClass()
-
-        # Download content.
-        client = api.Client(cls.cfg)
-        puppet_module = utils.http_get(PUPPET_MODULE_URL)
-
-        # Create a feed-less repository.
-        client.response_handler = api.json_handler
-        repo = client.post(REPOSITORY_PATH, gen_repo())
-        cls.resources.add(repo['_href'])
-
-        # Upload and import the puppet module into the repository, twice.
+        unit = utils.http_get(PUPPET_MODULE_URL)
+        unit_type_id = 'puppet_module'
+        client = api.Client(cls.cfg, api.json_handler)
+        repo_href = client.post(REPOSITORY_PATH, gen_repo())['_href']
+        cls.resources.add(repo_href)
         cls.call_reports = tuple((
-            utils.upload_import_unit(
-                cls.cfg,
-                puppet_module,
-                'puppet_module',
-                repo['_href'],
-            )
+            utils.upload_import_unit(cls.cfg, unit, unit_type_id, repo_href)
             for _ in range(2)
         ))
-
-    def test_call_report_result(self):
-        """Assert each call report's "result" field is null.
-
-        Other checks are done automatically by
-        :func:`pulp_smash.api.json_handler`. See it for details.
-        """
-        for i, call_report in enumerate(self.call_reports):
-            with self.subTest(i=i):
-                self.assertIsNone(call_report['result'])

--- a/pulp_smash/tests/python/api_v2/test_duplicate_uploads.py
+++ b/pulp_smash/tests/python/api_v2/test_duplicate_uploads.py
@@ -17,31 +17,8 @@ The second upload should silently fail for all Pulp releases in the 2.x series.
 from __future__ import unicode_literals
 
 from pulp_smash import api, utils
-from pulp_smash.compat import urljoin
-from pulp_smash.constants import (
-    CONTENT_UPLOAD_PATH,
-    PYTHON_EGG_URL,
-    REPOSITORY_PATH,
-)
+from pulp_smash.constants import PYTHON_EGG_URL, REPOSITORY_PATH
 from pulp_smash.tests.python.api_v2.utils import gen_repo
-
-
-def _upload_import_python_package(server_config, python_package, repo_href):
-    """Upload a Python package and import it into a repository.
-
-    Return the JSON-decoded body of the call report received when importing the
-    Python package.
-    """
-    client = api.Client(server_config, api.json_handler)
-    malloc = client.post(CONTENT_UPLOAD_PATH)
-    client.put(urljoin(malloc['_href'], '0/'), data=python_package)
-    call_report = client.post(urljoin(repo_href, 'actions/import_upload/'), {
-        'unit_key': {},
-        'unit_type_id': 'python_package',
-        'upload_id': malloc['upload_id'],
-    })
-    client.delete(malloc['_href'])
-    return call_report
 
 
 class DuplicateUploadsTestCase(utils.BaseAPITestCase):
@@ -63,9 +40,10 @@ class DuplicateUploadsTestCase(utils.BaseAPITestCase):
 
         # Upload and import the python package into the repository, twice.
         cls.call_reports = tuple((
-            _upload_import_python_package(
+            utils.upload_import_unit(
                 cls.cfg,
                 python_package,
+                'python_package',
                 repo['_href'],
             )
             for _ in range(2)

--- a/pulp_smash/tests/rpm/api_v2/test_broker.py
+++ b/pulp_smash/tests/rpm/api_v2/test_broker.py
@@ -36,6 +36,7 @@ from pulp_smash.constants import (
     REPOSITORY_PATH,
     RPM,
     RPM_FEED_URL,
+    RPM_URL,
 )
 from pulp_smash.tests.rpm.api_v2.utils import gen_distributor, gen_repo
 from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
@@ -125,5 +126,5 @@ class BrokerTestCase(unittest2.TestCase):
         pulp_rpm = client.get(url).content
 
         # Does this RPM match the original RPM?
-        rpm = utils.http_get(urljoin(RPM_FEED_URL, RPM))
+        rpm = utils.http_get(RPM_URL)
         self.assertEqual(rpm, pulp_rpm)

--- a/pulp_smash/tests/rpm/api_v2/test_duplicate_uploads.py
+++ b/pulp_smash/tests/rpm/api_v2/test_duplicate_uploads.py
@@ -17,12 +17,7 @@ The second upload should silently fail for all Pulp releases in the 2.x series.
 from __future__ import unicode_literals
 
 from pulp_smash import api, utils
-from pulp_smash.compat import urljoin
-from pulp_smash.constants import (
-    REPOSITORY_PATH,
-    RPM,
-    RPM_FEED_URL,
-)
+from pulp_smash.constants import REPOSITORY_PATH, RPM_URL
 from pulp_smash.tests.rpm.api_v2.utils import gen_repo
 from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
@@ -38,7 +33,7 @@ class DuplicateUploadsTestCase(utils.BaseAPITestCase):
 
         # Download content.
         client = api.Client(cls.cfg)
-        cls.rpm = utils.http_get(urljoin(RPM_FEED_URL, RPM))
+        cls.rpm = utils.http_get(RPM_URL)
 
         # Create a feed-less repository.
         client = api.Client(cls.cfg, api.json_handler)

--- a/pulp_smash/tests/rpm/api_v2/test_duplicate_uploads.py
+++ b/pulp_smash/tests/rpm/api_v2/test_duplicate_uploads.py
@@ -19,32 +19,12 @@ from __future__ import unicode_literals
 from pulp_smash import api, utils
 from pulp_smash.compat import urljoin
 from pulp_smash.constants import (
-    CONTENT_UPLOAD_PATH,
     REPOSITORY_PATH,
     RPM,
     RPM_FEED_URL,
 )
 from pulp_smash.tests.rpm.api_v2.utils import gen_repo
 from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
-
-
-def _upload_import_rpm(server_config, rpm, repo_href):
-    """Upload an RPM to a Pulp server and import it into a repository.
-
-    Create an upload request, upload ``rpm``, import it into the repository at
-    ``repo_href``, and close the upload request. Return the call report
-    returned when importing the RPM.
-    """
-    client = api.Client(server_config, api.json_handler)
-    malloc = client.post(CONTENT_UPLOAD_PATH)
-    client.put(urljoin(malloc['_href'], '0/'), data=rpm)
-    call_report = client.post(urljoin(repo_href, 'actions/import_upload/'), {
-        'unit_key': {},
-        'unit_type_id': 'rpm',
-        'upload_id': malloc['upload_id'],
-    })
-    client.delete(malloc['_href'])
-    return call_report
 
 
 class DuplicateUploadsTestCase(utils.BaseAPITestCase):
@@ -67,7 +47,7 @@ class DuplicateUploadsTestCase(utils.BaseAPITestCase):
 
         # Upload content and import it into the repository. Do it twice!
         cls.call_reports = tuple((
-            _upload_import_rpm(cls.cfg, cls.rpm, repo['_href'])
+            utils.upload_import_unit(cls.cfg, cls.rpm, 'rpm', repo['_href'])
             for _ in range(2)
         ))
 

--- a/pulp_smash/tests/rpm/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_sync_publish.py
@@ -43,6 +43,7 @@ from pulp_smash.constants import (
     REPOSITORY_PATH,
     RPM,
     RPM_FEED_URL,
+    RPM_URL,
 )
 from pulp_smash.tests.rpm.api_v2.utils import gen_distributor, gen_repo
 from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
@@ -240,7 +241,7 @@ class PublishTestCase(utils.BaseAPITestCase):
         for repo in repos:
             cls.resources.add(repo['_href'])
         client.response_handler = api.safe_handler
-        cls.rpms.append(utils.http_get(urljoin(RPM_FEED_URL, RPM)))
+        cls.rpms.append(utils.http_get(RPM_URL))
 
         # Begin an upload request, upload an RPM, move the RPM into a
         # repository, and end the upload request.

--- a/pulp_smash/utils.py
+++ b/pulp_smash/utils.py
@@ -272,6 +272,38 @@ class BaseAPICrudTestCase(unittest2.TestCase):
         self.assertEqual(cfg_sent, cfg_received)
 
 
+# It's OK for this method to have just one method. It's a mixin.
+class DuplicateUploadsMixin(object):  # pylint:disable=too-few-public-methods
+    """A mixin that adds tests for the "duplicate upload" test cases.
+
+    Consider the following procedure:
+
+    1. Create a new feed-less repository of any content unit type.
+    2. Upload a content unit into the repository.
+    3. Upload the same content unit into the same repository.
+
+    The second upload should silently fail for all Pulp releases in the 2.x
+    series. See:
+
+    * https://pulp.plan.io/issues/1406
+    * https://github.com/PulpQE/pulp-smash/issues/81
+
+    This mixin adds tests for this case. This mixin requires an attribute named
+    ``call_reports`` be present, where this attribute is an iterable of the
+    call reports produced by steps 2 and 3, above.
+    """
+
+    def test_call_report_result(self):
+        """Assert each call report's "result" field is null.
+
+        Other checks are done automatically by
+        :func:`pulp_smash.api.json_handler`. See it for details.
+        """
+        for i, call_report in enumerate(self.call_reports):
+            with self.subTest(i=i):
+                self.assertIsNone(call_report['result'])
+
+
 def reset_squid(server_config):
     """Stop Squid, reset its cache directory, and restart it.
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -176,3 +176,26 @@ class SyncRepoTestCase(unittest2.TestCase):
         with mock.patch.object(api, 'Client') as client:
             response = utils.sync_repo(mock.Mock(), 'http://example.com')
         self.assertIs(response, client.return_value.post.return_value)
+
+
+class UploadImportUnitTestCase(unittest2.TestCase):
+    """Test :func:`pulp_smash.utils.upload_import_unit`."""
+
+    def test_post(self):
+        """Assert the function makes an HTTP POST request."""
+        with mock.patch.object(api, 'Client') as client:
+            # post() is called twice, first to start a content upload and
+            # second to import and upload. In both cases, a dict is returned.
+            # Our dict mocks the first case, and just happens to work in the
+            # second case too.
+            client.return_value.post.return_value = {
+                '_href': 'foo',
+                'upload_id': 'bar',
+            }
+            response = utils.upload_import_unit(
+                mock.Mock(),  # server_config
+                'my unit',
+                'my unit type id',
+                'http://example.com',  # repo_href
+            )
+        self.assertIs(response, client.return_value.post.return_value)


### PR DESCRIPTION
All five of the plugins listed in #81 should have a test case for duplicate uploads. For the third of five plug-ins, I simply copied and pasted a module and fiddled with a few things. That's about when I knew it was a good time to refactor things.

Work is split into three commits for the sake of logical separation.