### PR TITLE
Conditionally skip Python duplicate upload tests

### DIFF
--- a/pulp_smash/tests/python/api_v2/test_duplicate_uploads.py
+++ b/pulp_smash/tests/python/api_v2/test_duplicate_uploads.py
@@ -19,6 +19,7 @@ from __future__ import unicode_literals
 from pulp_smash import api, utils
 from pulp_smash.constants import PYTHON_EGG_URL, REPOSITORY_PATH
 from pulp_smash.tests.python.api_v2.utils import gen_repo
+from pulp_smash.tests.python.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 
 class DuplicateUploadsTestCase(


### PR DESCRIPTION
Every module of tests should check to see if the necessary Pulp plugins
are installed before executing. If the plugin is missing, that module
should skip. Unfortunately, module
`pulp_smash.tests.python.api_v2.test_duplicate_uploads` is missing this
check. Add it in. This should fix a failing test in Jenkins. Test
results are sane, both when run against systems with and without the
plugin, with the following command:

    python -m unittest2 discover pulp_smash.tests.python.api_v2