### PR TITLE
Skip test affected by Pulp issue 1868

### DIFF
--- a/pulp_smash/tests/docker/cli/test_sync_publish.py
+++ b/pulp_smash/tests/docker/cli/test_sync_publish.py
@@ -147,6 +147,16 @@ class SyncPublishV2TestCase(_SuccessMixin, _BaseTestCase):
         checksum its blob, and compare this checksum to the one embedded in the
         blob's URL.
         """
+        # Issue 1868 only affects RHEL 6.
+        if (selectors.bug_is_untestable(1868, self.cfg.version) and
+                cli.Client(self.cfg, cli.echo_handler).run((
+                    'grep',
+                    '-i',
+                    'red hat enterprise linux server release 6',
+                    '/etc/redhat-release',
+                )).returncode == 0):
+            self.skipTest('https://pulp.plan.io/issues/1868')
+
         for fs_layer in self.manifest['fsLayers']:
             with self.subTest(fs_layer=fs_layer):
                 blob_sum = fs_layer['blobSum']


### PR DESCRIPTION
Pulp issue 1868 [1] affects the Docker CLI test
`SyncPublishV2TestCase.test_blob_digests` on RHEL 6. Skip the test as
appropriate. This change does not affect test results on other
platforms, such as Fedora 22 or 23. Tests executed with:

    python -m unittest2 \
        pulp_smash.tests.docker.cli.test_sync_publish.SyncPublishV2TestCase

[1] https://pulp.plan.io/issues/1868