### PR TITLE
Fix test for Pulp bug 1787

### DIFF
--- a/pulp_smash/tests/rpm/api_v2/test_comps_groups.py
+++ b/pulp_smash/tests/rpm/api_v2/test_comps_groups.py
@@ -251,7 +251,7 @@ class CompsGroupsTestCase(utils.BaseAPITestCase):
             self.skipTest('https://pulp.plan.io/issues/1787')
         input_id = self.package_groups[0]['id']  # minimal package group
         output = _get_groups_by_id(self.root_element)[input_id]
-        self.assertEqual(len(output.findall('display_order')), 1)
+        self.assertEqual(len(output.findall('display_order')), 0)
 
     def test_single_elements(self):
         """Assert that certain tags appear under groups exactly once."""


### PR DESCRIPTION
According to the bug [1], if an input package group has no
`display_order` element, then output XML should also omit said element.
The relevant test asserts that said element always appears exactly once
in the output — not good!

Thanks to @rohanpm for finding this issue.

Test results do not change as a result of this commit. (The test is
currently skipped.) Tests executed with:

    python -m unittest2 pulp_smash.tests.rpm.api_v2.test_comps_groups

[1] https://pulp.plan.io/issues/1787