### PR TITLE
Change expected configuration file contents

### DIFF
--- a/pulp_smash/__main__.py
+++ b/pulp_smash/__main__.py
@@ -11,18 +11,30 @@ from pulp_smash.config import ServerConfig
 
 MESSAGE = tuple((
     '''\
-    Pulp Smash's command line interface has not yet been fleshed out. Please
-    create a configuration file at {} and call `python -m unittest2 discover
-    pulp_smash.tests`. The configuration file should have this structure:
+    Please create a configuration file at {} and call `python -m unittest2
+    discover pulp_smash.tests`. The configuration file should have this
+    structure:
     ''',
     '''\
-    {"default": {
-        "base_url": "https://pulp.example.com",
-        "auth": ["username", "password"],
-        "verify": true,
-        "version": "2.7.5",
-        "cli_transport": "local"
-    }}''',
+    {
+        "pulp": {
+            "base_url": "https://pulp.example.com",
+            "auth": ["username", "password"],
+            "verify": true,
+            "version": "2.7.5",
+            "cli_transport": "local"
+        },
+        "pulp agent": {
+            "base_url": "https://pulp-agent.example.com"
+        }
+    }''',
+    '''\
+    Each section provides information about a single Pulp-related service and
+    the host on which that service is installed. The "pulp" and "pulp agent"
+    sections tell about the Pulp and Pulp Agent services, respectively. The
+    former is required. The latter is optional, and if omitted, relevant tests
+    are skipped.
+    ''',
     '''\
     The `verify`, `version` and `cli_transport` keys are optional. The `verify`
     option can be used to explicitly enable or disable SSL verification. The
@@ -72,14 +84,15 @@ def main():
     message += '\n\n' + MESSAGE[1]
     message += '\n\n' + wrapper.fill(textwrap.dedent(MESSAGE[2]))
     message += '\n\n' + wrapper.fill(textwrap.dedent(MESSAGE[3]))
+    message += '\n\n' + wrapper.fill(textwrap.dedent(MESSAGE[4]))
     wrapper.initial_indent = '* '
     wrapper.subsequent_indent = '  '
-    message += '\n\n' + wrapper.fill(textwrap.dedent(MESSAGE[4]))
+    message += '\n\n' + wrapper.fill(textwrap.dedent(MESSAGE[5]))
     message += '\n\n' + wrapper.fill(
         # pylint:disable=protected-access
-        textwrap.dedent(MESSAGE[5].format(cfg._xdg_config_file))
+        textwrap.dedent(MESSAGE[6].format(cfg._xdg_config_file))
     )
-    message += '\n\n' + wrapper.fill(textwrap.dedent(MESSAGE[6]))
+    message += '\n\n' + wrapper.fill(textwrap.dedent(MESSAGE[7]))
     print(message)
 
 

--- a/pulp_smash/exceptions.py
+++ b/pulp_smash/exceptions.py
@@ -39,6 +39,14 @@ class ConfigFileNotFoundError(Exception):
     """
 
 
+class ConfigFileSectionNotFoundError(Exception):
+    """We cannot read the requested Pulp Smash configuration file section.
+
+    See :mod:`pulp_smash.config` for more information on how configuration
+    files are handled.
+    """
+
+
 class NoKnownBrokerError(Exception):
     """We cannot determine the AMQP broker used by a system.
 


### PR DESCRIPTION
Fix https://github.com/PulpQE/pulp-smash/issues/224

It's technically already possible to create test cases that target both
a Pulp server and a Pulp agent. However, there is not proper
documentation for how to do this. Create such.

The most significant change in this commit regards the contents of
configuration files. Configuration files may now have two sections.
Here's what `python -m pulp_smash` has to say about the topic:

> The configuration file should have this structure:
>
>     {
>         "pulp": {
>             "base_url": "https://pulp.example.com",
>             "auth": ["username", "password"],
>             "verify": true,
>             "version": "2.7.5",
>             "cli_transport": "local"
>         },
>         "pulp agent": {
>             "base_url": "https://pulp-agent.example.com"
>         }
>     }
>
> Each section provides information about a single Pulp-related service
> and the host on which that service is installed. The "pulp" and "pulp
> agent" sections tell about the Pulp and Pulp Agent services,
> respectively. The former is required. The latter is optional, and if
> omitted, relevant tests are skipped.

The assertion that "relevant tests are skipped" will only hold true if
individual test tests (or test modules) implement such checks. A proof
of concept showing that this can be done has been written.

If a user calls `ServerConfig.read`, does not specify which
configuration file section to read, and the configuration file has a
single section named `default`, then that section is read and a
deprecation warning is raised.