### PR TITLE
Run children of SyncRepoBaseTestCase

### DIFF
--- a/pulp_smash/tests/rpm/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_sync_publish.py
@@ -31,6 +31,7 @@ Assertions not explored in this module include:
 """
 from __future__ import unicode_literals
 
+import inspect
 from itertools import product
 
 import unittest2
@@ -104,7 +105,6 @@ class CreateTestCase(utils.BaseAPITestCase):
 
 
 # This class is left public for documentation purposes.
-@unittest2.skip('Base test case.')
 class SyncRepoBaseTestCase(utils.BaseAPITestCase):
     """A parent class for repository syncronization test cases.
 
@@ -115,6 +115,8 @@ class SyncRepoBaseTestCase(utils.BaseAPITestCase):
     @classmethod
     def setUpClass(cls):
         """Create an RPM repository with a valid feed and sync it."""
+        if inspect.getmro(cls)[0] == SyncRepoBaseTestCase:
+            raise unittest2.SkipTest('Abstract base class.')
         super(SyncRepoBaseTestCase, cls).setUpClass()
         client = api.Client(cls.cfg, api.json_handler)
         body = gen_repo()


### PR DESCRIPTION
Class `SyncRepoBaseTestCase` is an abstract base class, and it should
not run. However, children of this class are expected to implement
abstract functionality and should run. The current attempt to implement
this is as follows:

```python
@unittest2.skip(…)
class SyncRepoBaseTestCase(…):
```

This fails, of course: child classes also execute this decorator. Use
reflection instead: a `SkipTest` exception is raised only if the first
element in the MRO tree is `SyncRepoBaseTestCase`.

This change allows more tests to run, without introducing any test
failures. Tests executed with:

    python -m unittest2 pulp_smash.tests.rpm.api_v2.test_sync_publish