### PR TITLE
Add a duplicate file upload test for Docker

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -23,6 +23,7 @@ developers, not a gospel.
     api/pulp_smash.tests.docker
     api/pulp_smash.tests.docker.api_v2
     api/pulp_smash.tests.docker.api_v2.test_crud
+    api/pulp_smash.tests.docker.api_v2.test_duplicate_uploads
     api/pulp_smash.tests.docker.api_v2.utils
     api/pulp_smash.tests.docker.cli
     api/pulp_smash.tests.docker.cli.test_copy

--- a/docs/api/pulp_smash.tests.docker.api_v2.test_duplicate_uploads.rst
+++ b/docs/api/pulp_smash.tests.docker.api_v2.test_duplicate_uploads.rst
@@ -1,0 +1,6 @@
+`pulp_smash.tests.docker.api_v2.test_duplicate_uploads`
+=======================================================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.docker.api_v2.test_duplicate_uploads`
+
+.. automodule:: pulp_smash.tests.docker.api_v2.test_duplicate_uploads

--- a/pulp_smash/constants.py
+++ b/pulp_smash/constants.py
@@ -19,6 +19,12 @@ CONTENT_UPLOAD_PATH = '/pulp/api/v2/content/uploads/'
    http://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/content/upload.html#creating-an-upload-request
 """
 
+DOCKER_IMAGE_URL = (
+    'https://repos.fedorapeople.org/repos/pulp/pulp/fixtures/docker/'
+    'busybox:latest.tar'
+)
+"""The URL to a Docker image as created by ``docker save``."""
+
 DOCKER_V1_FEED_URL = 'https://index.docker.io'
 """The URL to a V1 Docker registry.
 

--- a/pulp_smash/tests/docker/api_v2/test_duplicate_uploads.py
+++ b/pulp_smash/tests/docker/api_v2/test_duplicate_uploads.py
@@ -1,0 +1,42 @@
+# coding=utf-8
+"""Tests for how well Pulp can deal with duplicate uploads.
+
+This module targets `Pulp #1406`_ and `Pulp Smash #81`_. The test procedure is
+as follows:
+
+1. Create a new feed-less repository.
+2. Upload content and import it into the repository. Assert the upload and
+   import was successful.
+3. Upload identical content and import it into the repository.
+
+The second upload should silently fail for all Pulp releases in the 2.x series.
+
+.. _Pulp #1406: https://pulp.plan.io/issues/1406
+.. _Pulp Smash #81: https://github.com/PulpQE/pulp-smash/issues/81
+"""
+from __future__ import unicode_literals
+
+from pulp_smash import api, utils
+from pulp_smash.constants import DOCKER_IMAGE_URL, REPOSITORY_PATH
+from pulp_smash.tests.docker.api_v2.utils import gen_repo
+from pulp_smash.tests.docker.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+
+
+class DuplicateUploadsTestCase(
+        utils.BaseAPITestCase,
+        utils.DuplicateUploadsMixin):
+    """Test how well Pulp can deal with duplicate content unit uploads."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create a Docker repository. Upload a Docker image into it twice."""
+        super(DuplicateUploadsTestCase, cls).setUpClass()
+        unit = utils.http_get(DOCKER_IMAGE_URL)
+        unit_type_id = 'docker_image'
+        client = api.Client(cls.cfg, api.json_handler)
+        repo_href = client.post(REPOSITORY_PATH, gen_repo())['_href']
+        cls.resources.add(repo_href)
+        cls.call_reports = tuple((
+            utils.upload_import_unit(cls.cfg, unit, unit_type_id, repo_href)
+            for _ in range(2)
+        ))


### PR DESCRIPTION
Add module `pulp_smash.tests.docker.api_v2.test_duplicate_uploads`. This
new module has one test case, `DuplicateUploadsTestCase`, which uploads
a Docker image to a Docker repository twice in a row, and verifies that
the upload succeeds. The new test succeeds when run with:

    python -m unittest2 \
        pulp_smash.tests.docker.api_v2.test_duplicate_uploads

Also add a new constant, `DOCKER_IMAGE_URL`:

> The URL to a Docker iamge as created by `Docker save`.

Fix: https://github.com/PulpQE/pulp-smash/issues/81