### PR TITLE
Update RPM_FEED_URL constant

### DIFF
--- a/pulp_smash/constants.py
+++ b/pulp_smash/constants.py
@@ -195,7 +195,7 @@ RPM_ABS_PATH = (
 )
 """The absolute path to :data:`pulp_smash.constants.RPM` in the filesystem."""
 
-RPM_FEED_URL = 'https://repos.fedorapeople.org/repos/pulp/pulp/demo_repos/zoo/'
+RPM_FEED_URL = 'https://repos.fedorapeople.org/repos/pulp/pulp/fixtures/rpm/'
 """The URL to an RPM repository. See :data:`RPM_URL`."""
 
 RPM_SHA256_CHECKSUM = (


### PR DESCRIPTION
The new Pulp Fixtures [1] project is now being used to generate RPM and
Docker fixture files. Make use of them, instead of the old demo files.
The following command succeeds:

    python -m unittest2 pulp_smash.tests.rpm.api_v2.test_sync_publish

[1] https://github.com/PulpQE/pulp-fixtures