### PR TITLE
Make an assertion more verbose

### DIFF
--- a/pulp_smash/tests/rpm/api_v2/test_download_policies.py
+++ b/pulp_smash/tests/rpm/api_v2/test_download_policies.py
@@ -99,7 +99,9 @@ class BackgroundTestCase(utils.BaseAPITestCase):
         the client to the streamer and the rpm request would contain a history
         entry for that redirect.
         """
-        self.assertEqual(0, len(self.rpm.history), self.rpm.history)
+        # HTTP 302 responses should have a "Location" header.
+        history_headers = [response.headers for response in self.rpm.history]
+        self.assertEqual(0, len(self.rpm.history), history_headers)
 
     def test_rpm_checksum(self):
         """Assert the checksum of the downloaded RPM matches the metadata."""


### PR DESCRIPTION
Test results do not change on systems for which the test passes. Tests
executed with:

    python -m unittest2 \
        pulp_smash.tests.rpm.api_v2.test_download_policies.BackgroundTestCase