### PR TITLE
Link to readthedocs.io, not readthedocs.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ the prompts.
 
 .. All text above this comment should also be in docs/index.rst, word for word.
 
-The `full documentation <http://pulp-smash.readthedocs.org/en/latest/>`_ is
+The `full documentation <http://pulp-smash.readthedocs.io/en/latest/>`_ is
 available on ReadTheDocs. It can also be generated locally:
 
 .. code-block:: sh

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -46,4 +46,4 @@ For an explanation of key concepts and more installation strategies, see
 .. _Installing Python Modules: https://docs.python.org/3/installing/
 .. _PyPi: https://pypi.python.org/pypi/pulp-smash
 .. _Virtual Environments and Packages: https://docs.python.org/3/tutorial/venv.html
-.. _Virtualenv: http://virtualenv.readthedocs.org/en/latest/
+.. _Virtualenv: http://virtualenv.readthedocs.io/en/latest/

--- a/pulp_smash/api.py
+++ b/pulp_smash/api.py
@@ -333,7 +333,7 @@ def poll_spawned_tasks(server_config, call_report):
     :raises: Same as :meth:`poll_task`.
 
     .. _call report:
-        http://pulp.readthedocs.org/en/latest/dev-guide/conventions/sync-v-async.html#call-report
+        http://pulp.readthedocs.io/en/latest/dev-guide/conventions/sync-v-async.html#call-report
     """
     hrefs = (task['_href'] for task in call_report['spawned_tasks'])
     for href in hrefs:

--- a/pulp_smash/cli.py
+++ b/pulp_smash/cli.py
@@ -150,7 +150,7 @@ class Client(object):  # pylint:disable=too-few-public-methods
     :param response_handler: A callback function. Defaults to
         :func:`pulp_smash.cli.code_handler`.
 
-    .. _Plumbum: http://plumbum.readthedocs.org/en/latest/index.html
+    .. _Plumbum: http://plumbum.readthedocs.io/en/latest/index.html
     """
 
     def __init__(self, server_config, response_handler=None):
@@ -185,12 +185,12 @@ class Client(object):  # pylint:disable=too-few-public-methods
         instructions. See :class:`pulp_smash.cli.Client` for a usage example.
 
         .. _BaseCommand.run:
-           http://plumbum.readthedocs.org/en/latest/api/commands.html#plumbum.commands.base.BaseCommand.run
+           http://plumbum.readthedocs.io/en/latest/api/commands.html#plumbum.commands.base.BaseCommand.run
         .. _subprocess.Popen:
            https://docs.python.org/3/library/subprocess.html#subprocess.Popen
         """
         # Let self.response_handler check return codes. See:
-        # https://plumbum.readthedocs.org/en/latest/api/commands.html#plumbum.commands.base.BaseCommand.run
+        # https://plumbum.readthedocs.io/en/latest/api/commands.html#plumbum.commands.base.BaseCommand.run
         kwargs.setdefault('retcode')
 
         code, stdout, stderr = self.machine[args[0]].run(args[1:], **kwargs)

--- a/pulp_smash/constants.py
+++ b/pulp_smash/constants.py
@@ -9,14 +9,14 @@ CALL_REPORT_KEYS = frozenset(('error', 'result', 'spawned_tasks'))
 """See: `Call Report`_.
 
 .. _Call Report:
-    http://pulp.readthedocs.org/en/latest/dev-guide/conventions/sync-v-async.html#call-report
+    http://pulp.readthedocs.io/en/latest/dev-guide/conventions/sync-v-async.html#call-report
 """
 
 CONTENT_UPLOAD_PATH = '/pulp/api/v2/content/uploads/'
 """See: `Creating an Upload Request`_.
 
 .. _Creating an Upload Request:
-   http://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/content/upload.html#creating-an-upload-request
+   http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/content/upload.html#creating-an-upload-request
 """
 
 DOCKER_IMAGE_URL = (
@@ -55,7 +55,7 @@ ERROR_KEYS = frozenset((
 No ``href`` field should be present. See `Issue #1310`_.
 
 .. _Exception Handling:
-    https://pulp.readthedocs.org/en/latest/dev-guide/conventions/exceptions.html
+    https://pulp.readthedocs.io/en/latest/dev-guide/conventions/exceptions.html
 .. _Issue #1310: https://pulp.plan.io/issues/1310
 """
 
@@ -63,28 +63,28 @@ GROUP_CALL_REPORT_KEYS = frozenset(('_href', 'group_id'))
 """See: `Group Call Report`_.
 
 .. _Group Call Report:
-    http://pulp.readthedocs.org/en/latest/dev-guide/conventions/sync-v-async.html#group-call-report
+    http://pulp.readthedocs.io/en/latest/dev-guide/conventions/sync-v-async.html#group-call-report
 """
 
 LOGIN_KEYS = frozenset(('certificate', 'key'))
 """See: `User Certificates`_.
 
 .. _User Certificates:
-    http://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/authentication.html#user-certificates
+    http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/authentication.html#user-certificates
 """
 
 LOGIN_PATH = '/pulp/api/v2/actions/login/'
 """See: `Authentication`_.
 
 .. _Authentication:
-    https://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/authentication.html
+    https://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/authentication.html
 """
 
 ORPHANS_PATH = 'pulp/api/v2/content/orphans/'
 """See: `Orphaned Content`_.
 
 .. _Orphaned Content:
-    http://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/content/orphan.html
+    http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/content/orphan.html
 """
 
 OSTREE_FEED = (
@@ -93,21 +93,21 @@ OSTREE_FEED = (
 """The URL to a URL of OSTree branches. See OSTree `Importer Configuration`_.
 
 .. _Importer Configuration:
-    http://pulp-ostree.readthedocs.org/en/latest/tech-reference/importer.html
+    http://pulp-ostree.readthedocs.io/en/latest/tech-reference/importer.html
 """
 
 OSTREE_BRANCH = 'fedora-atomic/f21/x86_64/updates/docker-host'
 """A branch in :data:`OSTREE_FEED`. See OSTree `Importer Configuration`_.
 
 .. _Importer Configuration:
-    http://pulp-ostree.readthedocs.org/en/latest/tech-reference/importer.html
+    http://pulp-ostree.readthedocs.io/en/latest/tech-reference/importer.html
 """
 
 PLUGIN_TYPES_PATH = '/pulp/api/v2/plugins/types/'
 """See: `Retrieve All Content Unit Types`_.
 
 .. _Retrieve All Content Unit Types:
-   http://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/server_plugins.html#retrieve-all-content-unit-types
+   http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/server_plugins.html#retrieve-all-content-unit-types
 """
 
 PULP_SERVICES = {
@@ -182,14 +182,14 @@ REPOSITORY_PATH = '/pulp/api/v2/repositories/'
 """See: `Repository APIs`_.
 
 .. _Repository APIs:
-    https://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/repo/index.html
+    https://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/index.html
 """
 
 CONSUMER_PATH = '/pulp/api/v2/consumers/'
 """See: `Consumer APIs`_.
 
 .. _Consumer APIs:
-    https://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/consumer/index.html
+    https://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/consumer/index.html
 """
 
 RPM = 'bear-4.1-1.noarch.rpm'
@@ -221,5 +221,5 @@ USER_PATH = '/pulp/api/v2/users/'
 """See: `User APIs`_.
 
 .. _User APIs:
-    https://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/user/index.html
+    https://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/user/index.html
 """

--- a/pulp_smash/exceptions.py
+++ b/pulp_smash/exceptions.py
@@ -25,9 +25,9 @@ class CallReportError(Exception):
     `Synchronous and Asynchronous Calls`_ and `Task Management`_.
 
     .. _Synchronous and Asynchronous Calls:
-        http://pulp.readthedocs.org/en/latest/dev-guide/conventions/sync-v-async.html
+        http://pulp.readthedocs.io/en/latest/dev-guide/conventions/sync-v-async.html
     .. _Task Management:
-        http://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/tasks.html
+        http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/tasks.html
     """
 
 
@@ -68,9 +68,9 @@ class TaskReportError(Exception):
     `Synchronous and Asynchronous Calls`_ and `Task Management`_.
 
     .. _Synchronous and Asynchronous Calls:
-        http://pulp.readthedocs.org/en/latest/dev-guide/conventions/sync-v-async.html
+        http://pulp.readthedocs.io/en/latest/dev-guide/conventions/sync-v-async.html
     .. _Task Management:
-        http://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/tasks.html
+        http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/tasks.html
     """
 
 

--- a/pulp_smash/selectors.py
+++ b/pulp_smash/selectors.py
@@ -16,7 +16,7 @@ from pulp_smash import exceptions
 # These statuses apply to bugs filed at https://pulp.plan.io. They are ordered
 # according to an ideal workflow. As of this writing, these is no canonical
 # public source for this information. But see:
-# http://pulp.readthedocs.org/en/latest/dev-guide/contributing/bugs.html#fixing
+# http://pulp.readthedocs.io/en/latest/dev-guide/contributing/bugs.html#fixing
 _UNTESTABLE_BUGS = frozenset((
     'NEW',  # bug just entered into tracker
     'ASSIGNED',  # bug has been assigned to an engineer

--- a/pulp_smash/tests/ostree/api_v2/test_crud.py
+++ b/pulp_smash/tests/ostree/api_v2/test_crud.py
@@ -12,9 +12,9 @@ following trees of assumptions are explored in this module::
         It is not possible to update distrubutors to have conflicting paths
 
 .. _OSTree:
-    http://pulp-ostree.readthedocs.org/en/latest/
+    http://pulp-ostree.readthedocs.io/en/latest/
 .. _repositories:
-   http://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/repo/cud.html
+   http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/cud.html
 """
 from __future__ import unicode_literals
 

--- a/pulp_smash/tests/ostree/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/ostree/api_v2/test_sync_publish.py
@@ -17,9 +17,9 @@ assumptions are explored in this module::
         (SyncWithoutFeedTestCase).
 
 .. _OSTree:
-    http://pulp-ostree.readthedocs.org/en/latest/
+    http://pulp-ostree.readthedocs.io/en/latest/
 .. _repositories:
-   http://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/repo/cud.html
+   http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/cud.html
 """
 from __future__ import unicode_literals
 

--- a/pulp_smash/tests/platform/api_v2/test_consumer.py
+++ b/pulp_smash/tests/platform/api_v2/test_consumer.py
@@ -2,7 +2,7 @@
 """Test the `consumer`_ API endpoints.
 
 .. _consumer:
-    https://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/consumer/index.html
+    https://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/consumer/index.html
 """
 from __future__ import unicode_literals
 
@@ -16,7 +16,7 @@ class BindConsumerTestCase(utils.BaseAPITestCase):
     """Show that one can `bind a consumer to a repository`_.
 
     .. _bind a consumer to a repository:
-        https://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/consumer/bind.html#bind-a-consumer-to-a-repository
+        https://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/consumer/bind.html#bind-a-consumer-to-a-repository
     """
 
     @classmethod

--- a/pulp_smash/tests/platform/api_v2/test_content_applicability.py
+++ b/pulp_smash/tests/platform/api_v2/test_content_applicability.py
@@ -11,7 +11,7 @@ report.  (See :data:`pulp_smash.constants.CALL_REPORT_KEYS` and
 and :class:`ParallelTestCase` test these two use cases, respectively.
 
 .. _content applicability:
-    https://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/consumer/applicability.html
+    https://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/consumer/applicability.html
 """
 from __future__ import unicode_literals
 

--- a/pulp_smash/tests/platform/api_v2/test_login.py
+++ b/pulp_smash/tests/platform/api_v2/test_login.py
@@ -2,7 +2,7 @@
 """Test the API's `authentication`_ functionality.
 
 .. _authentication:
-    https://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/authentication.html
+    https://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/authentication.html
 """
 from __future__ import unicode_literals
 

--- a/pulp_smash/tests/platform/api_v2/test_repository.py
+++ b/pulp_smash/tests/platform/api_v2/test_repository.py
@@ -12,7 +12,7 @@ The assumptions explored in this module have the following dependencies::
         └── It is possible to delete a repository.
 
 .. _repository:
-    https://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/repo/index.html
+    https://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/index.html
 """
 from __future__ import unicode_literals
 

--- a/pulp_smash/tests/platform/api_v2/test_search.py
+++ b/pulp_smash/tests/platform/api_v2/test_search.py
@@ -22,9 +22,9 @@ The assumptions explored in this module have the following dependencies::
             └── It is possible to limit how many search results are returned.
 
 .. _Searching:
-    https://pulp.readthedocs.org/en/latest/dev-guide/conventions/criteria.html
+    https://pulp.readthedocs.io/en/latest/dev-guide/conventions/criteria.html
 .. _User APIs:
-    https://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/user/index.html
+    https://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/user/index.html
 """
 from __future__ import unicode_literals
 

--- a/pulp_smash/tests/platform/api_v2/test_user.py
+++ b/pulp_smash/tests/platform/api_v2/test_user.py
@@ -11,7 +11,7 @@ The assumptions explored in this module have the following dependencies::
     └── It is possible to delete a user.
 
 .. _user:
-    https://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/user/index.html
+    https://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/user/index.html
 """
 from __future__ import unicode_literals
 

--- a/pulp_smash/tests/puppet/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/puppet/api_v2/test_sync_publish.py
@@ -30,7 +30,7 @@ Assertions not explored in this module include:
   in single directory on pulp server over HTTPS.
 
 .. _repositories:
-   http://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/repo/cud.html
+   http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/cud.html
 """
 from __future__ import unicode_literals
 
@@ -383,7 +383,7 @@ class PublishTestCase(utils.BaseAPITestCase):
         """Verify the response body for `creating an upload request`_.
 
         .. _creating an upload request:
-           http://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/content/upload.html#creating-an-upload-request
+           http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/content/upload.html#creating-an-upload-request
         """
         keys = set(self.responses['malloc'].json().keys())
         self.assertLessEqual({'_href', 'upload_id'}, keys)
@@ -392,7 +392,7 @@ class PublishTestCase(utils.BaseAPITestCase):
         """Verify the response body for `uploading bits`_.
 
         .. _uploading bits:
-           http://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/content/upload.html#upload-bits
+           http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/content/upload.html#upload-bits
         """
         self.assertIsNone(self.responses['upload'].json())
 
@@ -400,9 +400,9 @@ class PublishTestCase(utils.BaseAPITestCase):
         """Verify each call report has a sane structure.
 
         * `Import into a Repository
-          <http://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/content/upload.html#import-into-a-repository>`_
+          <http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/content/upload.html#import-into-a-repository>`_
         * `Copying Units Between Repositories
-          <http://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/content/associate.html#copying-units-between-repositories>`_
+          <http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/content/associate.html#copying-units-between-repositories>`_
         """
         for step in {'import', 'copy'}:
             with self.subTest(step=step):
@@ -419,7 +419,7 @@ class PublishTestCase(utils.BaseAPITestCase):
         """Verify the response body for ending an upload.
 
         `Delete an Upload Request
-        <http://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/content/upload.html#delete-an-upload-request>`_
+        <http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/content/upload.html#delete-an-upload-request>`_
         """
         self.assertIsNone(self.responses['free'].json())
 

--- a/pulp_smash/tests/rpm/api_v2/test_export.py
+++ b/pulp_smash/tests/rpm/api_v2/test_export.py
@@ -6,7 +6,7 @@ This module assumes that the tests in
 :mod:`pulp_smash.tests.rpm.api_v2.test_sync_publish` hold true.
 
 .. _Export Distributors:
-    http://pulp-rpm.readthedocs.org/en/latest/tech-reference/export-distributor.html
+    http://pulp-rpm.readthedocs.io/en/latest/tech-reference/export-distributor.html
 """
 from __future__ import unicode_literals
 

--- a/pulp_smash/tests/rpm/api_v2/test_iso_crud.py
+++ b/pulp_smash/tests/rpm/api_v2/test_iso_crud.py
@@ -204,9 +204,9 @@ class AddImporterDistributorTestCase(utils.BaseAPITestCase):
     See:
 
     * `Associate an Importer to a Repository
-      <http://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/repo/cud.html#associate-an-importer-to-a-repository>`_
+      <http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/cud.html#associate-an-importer-to-a-repository>`_
     * `Associate a Distributor with a Repository
-      <http://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/repo/cud.html#associate-a-distributor-with-a-repository>`_
+      <http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/cud.html#associate-a-distributor-with-a-repository>`_
     """
 
     @classmethod

--- a/pulp_smash/tests/rpm/api_v2/test_remove_unit.py
+++ b/pulp_smash/tests/rpm/api_v2/test_remove_unit.py
@@ -14,7 +14,7 @@ of repository created with valid feed and remove_missing option set.
 6. Assert that both repositories contain same units.
 
 .. _remove_missing:
-    https://pulp-rpm.readthedocs.org/en/latest/tech-reference/yum-plugins.html
+    https://pulp-rpm.readthedocs.io/en/latest/tech-reference/yum-plugins.html
 """
 
 from __future__ import unicode_literals

--- a/pulp_smash/tests/rpm/api_v2/test_retain_old_count.py
+++ b/pulp_smash/tests/rpm/api_v2/test_retain_old_count.py
@@ -12,7 +12,7 @@ repository created with valid feed and `retain_old_count`_ option set.
 4. Assert that number or RPMs in repo bar is less then in foo repo.
 
 .. _retain_old_count:
-    https://pulp-rpm.readthedocs.org/en/latest/tech-reference/yum-plugins.html
+    https://pulp-rpm.readthedocs.io/en/latest/tech-reference/yum-plugins.html
 """
 from __future__ import unicode_literals
 

--- a/pulp_smash/tests/rpm/api_v2/test_schedule_publish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_schedule_publish.py
@@ -6,7 +6,7 @@ This module assumes that the tests in
 :mod:`pulp_smash.tests.rpm.api_v2.test_sync_publish` hold true.
 
 .. _publication:
-    https://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/repo/publish.html#scheduling-a-publish
+    https://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/publish.html#scheduling-a-publish
 """
 
 from __future__ import unicode_literals
@@ -77,7 +77,7 @@ class CreateFailureTestCase(utils.BaseAPITestCase):
     """Establish that schedules are not created in `documented scenarios`_.
 
     .. _documented scenarios:
-        https://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/repo/publish.html#scheduling-a-publish
+        https://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/publish.html#scheduling-a-publish
     """
 
     @classmethod
@@ -147,11 +147,11 @@ class ReadUpdateDeleteTestCase(utils.BaseAPITestCase):
     hold true.
 
     .. _read:
-        https://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/repo/publish.html#listing-a-single-scheduled-publish
+        https://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/publish.html#listing-a-single-scheduled-publish
     .. _update:
-        https://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/repo/publish.html#updating-a-scheduled-publish
+        https://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/publish.html#updating-a-scheduled-publish
     .. _delete:
-        https://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/repo/publish.html#deleting-a-scheduled-publish
+        https://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/publish.html#deleting-a-scheduled-publish
     """
 
     @classmethod

--- a/pulp_smash/tests/rpm/api_v2/test_schedule_sync.py
+++ b/pulp_smash/tests/rpm/api_v2/test_schedule_sync.py
@@ -5,7 +5,7 @@ This module assumes that the tests in
 :mod:`pulp_smash.tests.platform.api_v2.test_repository` hold true.
 
 .. _syncronization:
-    https://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/repo/sync.html#scheduling-a-sync
+    https://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/sync.html#scheduling-a-sync
 """
 from __future__ import unicode_literals
 
@@ -93,7 +93,7 @@ class CreateFailureTestCase(CreateRepoMixin, utils.BaseAPITestCase):
     """Establish that schedules are not created in `documented scenarios`_.
 
     .. _documented scenarios:
-        https://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/repo/sync.html#scheduling-a-sync
+        https://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/sync.html#scheduling-a-sync
     """
 
     @classmethod
@@ -154,11 +154,11 @@ class ReadUpdateDeleteTestCase(CreateRepoMixin, utils.BaseAPITestCase):
     hold true.
 
     .. _read:
-        https://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/repo/sync.html#listing-a-single-scheduled-sync
+        https://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/sync.html#listing-a-single-scheduled-sync
     .. _update:
-        https://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/repo/sync.html#updating-a-scheduled-sync
+        https://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/sync.html#updating-a-scheduled-sync
     .. _delete:
-        https://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/repo/sync.html#deleting-a-scheduled-sync
+        https://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/sync.html#deleting-a-scheduled-sync
     """
 
     @classmethod

--- a/pulp_smash/tests/rpm/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_sync_publish.py
@@ -27,7 +27,7 @@ Assertions not explored in this module include:
 * It is possible to get content into a repository via a sync and publish it.
 
 .. _repositories:
-   http://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/repo/cud.html
+   http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/cud.html
 """
 from __future__ import unicode_literals
 
@@ -351,7 +351,7 @@ class PublishTestCase(utils.BaseAPITestCase):
         """Verify the response body for `creating an upload request`_.
 
         .. _creating an upload request:
-           http://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/content/upload.html#creating-an-upload-request
+           http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/content/upload.html#creating-an-upload-request
         """
         keys = set(self.responses['malloc'].json().keys())
         self.assertLessEqual({'_href', 'upload_id'}, keys)
@@ -360,7 +360,7 @@ class PublishTestCase(utils.BaseAPITestCase):
         """Verify the response body for `uploading bits`_.
 
         .. _uploading bits:
-           http://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/content/upload.html#upload-bits
+           http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/content/upload.html#upload-bits
         """
         self.assertIsNone(self.responses['upload'].json())
 
@@ -368,9 +368,9 @@ class PublishTestCase(utils.BaseAPITestCase):
         """Verify each call report has a sane structure.
 
         * `Import into a Repository
-          <http://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/content/upload.html#import-into-a-repository>`_
+          <http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/content/upload.html#import-into-a-repository>`_
         * `Copying Units Between Repositories
-          <http://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/content/associate.html#copying-units-between-repositories>`_
+          <http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/content/associate.html#copying-units-between-repositories>`_
         """
         for step in {'import', 'copy'}:
             with self.subTest(step=step):
@@ -387,7 +387,7 @@ class PublishTestCase(utils.BaseAPITestCase):
         """Verify the response body for ending an upload.
 
         `Delete an Upload Request
-        <http://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/content/upload.html#delete-an-upload-request>`_
+        <http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/content/upload.html#delete-an-upload-request>`_
         """
         self.assertIsNone(self.responses['free'].json())
 

--- a/pulp_smash/tests/rpm/api_v2/test_unassociate.py
+++ b/pulp_smash/tests/rpm/api_v2/test_unassociate.py
@@ -6,7 +6,7 @@ This module assumes that the tests in
 :mod:`pulp_smash.tests.rpm.api_v2.test_sync_publish` hold true.
 
 .. _Unassociating Content Units from a Repository:
-   http://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/content/associate.html#unassociating-content-units-from-a-repository
+   http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/content/associate.html#unassociating-content-units-from-a-repository
 """
 from __future__ import unicode_literals
 

--- a/pulp_smash/utils.py
+++ b/pulp_smash/utils.py
@@ -199,13 +199,13 @@ class BaseAPICrudTestCase(unittest2.TestCase):
     Relevant Pulp documentation:
 
     Create
-        http://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/repo/cud.html#create-a-repository
+        http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/cud.html#create-a-repository
     Read
-        http://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/repo/retrieval.html#retrieve-a-single-repository
+        http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/retrieval.html#retrieve-a-single-repository
     Update
-        http://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/repo/cud.html#update-a-repository
+        http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/cud.html#update-a-repository
     Delete
-        http://pulp.readthedocs.org/en/latest/dev-guide/integration/rest-api/repo/cud.html#delete-a-repository
+        http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/cud.html#delete-a-repository
     """
 
     @classmethod
@@ -384,9 +384,9 @@ def get_unit_type_ids(server_config):
     :returns: A set of content unit type IDs. For example: ``{'ostree',
         'python_package'}``.
 
-    .. [1] http://pulp-python.readthedocs.org/en/latest/
+    .. [1] http://pulp-python.readthedocs.io/en/latest/
     .. [2]
-        http://pulp-python.readthedocs.org/en/latest/reference/python-type.html
+        http://pulp-python.readthedocs.io/en/latest/reference/python-type.html
     """
     unit_types = api.Client(server_config).get(PLUGIN_TYPES_PATH).json()
     return {unit_type['id'] for unit_type in unit_types}


### PR DESCRIPTION
From an announcement sent on 2016-04-27:

> Starting today, Read the Docs will start hosting projects from
> subdomains on the domain readthedocs.io, instead of on
> readthedocs.org. This change addresses some security concerns around
> site cookies while hosting user generated data on the same domain as
> our dashboard.