### PR TITLE
Skip another test affected by Pulp issue 1905

### DIFF
--- a/pulp_smash/tests/rpm/api_v2/test_download_policies.py
+++ b/pulp_smash/tests/rpm/api_v2/test_download_policies.py
@@ -234,6 +234,9 @@ class FixFileCorruptionTestCase(utils.BaseAPITestCase):
         7. Trigger a repository download, with unit verification.
         """
         super(FixFileCorruptionTestCase, cls).setUpClass()
+        if (selectors.bug_is_untestable(1905, cls.cfg.version) and
+                _os_is_rhel6(cls.cfg)):
+            raise unittest2.SkipTest('https://pulp.plan.io/issues/1905')
 
         # Ensure Pulp is empty of units otherwise we might just associate pre-
         # existing units.


### PR DESCRIPTION
Test case `FixFileCorruptionTestCase` in module
`pulp_smash.tests.rpm.api_v2.test_download_policies` is affected by Pulp
issue 1905. [1] This can be proved by running the test case and
examining logs on the target system as the tests run. Skip the test case
when the Pulp host is running RHEL 6. Tests executed against F23 and
RHEL6 hosts with the following command:

    python -m unittest2 \
        pulp_smash.tests.rpm.api_v2.test_download_policies.FixFileCorruption

Test results are improved on RHEL 6 and unchanged on other platforms.

[1] https://pulp.plan.io/issues/1905