### PR TITLE
Skip tests affected by Pulp issue 1909

### DIFF
--- a/pulp_smash/tests/docker/cli/test_sync_publish.py
+++ b/pulp_smash/tests/docker/cli/test_sync_publish.py
@@ -50,6 +50,9 @@ class SyncV1TestCase(_SuccessMixin, _BaseTestCase):
     def setUpClass(cls):
         """Create and sync a docker repository with a v1 registry."""
         super(SyncV1TestCase, cls).setUpClass()
+        if (cls.cfg.version >= Version('2.9') and
+                selectors.bug_is_untestable(1909, cls.cfg.version)):
+            raise unittest2.SkipTest('https://pulp.plan.io/issues/1909')
         docker_utils.repo_create(
             cls.cfg,
             feed=DOCKER_V1_FEED_URL,
@@ -100,6 +103,9 @@ class SyncPublishV2TestCase(_SuccessMixin, _BaseTestCase):
         super(SyncPublishV2TestCase, cls).setUpClass()
         if cls.cfg.version < Version('2.8'):
             raise unittest2.SkipTest('These tests require Pulp 2.8 or above.')
+        if (cls.cfg.version >= Version('2.9') and
+                selectors.bug_is_untestable(1909, cls.cfg.version)):
+            raise unittest2.SkipTest('https://pulp.plan.io/issues/1909')
         docker_utils.repo_create(
             cls.cfg,
             feed=DOCKER_V2_FEED_URL,
@@ -234,6 +240,9 @@ class SyncUnnamespacedV2TestCase(_SuccessMixin, _BaseTestCase):
         super(SyncUnnamespacedV2TestCase, cls).setUpClass()
         if cls.cfg.version < Version('2.8'):
             raise unittest2.SkipTest('These tests require Pulp 2.8 or above.')
+        if (cls.cfg.version >= Version('2.9') and
+                selectors.bug_is_untestable(1909, cls.cfg.version)):
+            raise unittest2.SkipTest('https://pulp.plan.io/issues/1909')
         docker_utils.repo_create(
             cls.cfg,
             feed=DOCKER_V2_FEED_URL,


### PR DESCRIPTION
Pulp issue 1909 [1] describes how Pulp 2.9 cannot sync Docker
repositories. Skip test cases affected by this issue:

* `pulp_smash.tests.docker.cli.test_sync_publish.SyncPublishV2TestCase`
* `pulp_smash.tests.docker.cli.test_sync_publish.SyncUnnamespacedV2TestCase`
* `pulp_smash.tests.docker.cli.test_sync_publish.SyncV1TestCase`

Tests executed with:

    python -m unittest2 pulp_smash.tests.docker.cli.test_sync_publish

Test results are unaffected when the target Pulp system is running Pulp
2.8, and are improved when the target Pulp system is running Pulp 2.9.