### PR TITLE
Fix test for RPM repo content unit counts

### DIFF
--- a/pulp_smash/tests/rpm/api_v2/test_download_policies.py
+++ b/pulp_smash/tests/rpm/api_v2/test_download_policies.py
@@ -283,7 +283,16 @@ class FixFileCorruptionTestCase(utils.BaseAPITestCase):
 
     def test_units_after_download(self):
         """Assert all units are downloaded after download_repo finishes."""
-        self.assertEqual(self.repo_post_download['locally_stored_units'], 39)
+        # Support for package langpacks has been added in Pulp 2.9. In earlier
+        # versions, langpacks are ignored.
+        locally_stored_units = 39  # See repo['content_unit_counts']
+        if self.cfg.version >= Version('2.9'):
+            locally_stored_units += 1
+        self.assertEqual(
+            self.repo_post_download['locally_stored_units'],
+            locally_stored_units,
+            self.repo_post_download,
+        )
 
     def test_corruption_occurred(self):
         """Assert the checksum after corrupting an RPM isn't the same.


### PR DESCRIPTION
Support for langpacks has been added in Pulp 2.9. In earlier versions of
Pulp, repositories do not track this type of content unit. Consequently,
tests that verify the number of content units in repositories must take
this in to account.

Update test `FixFileCorruptionTestCase.test_units_after_download` in
module `pulp_smash.tests.rpm.api_v2.test_download_policies`. This test
now succeeds when run against a Pulp 2.9 system, and there is no change
when the test is run against a Pulp 2.8 system. Tests executed with:

    python -m unittest2 pulp_smash.tests.rpm.api_v2.test_download_policies