### PR TITLE
Fix broken sudo logic

### DIFF
--- a/pulp_smash/tests/rpm/api_v2/test_export.py
+++ b/pulp_smash/tests/rpm/api_v2/test_export.py
@@ -128,7 +128,7 @@ class ExportDistributorTestCase(utils.BaseAPITestCase):
         if (_has_getenforce(self.cfg) and
                 _run_getenforce(self.cfg).lower() == 'enforcing' and
                 selectors.bug_is_untestable(616, self.cfg.version)):
-            sudo = 'sudo ' if utils.is_root(self.cfg) else ''
+            sudo = '' if utils.is_root(self.cfg) else 'sudo '
             client.run((sudo + 'setenforce 0').split())
             self.addCleanup(client.run, (sudo + 'setenforce 1').split())
 


### PR DESCRIPTION
Function `utils.is_root` tells whether the Pulp Smash CLI client has
root access on a target system. A common use case for this function is
deciding whether to prefix a command with `sudo` or not. (`sudo` is an
optional system utility.) Fix an incorrect bit of logic that prepends
CLI commands with "sudo" when the test already has root access.