### PR TITLE
Skip an abstract test case class

### DIFF
--- a/pulp_smash/tests/platform/api_v2/test_content_applicability.py
+++ b/pulp_smash/tests/platform/api_v2/test_content_applicability.py
@@ -15,8 +15,10 @@ and :class:`ParallelTestCase` test these two use cases, respectively.
 """
 from __future__ import unicode_literals
 
+import inspect
+
+import unittest2
 from packaging.version import Version
-from unittest2 import TestCase
 
 from pulp_smash import api, config
 from pulp_smash.constants import CALL_REPORT_KEYS, GROUP_CALL_REPORT_KEYS
@@ -27,11 +29,13 @@ _PATHS = {
 }
 
 
-class _SuccessTestCase(TestCase):
+class _SuccessTestCase(unittest2.TestCase):
 
     @classmethod
     def setUpClass(cls):
         """Provide a server config and an empty set of responses."""
+        if inspect.getmro(cls)[0] == _SuccessTestCase:
+            raise unittest2.SkipTest('Abstract base class.')
         cls.cfg = config.get_config()
         cls.responses = {}
 
@@ -99,7 +103,7 @@ class ParallelTestCase(_SuccessTestCase):
                 self.assertEqual(response_keys, GROUP_CALL_REPORT_KEYS)
 
 
-class FailureTestCase(TestCase):
+class FailureTestCase(unittest2.TestCase):
     """Fail to generate content applicability for consumers and repos."""
 
     @classmethod


### PR DESCRIPTION
test_content_applicability makes use of an abstract test case class for the
success tests, make sure it will be skipped and not counted as a valid test.