### PR TITLE
Add tests that search for RPM & SRPM units

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -74,6 +74,7 @@ developers, not a gospel.
     api/pulp_smash.tests.rpm.api_v2.test_retain_old_count
     api/pulp_smash.tests.rpm.api_v2.test_schedule_publish
     api/pulp_smash.tests.rpm.api_v2.test_schedule_sync
+    api/pulp_smash.tests.rpm.api_v2.test_search
     api/pulp_smash.tests.rpm.api_v2.test_sync_publish
     api/pulp_smash.tests.rpm.api_v2.test_unassociate
     api/pulp_smash.tests.rpm.api_v2.test_updateinfo

--- a/docs/api/pulp_smash.tests.rpm.api_v2.test_search.rst
+++ b/docs/api/pulp_smash.tests.rpm.api_v2.test_search.rst
@@ -1,0 +1,6 @@
+`pulp_smash.tests.rpm.api_v2.test_search`
+=========================================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.rpm.api_v2.test_search`
+
+.. automodule:: pulp_smash.tests.rpm.api_v2.test_search

--- a/pulp_smash/constants.py
+++ b/pulp_smash/constants.py
@@ -12,6 +12,13 @@ CALL_REPORT_KEYS = frozenset(('error', 'result', 'spawned_tasks'))
     http://pulp.readthedocs.io/en/latest/dev-guide/conventions/sync-v-async.html#call-report
 """
 
+CONTENT_UNITS_PATH = '/pulp/api/v2/content/units/'
+"""See: `Search for Units`_.
+
+.. _Search for Units:
+    http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/content/units.html#search-for-units
+"""
+
 CONTENT_UPLOAD_PATH = '/pulp/api/v2/content/uploads/'
 """See: `Creating an Upload Request`_.
 
@@ -211,6 +218,9 @@ RPM_SHA256_CHECKSUM = (
 
 RPM_URL = urljoin(RPM_FEED_URL, RPM)
 """The URL to an RPM file. Built from :data:`RPM_FEED_URL` and :data:`RPM`."""
+
+SRPM = 'test-srpm02-1.0-1.src.rpm'
+"""The name of an SRPM file at :data:`pulp_smash.constants.SRPM_FEED_URL`."""
 
 SRPM_FEED_URL = (
     'https://repos.fedorapeople.org/repos/pulp/pulp/demo_repos/test_srpm_repo/'

--- a/pulp_smash/tests/rpm/api_v2/test_search.py
+++ b/pulp_smash/tests/rpm/api_v2/test_search.py
@@ -1,0 +1,184 @@
+# coding=utf-8
+"""Test Pulp's `Searching`_ facilities.
+
+The test cases in this module searches for content units by their type. See:
+
+* `Pulp Smash #133`_ asks for tests showing that it's possible to search for
+  content units by their type.
+* The `Search for Units`_ API documentation is relevant.
+
+.. _Pulp Smash #133: https://github.com/PulpQE/pulp-smash/issues/133
+.. _Search for Units:
+    http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/content/units.html#search-for-units
+.. _Searching:
+    http://pulp.readthedocs.io/en/latest/dev-guide/conventions/criteria.html
+"""
+from __future__ import unicode_literals
+
+import inspect
+
+import unittest2
+
+from pulp_smash import api, utils
+from pulp_smash.compat import urljoin
+from pulp_smash.constants import (
+    CONTENT_UNITS_PATH,
+    REPOSITORY_PATH,
+    RPM,
+    RPM_FEED_URL,
+    SRPM,
+    SRPM_FEED_URL,
+)
+from pulp_smash.tests.rpm.api_v2.utils import gen_repo
+from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+
+
+class BaseSearchTestCase(utils.BaseAPITestCase):
+    """Provide common functionality for the other test cases in this module."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create and sync a repository."""
+        if inspect.getmro(cls)[0] == BaseSearchTestCase:
+            raise unittest2.SkipTest('Abstract base class.')
+        super(BaseSearchTestCase, cls).setUpClass()
+        body = gen_repo()
+        body['importer_config']['feed'] = cls.get_feed_url()
+        cls.repo = api.Client(cls.cfg).post(REPOSITORY_PATH, body).json()
+        cls.resources.add(cls.repo['_href'])
+        utils.sync_repo(cls.cfg, cls.repo['_href'])
+
+    @staticmethod
+    def get_feed_url():
+        """Return a repository feed URL. Used by :meth:`setUpClass`.
+
+        All child classes should override this method.
+        """
+        raise NotImplementedError('Please provide a repository feed URL.')
+
+    def get_unit_by_filename(self, units, filename):
+        """Return the unit with the given filename.
+
+        Test methods in child classes may find this method to be of use.
+
+        :param units: An iterable of SRPM content units.
+        :param filename: The filename of one of the content units.
+        :returns: The content unit with the given filename.
+        :raises: An assertion error if more or less than one matching unit is
+            found.
+        """
+        matches = [unit for unit in units if unit['filename'] == filename]
+        self.assertEqual(len(matches), 1, matches)
+        return matches[0]
+
+
+class SearchForRpmTestCase(BaseSearchTestCase):
+    """Search for ``rpm`` content units in several different ways."""
+
+    @staticmethod
+    def get_feed_url():
+        """Return an RPM repository feed URL."""
+        return RPM_FEED_URL
+
+    def test_search_for_all(self):
+        """Search for all "rpm" units.
+
+        Perform the following searches. Assert a unit with filename
+        :data:`pulp_smash.constants.RPM` is in the search results.
+
+        ==== ====================
+        GET  n/a
+        POST ``{'criteria': {}}``
+        ==== ====================
+        """
+        def verify(units):
+            """Make assertions about search results."""
+            self.get_unit_by_filename(units, RPM)
+
+        client = api.Client(self.cfg, api.json_handler)
+        path = urljoin(CONTENT_UNITS_PATH, 'rpm/search/')
+        with self.subTest(method='get'):
+            verify(client.get(path))
+        with self.subTest(method='post'):
+            verify(client.post(path, {'criteria': {}}))
+
+    def test_include_repos(self):
+        """Search for all "rpm" units, and include repos in the results.
+
+        Perform the following searches. Assert a unit with filename
+        :data:`pulp_smash.constants.RPM` is in the search results, and assert
+        it belongs to the repository created in
+        :meth:`BaseSearchTestCase.setUpClass`.
+
+        ==== ====================
+        GET  ``{'include_repos': True}`` (urlencoded)
+        POST ``{'criteria': {}, 'include_repos': True}``
+        ==== ====================
+        """
+        def verify(units):
+            """Make assertions about search results."""
+            unit = self.get_unit_by_filename(units, RPM)
+            self.assertIn(self.repo['id'], unit['repository_memberships'])
+
+        client = api.Client(self.cfg, api.json_handler)
+        path = urljoin(CONTENT_UNITS_PATH, 'rpm/search/')
+        with self.subTest(method='get'):
+            verify(client.get(path, params={'include_repos': True}))
+        with self.subTest(method='post'):
+            verify(client.post(path, {'criteria': {}, 'include_repos': True}))
+
+
+class SearchForSrpmTestCase(BaseSearchTestCase):
+    """Search for ``srpm`` content units in several different ways."""
+
+    @staticmethod
+    def get_feed_url():
+        """Return an RPM repository feed URL."""
+        return SRPM_FEED_URL
+
+    def test_search_for_all(self):
+        """Search for all "srpm" units.
+
+        Perform the following searches. Assert a unit with filename
+        :data:`pulp_smash.constants.SRPM` is in the search results.
+
+        ==== ====================
+        GET  n/a
+        POST ``{'criteria': {}}``
+        ==== ====================
+        """
+        def verify(units):
+            """Make assertions about search results."""
+            self.get_unit_by_filename(units, SRPM)
+
+        client = api.Client(self.cfg, api.json_handler)
+        path = urljoin(CONTENT_UNITS_PATH, 'srpm/search/')
+        with self.subTest(method='get'):
+            verify(client.get(path))
+        with self.subTest(method='post'):
+            verify(client.post(path, {'criteria': {}}))
+
+    def test_include_repos(self):
+        """Search for all "srpm" units, and include repos in the results.
+
+        Perform the following searches. Assert a unit with filename
+        :data:`pulp_smash.constants.SRPM` is in the search results, and assert
+        it belongs to the repository created in
+        :meth:`BaseSearchTestCase.setUpClass`.
+
+        ==== ====================
+        GET  ``{'include_repos': True}`` (urlencoded)
+        POST ``{'criteria': {}, 'include_repos': True}``
+        ==== ====================
+        """
+        def verify(units):
+            """Make assertions about search results."""
+            unit = self.get_unit_by_filename(units, SRPM)
+            self.assertIn(self.repo['id'], unit['repository_memberships'])
+
+        client = api.Client(self.cfg, api.json_handler)
+        path = urljoin(CONTENT_UNITS_PATH, 'srpm/search/')
+        with self.subTest(method='get'):
+            verify(client.get(path, params={'include_repos': True}))
+        with self.subTest(method='post'):
+            verify(client.post(path, {'criteria': {}, 'include_repos': True}))


### PR DESCRIPTION
Add module `pulp_smash.tests.rpm.api_v2.test_search`. This module has
two test cases:

* `SearchRpmTestCase`
* `SearchSrpmTestCase`

The `SearchRpmTestCase` creates and syncs an RPM repository, then
executes a variety of searches for RPM content units. The
`SearchSrpmTestCase` does the same, but for SRPM.

Add a new constant, `SRPM`. This new constant is the name of an SRPM
file, and it's used by `SearchSrpmTestCase`.

Related to https://github.com/PulpQE/pulp-smash/issues/133