### PR TITLE
Refactor DuplicateUploadsMixin base test case

### DIFF
--- a/pulp_smash/tests/docker/api_v2/test_duplicate_uploads.py
+++ b/pulp_smash/tests/docker/api_v2/test_duplicate_uploads.py
@@ -29,14 +29,11 @@ class DuplicateUploadsTestCase(
 
     @classmethod
     def setUpClass(cls):
-        """Create a Docker repository. Upload a Docker image into it twice."""
+        """Create a Docker repository."""
         super(DuplicateUploadsTestCase, cls).setUpClass()
         unit = utils.http_get(DOCKER_IMAGE_URL)
         unit_type_id = 'docker_image'
         client = api.Client(cls.cfg, api.json_handler)
         repo_href = client.post(REPOSITORY_PATH, gen_repo())['_href']
         cls.resources.add(repo_href)
-        cls.call_reports = tuple((
-            utils.upload_import_unit(cls.cfg, unit, unit_type_id, repo_href)
-            for _ in range(2)
-        ))
+        cls.upload_import_unit_args = (cls.cfg, unit, unit_type_id, repo_href)

--- a/pulp_smash/tests/puppet/api_v2/test_duplicate_uploads.py
+++ b/pulp_smash/tests/puppet/api_v2/test_duplicate_uploads.py
@@ -29,14 +29,11 @@ class DuplicateUploadsTestCase(
 
     @classmethod
     def setUpClass(cls):
-        """Create a Puppet repository. Upload a Puppet module into it twice."""
+        """Create a Puppet repository."""
         super(DuplicateUploadsTestCase, cls).setUpClass()
         unit = utils.http_get(PUPPET_MODULE_URL)
         unit_type_id = 'puppet_module'
         client = api.Client(cls.cfg, api.json_handler)
         repo_href = client.post(REPOSITORY_PATH, gen_repo())['_href']
         cls.resources.add(repo_href)
-        cls.call_reports = tuple((
-            utils.upload_import_unit(cls.cfg, unit, unit_type_id, repo_href)
-            for _ in range(2)
-        ))
+        cls.upload_import_unit_args = (cls.cfg, unit, unit_type_id, repo_href)

--- a/pulp_smash/tests/python/api_v2/test_duplicate_uploads.py
+++ b/pulp_smash/tests/python/api_v2/test_duplicate_uploads.py
@@ -36,7 +36,4 @@ class DuplicateUploadsTestCase(
         client = api.Client(cls.cfg, api.json_handler)
         repo_href = client.post(REPOSITORY_PATH, gen_repo())['_href']
         cls.resources.add(repo_href)
-        cls.call_reports = tuple((
-            utils.upload_import_unit(cls.cfg, unit, unit_type_id, repo_href)
-            for _ in range(2)
-        ))
+        cls.upload_import_unit_args = (cls.cfg, unit, unit_type_id, repo_href)

--- a/pulp_smash/tests/rpm/api_v2/test_duplicate_uploads.py
+++ b/pulp_smash/tests/rpm/api_v2/test_duplicate_uploads.py
@@ -37,7 +37,4 @@ class DuplicateUploadsTestCase(
         client = api.Client(cls.cfg, api.json_handler)
         repo_href = client.post(REPOSITORY_PATH, gen_repo())['_href']
         cls.resources.add(repo_href)
-        cls.call_reports = tuple((
-            utils.upload_import_unit(cls.cfg, unit, unit_type_id, repo_href)
-            for _ in range(2)
-        ))
+        cls.upload_import_unit_args = (cls.cfg, unit, unit_type_id, repo_href)

--- a/pulp_smash/utils.py
+++ b/pulp_smash/utils.py
@@ -313,20 +313,23 @@ class DuplicateUploadsMixin(object):  # pylint:disable=too-few-public-methods
     * https://pulp.plan.io/issues/1406
     * https://github.com/PulpQE/pulp-smash/issues/81
 
-    This mixin adds tests for this case. This mixin requires an attribute named
-    ``call_reports`` be present, where this attribute is an iterable of the
-    call reports produced by steps 2 and 3, above.
+    This mixin adds tests for this case. Child classes should do the following:
+
+    * Create a repository. Content units will be uploaded into this repository.
+    * Create a class or instance attribute named ``upload_import_unit_args``.
+      It should be an iterable whose contents match the signature of
+      :meth:`upload_import_unit`.
     """
 
-    def test_call_report_result(self):
-        """Assert each call report's "result" field is null.
+    def test_01_first_upload(self):
+        """Upload a content unit to a repository."""
+        call_report = upload_import_unit(*self.upload_import_unit_args)
+        self.assertIsNone(call_report['result'])
 
-        Other checks are done automatically by
-        :func:`pulp_smash.api.json_handler`. See it for details.
-        """
-        for i, call_report in enumerate(self.call_reports):
-            with self.subTest(i=i):
-                self.assertIsNone(call_report['result'])
+    def test_02_second_upload(self):
+        """Upload the same content unit to the same repository."""
+        call_report = upload_import_unit(*self.upload_import_unit_args)
+        self.assertIsNone(call_report['result'])
 
 
 def reset_squid(server_config):


### PR DESCRIPTION
The `DuplicateUploadsMixin` is designed to test the following procedure:

1. Create a repository without a feed.
2. Upload a package into the repository.
3. Upload the same package into the repository.

The class is currently designed such that the two uploads should occur
in method `setUpClass`.

Refactor the test case so that repository creation occurs in
`setUpClass` and the uploads occur in the test methods. This makes it
easier to tell which of the two uploads failed, and it ensures the class
always cleans up after itself.

This change doesn't affect test coverage or introduce any test failures.
It adds four new tests. Tests executed with:

    python -m unittest2 \
        pulp_smash.tests.docker.api_v2.test_duplicate_uploads \
        pulp_smash.tests.puppet.api_v2.test_duplicate_uploads \
        pulp_smash.tests.python.api_v2.test_duplicate_uploads \
        pulp_smash.tests.rpm.api_v2.test_duplicate_uploads