### PR TITLE
Increase hard-coded timeout by order of magnitude

### DIFF
--- a/pulp_smash/api.py
+++ b/pulp_smash/api.py
@@ -354,7 +354,10 @@ def poll_task(server_config, href):
     :raises pulp_smash.exceptions.TaskTimedOutError: If a task takes too
         long to complete.
     """
-    poll_limit = 36  # 36 * 5s == 180s
+    # 360 * 5s == 1800s == 30m
+    # NOTE: The timeout counter is synchronous. We query Pulp, then count down,
+    # then query pulp, then count down, etc. This is… dumb.
+    poll_limit = 360
     poll_counter = 0
     while True:
         response = requests.get(
@@ -376,6 +379,4 @@ def poll_task(server_config, href):
             raise exceptions.TaskTimedOutError(
                 'Task {} is ongoing after {} polls.'.format(href, poll_limit)
             )
-        # This approach is dumb, in that we don't account for time spent
-        # waiting for the Pulp server to respond to us.
         sleep(5)


### PR DESCRIPTION
Pulp Smash has a task polling function, `poll_task`, that waits for a
task to complete and then polls each task spawned by the current task.
This function includes a hard-coded time-out. This is intended to let
Pulp Smash continue testing, even if Pulp produces a never-ending task.

The time-out is currently set to 3+ minutes. [1] This is generally
reasonable, but frequently, one or several tasks will take more than
this long. This is problematic: Pulp Smash is not in the business of
enforcing performance metrics, and it should not fail simply because of
an annoying level of slowness.

Change the time-out to 30+ minutes. This is an enormously long period of
time for any single task, and it should produce very few false-positive
test errors.