### PR TITLE
Move and refactor RPM CRUD tests

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -63,6 +63,7 @@ developers, not a gospel.
     api/pulp_smash.tests.rpm.api_v2
     api/pulp_smash.tests.rpm.api_v2.test_broker
     api/pulp_smash.tests.rpm.api_v2.test_comps_xml
+    api/pulp_smash.tests.rpm.api_v2.test_crud
     api/pulp_smash.tests.rpm.api_v2.test_download_policies
     api/pulp_smash.tests.rpm.api_v2.test_duplicate_uploads
     api/pulp_smash.tests.rpm.api_v2.test_export

--- a/docs/api/pulp_smash.tests.rpm.api_v2.test_crud.rst
+++ b/docs/api/pulp_smash.tests.rpm.api_v2.test_crud.rst
@@ -1,0 +1,6 @@
+`pulp_smash.tests.rpm.api_v2.test_crud`
+=======================================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.rpm.api_v2.test_crud`
+
+.. automodule:: pulp_smash.tests.rpm.api_v2.test_crud

--- a/pulp_smash/tests/rpm/api_v2/test_crud.py
+++ b/pulp_smash/tests/rpm/api_v2/test_crud.py
@@ -1,0 +1,37 @@
+# coding=utf-8
+"""Tests that CRUD RPM repositories.
+
+For information on repository CRUD operations, see `Creation, Deletion and
+Configuration
+<http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/cud.html>`_.
+"""
+from __future__ import unicode_literals
+
+from pulp_smash import utils
+from pulp_smash.tests.rpm.api_v2.utils import gen_repo
+from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+
+
+class CrudTestCase(utils.BaseAPICrudTestCase):
+    """CRUD a minimal RPM repository."""
+
+    @staticmethod
+    def create_body():
+        """Return a dict for creating a repository."""
+        return gen_repo()
+
+    @staticmethod
+    def update_body():
+        """Return a dict for updating a repository."""
+        return {'delta': {'display_name': utils.uuid4()}}
+
+
+class CrudWithFeedTestCase(CrudTestCase):
+    """CRUD an RPM repository with a feed URL."""
+
+    @staticmethod
+    def create_body():
+        """Return a dict for creating a repository."""
+        body = CrudTestCase.create_body()
+        body['importer_config'] = {'feed': utils.uuid4()}
+        return body

--- a/pulp_smash/tests/rpm/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_sync_publish.py
@@ -1,33 +1,13 @@
 # coding=utf-8
-"""Test the API endpoints for RPM `repositories`_.
+"""Tests that sync and publish RPM repositories.
 
-This module assumes that the tests in
-:mod:`pulp_smash.tests.platform.api_v2.test_repository` hold true. The
-following trees of assumptions are explored in this module::
+For information on repository sync and publish operations, see
+`Synchronization`_ and `Publication`_.
 
-    It is possible to create an RPM repo with a feed. (CreateTestCase)
-    ├── If a valid feed is given, the sync completes and no errors are
-    │   reported. (SyncValidFeedTestCase)
-    └── If an invalid feed is given, the sync completes and errors are
-        reported. (SyncInvalidFeedTestCase)
-
-    It is possible to create an RPM repository without a feed. (CreateTestCase)
-    └── It is possible to upload an RPM file to a repository, copy the
-        repository's contents to a second repository, add a distributor to the
-        first repository, publish the first repository, and download the
-        original RPM. (PublishTestCase)
-
-Assertions not explored in this module include:
-
-* Given an RPM repository without a feed, sync requests fail.
-* It is impossible to create two RPM repositories with the same relative URL.
-* It is possible to upload a directory of RPM files to an RPM repository.
-* It is possible to upload an ISO of RPM files to an RPM repository.
-* It is possible to upload content and copy it into multiple repositories.
-* It is possible to get content into a repository via a sync and publish it.
-
-.. _repositories:
-   http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/cud.html
+.. _Publication:
+    http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/publish.html
+.. _Synchronization:
+    http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/sync.html
 """
 from __future__ import unicode_literals
 
@@ -54,55 +34,6 @@ from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pyli
 
 
 _REPO_PUBLISH_PATH = '/pulp/repos/'  # + relative_url + unit_name.rpm.arch
-
-
-class CreateTestCase(utils.BaseAPITestCase):
-    """Create two RPM repositories, with and without feed URLs respectively."""
-
-    @classmethod
-    def setUpClass(cls):
-        """Create two RPM repositories, with and without feed URLs."""
-        super(CreateTestCase, cls).setUpClass()
-        client = api.Client(cls.cfg, api.json_handler)
-        cls.bodies = tuple((gen_repo() for _ in range(2)))
-        cls.bodies[1]['importer_config'] = {'feed': utils.uuid4()}
-        cls.repos = [client.post(REPOSITORY_PATH, body) for body in cls.bodies]
-        cls.importers_iter = [
-            client.get(urljoin(repo['_href'], 'importers/'))
-            for repo in cls.repos
-        ]
-        for repo in cls.repos:
-            cls.resources.add(repo['_href'])  # mark for deletion
-
-    def test_id_notes(self):
-        """Validate the ``id`` and ``notes`` attributes for each repository."""
-        for body, repo in zip(self.bodies, self.repos):  # for input, output:
-            for key in {'id', 'notes'}:
-                with self.subTest(body=body):
-                    self.assertIn(key, repo)
-                    self.assertEqual(repo[key], body[key])
-
-    def test_number_importers(self):
-        """Assert each repository has one importer."""
-        for body, importers in zip(self.bodies, self.importers_iter):
-            with self.subTest(body=body):
-                self.assertEqual(len(importers), 1)
-
-    def test_importer_type_id(self):
-        """Validate the ``importer_type_id`` attribute of each importer."""
-        key = 'importer_type_id'
-        for body, importers in zip(self.bodies, self.importers_iter):
-            with self.subTest(body=body):
-                self.assertIn(key, importers[0])
-                self.assertEqual(importers[0][key], body[key])
-
-    def test_importer_config(self):
-        """Validate the ``config`` attribute of each importer."""
-        key = 'config'
-        for body, importers in zip(self.bodies, self.importers_iter):
-            with self.subTest(body=body):
-                self.assertIn(key, importers[0])
-                self.assertEqual(importers[0][key], body['importer_' + key])
 
 
 # This class is left public for documentation purposes.


### PR DESCRIPTION
Move RPM CRUD tests from module
`pulp_smash.tests.rpm.api_v2.test_sync_publish` to module
`pulp_smash.tests.rpm.api_v2.test_crud`. This is in line with how other
plugin tests are structured: there are similarly-named modules for the
docker, puppet, ostree and python modules too.

Refactor the RPM CRUD tests. Use the `BaseAPICrudTestCase`, instead of
writing out numerous redundant test methods.

Simplify the docstring for module
`pulp_smash.tests.rpm.api_v2.test_sync_publish`.