### PR TITLE
Add tests for CRUD repository group

### DIFF
--- a/pulp_smash/constants.py
+++ b/pulp_smash/constants.py
@@ -192,6 +192,14 @@ REPOSITORY_PATH = '/pulp/api/v2/repositories/'
     https://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/index.html
 """
 
+REPOSITORY_GROUP_PATH = '/pulp/api/v2/repo_groups/'
+"""See: `Repository Group APIs`_
+
+.. _Repository Group APIs:
+    http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/groups/index.html
+"""
+
+
 CONSUMER_PATH = '/pulp/api/v2/consumers/'
 """See: `Consumer APIs`_.
 

--- a/pulp_smash/tests/rpm/api_v2/test_crud.py
+++ b/pulp_smash/tests/rpm/api_v2/test_crud.py
@@ -7,8 +7,9 @@ Configuration
 """
 from __future__ import unicode_literals
 
-from pulp_smash import utils
-from pulp_smash.tests.rpm.api_v2.utils import gen_repo
+from pulp_smash import api, utils
+from pulp_smash.constants import REPOSITORY_GROUP_PATH
+from pulp_smash.tests.rpm.api_v2.utils import gen_repo, gen_repo_group
 from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 
@@ -35,3 +36,66 @@ class CrudWithFeedTestCase(CrudTestCase):
         body = CrudTestCase.create_body()
         body['importer_config'] = {'feed': utils.uuid4()}
         return body
+
+
+class RepositoryGroupCrudTestCase(utils.BaseAPITestCase):
+    """CRUD a minimal RPM repositories' groups.
+
+    For information on repositories' groups CRUD operations, see `Creation,
+    Delete, and Update
+    <http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/groups/cud.html>`
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Create, update, read and delete a repository group."""
+        super(RepositoryGroupCrudTestCase, cls).setUpClass()
+        client = api.Client(cls.cfg)
+        cls.bodies = {
+            'create': gen_repo_group(),
+            'update': {'display_name': utils.uuid4()},
+        }
+        cls.responses = {}
+        cls.responses['create'] = client.post(
+            REPOSITORY_GROUP_PATH,
+            cls.bodies['create'],
+        )
+        repo_href = cls.responses['create'].json()['_href']
+        cls.responses['update'] = client.put(repo_href, cls.bodies['update'])
+        cls.responses['read'] = client.get(repo_href, params={'details': True})
+        cls.responses['delete'] = client.delete(repo_href)
+
+    def test_status_codes(self):
+        """Assert each response has a correct status code."""
+        for response, code in (
+                ('create', 201),
+                ('update', 200),
+                ('read', 200),
+                ('delete', 200)):
+            with self.subTest((response, code)):
+                self.assertEqual(self.responses[response].status_code, code)
+
+    def test_create(self):
+        """Assert the created repository group has all requested attributes.
+
+        Walk through each of the attributes present on the create body and
+        verify the attribute is present in the repository group.
+        """
+        received = self.responses['create'].json()
+        for key, value in self.bodies['create'].items():
+            with self.subTest(key=key, value=value):
+                self.assertEqual(received[key], value)
+
+    def test_update(self):
+        """Assert the repo group update response has the requested changes."""
+        received = self.responses['update'].json()
+        for key, value in self.bodies['update'].items():
+            with self.subTest(key=key, value=value):
+                self.assertEqual(received[key], value)
+
+    def test_read(self):
+        """Assert the repo group update response has the requested changes."""
+        received = self.responses['read'].json()
+        for key, value in self.bodies['update'].items():
+            with self.subTest(key=key, value=value):
+                self.assertEqual(received[key], value)

--- a/pulp_smash/tests/rpm/api_v2/utils.py
+++ b/pulp_smash/tests/rpm/api_v2/utils.py
@@ -23,6 +23,13 @@ def gen_repo():
     }
 
 
+def gen_repo_group():
+    """Return a semi-random dict for use in creating a RPM repository group."""
+    return {
+        'id': utils.uuid4(),
+    }
+
+
 def gen_distributor():
     """Return a semi-random dict for use in creating a YUM distributor."""
     return {


### PR DESCRIPTION
Introduce a new test case class which is responsible for ensure basic CRUD for
repository group works.

Related to #159

Test results for Pulp 2.9.0:

```
$ py.test pulp_smash/tests/rpm/api_v2/test_crud.py
================================ test session starts ================================
platform linux -- Python 3.4.3, pytest-2.9.2, py-1.4.31, pluggy-0.3.1
rootdir: /home/elyezer/code/pulp-smash, inifile: 
collected 18 items 

pulp_smash/tests/rpm/api_v2/test_crud.py ..................

============================= 18 passed in 1.71 seconds =============================
```

Test results for Pulp 2.8.5:

```
$ py.test pulp_smash/tests/rpm/api_v2/test_crud.py
================================ test session starts ================================
platform linux -- Python 3.4.3, pytest-2.9.2, py-1.4.31, pluggy-0.3.1
rootdir: /home/elyezer/code/pulp-smash, inifile: 
collected 18 items 

pulp_smash/tests/rpm/api_v2/test_crud.py ..................

============================ 18 passed in 46.14 seconds =============================
```