### PR TITLE
Add tests for repo group export

### DIFF
--- a/pulp_smash/constants.py
+++ b/pulp_smash/constants.py
@@ -185,6 +185,20 @@ PYTHON_WHEEL_URL = (
 )
 """The URL to a Python wheel."""
 
+REPOSITORY_EXPORT_DISTRIBUTOR = 'export_distributor'
+"""A ``distributor_type_id`` to export a repository.
+
+See: `Export Distributors
+<https://pulp-rpm.readthedocs.io/en/latest/tech-reference/export-distributor.html>`_.
+"""
+
+REPOSITORY_GROUP_EXPORT_DISTRIBUTOR = 'group_export_distributor'
+"""A ``distributor_type_id`` to export a repository group.
+
+See: `Export Distributors
+<https://pulp-rpm.readthedocs.io/en/latest/tech-reference/export-distributor.html>`_.
+"""
+
 REPOSITORY_PATH = '/pulp/api/v2/repositories/'
 """See: `Repository APIs`_.
 

--- a/pulp_smash/tests/rpm/api_v2/test_export.py
+++ b/pulp_smash/tests/rpm/api_v2/test_export.py
@@ -10,6 +10,7 @@ This module assumes that the tests in
 """
 from __future__ import unicode_literals
 
+import inspect
 import os
 from xml.dom import minidom
 
@@ -20,12 +21,19 @@ from packaging.version import Version
 from pulp_smash import api, cli, selectors, utils
 from pulp_smash.compat import urljoin, urlparse, urlunparse
 from pulp_smash.constants import (
+    REPOSITORY_EXPORT_DISTRIBUTOR,
+    REPOSITORY_GROUP_EXPORT_DISTRIBUTOR,
+    REPOSITORY_GROUP_PATH,
     REPOSITORY_PATH,
     RPM,
     RPM_FEED_URL,
     RPM_SHA256_CHECKSUM,
 )
-from pulp_smash.tests.rpm.api_v2.utils import gen_distributor, gen_repo
+from pulp_smash.tests.rpm.api_v2.utils import (
+    gen_distributor,
+    gen_repo,
+    gen_repo_group,
+)
 from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 
@@ -55,27 +63,28 @@ def _run_getenforce(server_config):
     return client.run(('/usr/sbin/getenforce',)).stdout.strip()
 
 
-def _create_distributor(server_config, repo_href, checksum_type=None):
-    """Create an export distributor for the repository at ``repo_href``."""
-    path = urljoin(repo_href, 'distributors/')
+def _create_distributor(
+        server_config, href, distributor_type_id, checksum_type=None):
+    """Create an export distributor for the entity at ``href``."""
+    path = urljoin(href, 'distributors/')
     body = gen_distributor()
-    body['distributor_type_id'] = 'export_distributor'
+    body['distributor_type_id'] = distributor_type_id
     if checksum_type is not None:
         body['distributor_config']['checksum_type'] = checksum_type
     return api.Client(server_config).post(path, body).json()
 
 
-def _get_iso_url(cfg, repo, distributor):
+def _get_iso_url(cfg, entity, entity_type, distributor):
     """Build the URL to the ISO file.
 
     By default, the file is named like so:
     {repo_id}-{iso_creation_time}-{iso_number}.iso
     """
     iso_name = '{}-{}-01.iso'.format(
-        repo['id'],
+        entity['id'],
         parse(distributor['last_publish']).strftime('%Y-%m-%dT%H.%M')
     )
-    path = '/pulp/exports/repos/'
+    path = '/pulp/exports/{}/'.format(entity_type)
     path = urljoin(path, distributor['config']['relative_url'])
     iso_path = urljoin(path, iso_name)
     return urljoin(cfg.base_url, iso_path)
@@ -91,6 +100,9 @@ class ExportDirMixin(object):
     2. Export a repository to the directory.
     3. Make the directory readable. (See :meth:`change_export_dir_owner`.)
     4. Inspect the contents of the directory.
+
+    :meth:`publish_to_dir` conveniently executes steps 1–3. Consider using the
+    other methods only if more granularity is needed.
 
     A class attribute named ``cfg`` must be present. It should be a
     :class:`pulp_smash.config.ServerConfig`.
@@ -153,17 +165,41 @@ class ExportDirMixin(object):
         client.run(
             (self.sudo() + 'chown -R {} {}'.format(uid, export_dir)).split())
 
+    def publish_to_dir(self, entity_href, distributor_id):
+        """Create an export directory, publish to it, and change its owner.
 
-class ExportChecksumTypeTestCase(ExportDirMixin, utils.BaseAPITestCase):
-    """Publish a repository choosing the distributor checksum type."""
+        For details, see :class:`ExportDirMixin`.
+
+        :param entity_href: The path to an entity such as a repository or a
+            repository group.
+        :param distributor_id: The ID of the distributor to use when exporting.
+        :returns: The path to the export directory.
+        """
+        export_dir = self.create_export_dir()
+        api.Client(self.cfg).post(urljoin(entity_href, 'actions/publish/'), {
+            'id': distributor_id,
+            'override_config': {'export_dir': export_dir},
+        })
+        self.change_export_dir_owner(export_dir)
+        return export_dir
+
+
+class BaseExportChecksumTypeTestCase(ExportDirMixin, utils.BaseAPITestCase):
+    """Base class for repo and repo group export with checksum type tests."""
 
     @classmethod
     def setUpClass(cls):
-        """Create and sync a repository. Creates some distributors.
+        """Create and sync a repository.
 
-        Each distributor is configured with a valid checksum type.
+        Also skips the test if Pulp version less than 2.9.
+
+        Children of this base class must provide a ``distributors`` attribute
+        with the list of distributors to export a repository or repository
+        group.
         """
-        super(ExportChecksumTypeTestCase, cls).setUpClass()
+        if inspect.getmro(cls)[0] == BaseExportChecksumTypeTestCase:
+            raise unittest2.SkipTest('Abstract base class.')
+        super(BaseExportChecksumTypeTestCase, cls).setUpClass()
         if cls.cfg.version < Version('2.9'):
             raise unittest2.SkipTest('This test requires Pulp 2.9 or newer')
         body = gen_repo()
@@ -171,66 +207,96 @@ class ExportChecksumTypeTestCase(ExportDirMixin, utils.BaseAPITestCase):
         cls.repo = api.Client(cls.cfg).post(REPOSITORY_PATH, body).json()
         cls.resources.add(cls.repo['_href'])
         utils.sync_repo(cls.cfg, cls.repo['_href'])
-        cls.distributors = [
-            _create_distributor(cls.cfg, cls.repo['_href'], checksum_type)
-            for checksum_type in ('md5', 'sha1', 'sha256')
-        ]
 
-    def _publish_to_dir(self, distributor):
-        """Publish repository to dir using the ``distributor`` argument."""
-        export_dir = self.create_export_dir()
-        # Publish into the directory
-        path = urljoin(self.repo['_href'], 'actions/publish/')
-        api.Client(self.cfg).post(path, {
-            'id': distributor['id'],
-            'override_config': {'export_dir': export_dir},
-        })
-        self.change_export_dir_owner(export_dir)
-        return export_dir
-
-    def _publish_to_web(self, distributor):
-        """Publish repository to web using the ``distributor`` argument.
+    def _publish_to_web(self, entity, distributor):
+        """Publish ``entity`` to web using the ``distributor``.
 
         Return the updated distributor information.
         """
         client = api.Client(self.cfg, api.json_handler)
-        path = urljoin(self.repo['_href'], 'actions/publish/')
+        path = urljoin(entity['_href'], 'actions/publish/')
         client.post(path, {'id': distributor['id']})
         return client.get(distributor['_href'])
 
-    def _assert_checksum_type(self, export_dir, distributor, checksum_type):
-        repomd_path = os.path.join(
-            export_dir,
-            distributor['config']['relative_url'],
-            'repodata',
-            'repomd.xml'
-        )
+    def _assert_checksum_type(self, path, checksum_type):
+        """Assert repomd.xml have the proper ``checksum_type``.
+
+        ``path`` must be the remote path of the repomd.xml file.
+        """
         document = minidom.parseString(cli.Client(self.cfg).run(
-            'cat {}'.format(repomd_path).split()).stdout)
+            'cat {}'.format(path).split()).stdout)
         self.assertTrue(all([
             element.attributes.get('type').value == checksum_type
             for element in document.getElementsByTagName('checksum')
         ]))
 
+    def get_export_entity(self):
+        """Provide the export entity.
+
+        The entity can be either a repository or a repository group.
+        """
+        raise NotImplementedError(
+            'Please provide an export entity. Either a repository or a '
+            'repository group.'
+        )
+
+    def get_repomd_publish_path(self, export_dir, distributor):
+        """Provide the repomd.xml publish path.
+
+        Repository and repository group exports have a different path to
+        repomd.xml file.
+        """
+        raise NotImplementedError(
+            'Please provide the repomd.xml publish path.')
+
+    def get_repomd_iso_publish_path(self, export_dir, distributor):
+        """Provide the repomd.xml publish path within an exported ISO.
+
+        Repository and repository group exports have a different path to
+        repomd.xml file within the exported ISO.
+        """
+        raise NotImplementedError(
+            'Please provide the repomd.xml ISO publish path.')
+
+    def get_export_entity_type(self):
+        """Provide the export entity type.
+
+        Return ``repos`` for repository and ``repo_group`` for repository
+        group.
+        """
+        raise NotImplementedError(
+            'Please provide the export entity type: ``repos`` for repository '
+            'and ``repo_group`` for repository group.'
+        )
+
     def test_publish_to_dir_checksum_type(self):  # pylint:disable=invalid-name
         """Publish to a directory choosing the checksum type."""
-        for distributor in self.distributors:
+        for distributor in self.distributors:  # pylint:disable=no-member
             checksum_type = distributor['config']['checksum_type']
             with self.subTest(msg=checksum_type):
+                export_dir = self.publish_to_dir(
+                    self.get_export_entity()['_href'],
+                    distributor['id'],
+                )
                 self._assert_checksum_type(
-                    self._publish_to_dir(distributor),
-                    distributor,
+                    self.get_repomd_publish_path(export_dir, distributor),
                     checksum_type
                 )
 
     def test_publish_to_web_checksum_type(self):  # pylint:disable=invalid-name
         """Publish to web choosing the checksum type."""
         client = cli.Client(self.cfg)
-        for distributor in self.distributors:
+        for distributor in self.distributors:  # pylint:disable=no-member
             checksum_type = distributor['config']['checksum_type']
             with self.subTest(msg=checksum_type):
-                distributor = self._publish_to_web(distributor)
-                url = _get_iso_url(self.cfg, self.repo, distributor)
+                distributor = self._publish_to_web(
+                    self.get_export_entity(), distributor)
+                url = _get_iso_url(
+                    self.cfg,
+                    self.get_export_entity(),
+                    self.get_export_entity_type(),
+                    distributor
+                )
                 export_dir = client.run(
                     'mktemp --directory'.split()).stdout.strip()
                 iso_path = client.run('mktemp'.split()).stdout.strip()
@@ -249,10 +315,113 @@ class ExportChecksumTypeTestCase(ExportDirMixin, utils.BaseAPITestCase):
                     (self.sudo() + 'umount {}'.format(export_dir)).split()
                 )
                 self._assert_checksum_type(
-                    export_dir,
-                    distributor,
+                    self.get_repomd_iso_publish_path(export_dir, distributor),
                     checksum_type
                 )
+
+
+class ExportChecksumTypeTestCase(BaseExportChecksumTypeTestCase):
+    """Publish a repository choosing the distributor checksum type."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create some distributors.
+
+        Each distributor is configured with a valid checksum type.
+        """
+        super(ExportChecksumTypeTestCase, cls).setUpClass()
+        cls.distributors = [
+            _create_distributor(
+                cls.cfg, cls.repo['_href'],
+                REPOSITORY_EXPORT_DISTRIBUTOR,
+                checksum_type
+            )
+            for checksum_type in ('md5', 'sha1', 'sha256')
+        ]
+
+    def get_export_entity(self):
+        """Provide the export entity."""
+        return self.repo
+
+    def get_repomd_publish_path(self, export_dir, distributor):
+        """Provide the repomd.xml publish path."""
+        return os.path.join(
+            export_dir,
+            distributor['config']['relative_url'],
+            'repodata',
+            'repomd.xml'
+        )
+
+    def get_export_entity_type(self):
+        """Provide the export entity type."""
+        return 'repos'
+
+    def get_repomd_iso_publish_path(self, export_dir, distributor):
+        """Provide the repomd.xml publish path within an exported ISO."""
+        return os.path.join(
+            export_dir,
+            distributor['config']['relative_url'],
+            'repodata',
+            'repomd.xml'
+        )
+
+
+class RepoGroupExportChecksumTypeTestCase(BaseExportChecksumTypeTestCase):
+    """Publish a repository group choosing the distributor checksum type."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create required entities for publishing a repository group.
+
+        Do the following:
+
+        1. Create a repository group and add the repository created by super
+           call.
+        2. Creates some distributors. Each distributor is configured with a
+           valid checksum type.
+        """
+        super(RepoGroupExportChecksumTypeTestCase, cls).setUpClass()
+        body = gen_repo_group()
+        body['repo_ids'] = [cls.repo['id']]
+        cls.repo_group = api.Client(cls.cfg).post(
+            REPOSITORY_GROUP_PATH, body).json()
+        cls.resources.add(cls.repo_group['_href'])
+        cls.distributors = [
+            _create_distributor(
+                cls.cfg,
+                cls.repo_group['_href'],
+                REPOSITORY_GROUP_EXPORT_DISTRIBUTOR,
+                checksum_type
+            )
+            for checksum_type in ('md5', 'sha1', 'sha256')
+        ]
+
+    def get_export_entity(self):
+        """Provide the export entity."""
+        return self.repo_group
+
+    def get_repomd_publish_path(self, export_dir, distributor):
+        """Provide the repomd.xml publish path."""
+        return os.path.join(
+            export_dir,
+            distributor['config']['relative_url'],
+            self.repo['id'],
+            'repodata',
+            'repomd.xml'
+        )
+
+    def get_export_entity_type(self):
+        """Provide the export entity type."""
+        return 'repo_group'
+
+    def get_repomd_iso_publish_path(self, export_dir, distributor):
+        """Provide the repomd.xml publish path within an exported ISO."""
+        return os.path.join(
+            export_dir,
+            self.repo['id'],
+            'repodata',
+            'repomd.xml'
+        )
 
 
 class ExportDistributorTestCase(ExportDirMixin, utils.BaseAPITestCase):
@@ -277,7 +446,8 @@ class ExportDistributorTestCase(ExportDirMixin, utils.BaseAPITestCase):
                 selectors.bug_is_untestable(1928, cls.cfg.version)):
             cls.distributor = None
         else:
-            cls.distributor = _create_distributor(cls.cfg, cls.repo['_href'])
+            cls.distributor = _create_distributor(
+                cls.cfg, cls.repo['_href'], REPOSITORY_EXPORT_DISTRIBUTOR)
 
     def setUp(self):
         """Optionally create an export distributor.
@@ -290,6 +460,7 @@ class ExportDistributorTestCase(ExportDirMixin, utils.BaseAPITestCase):
             self.distributor = _create_distributor(
                 self.cfg,
                 self.repo['_href'],
+                REPOSITORY_EXPORT_DISTRIBUTOR
             )
 
     def test_publish_to_web(self):
@@ -306,7 +477,7 @@ class ExportDistributorTestCase(ExportDirMixin, utils.BaseAPITestCase):
 
         # Fetch the ISO file via HTTP and HTTPS.
         client.response_handler = api.safe_handler
-        url = _get_iso_url(self.cfg, self.repo, distributor)
+        url = _get_iso_url(self.cfg, self.repo, 'repos', distributor)
         for scheme in ('http', 'https'):
             url = urlunparse((scheme,) + urlparse(url)[1:])
             with self.subTest(url=url):
@@ -321,14 +492,10 @@ class ExportDistributorTestCase(ExportDirMixin, utils.BaseAPITestCase):
         This test is skipped if selinux is installed and enabled on the target
         system an `Pulp issue 616 <https://pulp.plan.io/issues/616>`_ is open.
         """
-        export_dir = self.create_export_dir()
-        # Publish into the directory
-        path = urljoin(self.repo['_href'], 'actions/publish/')
-        api.Client(self.cfg).post(path, {
-            'id': self.distributor['id'],
-            'override_config': {'export_dir': export_dir},
-        })
-        self.change_export_dir_owner(export_dir)
+        export_dir = self.publish_to_dir(
+            self.repo['_href'],
+            self.distributor['id'],
+        )
         checksum = cli.Client(self.cfg).run(('sha256sum', os.path.join(
             export_dir,
             self.distributor['config']['relative_url'],


### PR DESCRIPTION
Add tests for repo group export with a custom checksum type defined.

Close #292 

Results for Pulp 2.8.5:

```
$ py.test pulp_smash/tests/rpm/api_v2/test_export.py
================================ test session starts ================================
platform linux -- Python 3.4.3, pytest-2.9.2, py-1.4.31, pluggy-0.3.1
rootdir: /home/elyezer/code/pulp-smash, inifile: 
collected 8 items 

pulp_smash/tests/rpm/api_v2/test_export.py ssssss..

======================= 2 passed, 6 skipped in 190.68 seconds =======================
```

Results for Pulp 2.9:

```
$ py.test pulp_smash/tests/rpm/api_v2/test_export.py
================================ test session starts ================================
platform linux -- Python 3.4.3, pytest-2.9.2, py-1.4.31, pluggy-0.3.1
rootdir: /home/elyezer/code/pulp-smash, inifile: 
collected 8 items 

pulp_smash/tests/rpm/api_v2/test_export.py ss......

======================= 6 passed, 2 skipped in 220.70 seconds =======================
```