### PR TITLE
Upload erratum

### DIFF
--- a/pulp_smash/constants.py
+++ b/pulp_smash/constants.py
@@ -230,6 +230,12 @@ RPM_ABS_PATH = (
 )
 """The absolute path to :data:`pulp_smash.constants.RPM` in the filesystem."""
 
+RPM_ERRATUM_URL = (
+    'https://repos.fedorapeople.org'
+    '/repos/pulp/pulp/fixtures/rpm-erratum/erratum.json'
+)
+"""The URL to an JSON erratum file for an RPM repository."""
+
 RPM_FEED_URL = 'https://repos.fedorapeople.org/repos/pulp/pulp/fixtures/rpm/'
 """The URL to an RPM repository. See :data:`RPM_URL`."""
 

--- a/pulp_smash/tests/rpm/api_v2/test_upload_publish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_upload_publish.py
@@ -13,17 +13,137 @@ from __future__ import unicode_literals
 
 from itertools import product
 
-from pulp_smash import api, utils
+from pulp_smash import api, selectors, utils
 from pulp_smash.compat import urljoin
 from pulp_smash.constants import (
     CALL_REPORT_KEYS,
     CONTENT_UPLOAD_PATH,
     REPOSITORY_PATH,
     RPM,
+    RPM_FEED_URL,
     RPM_URL,
 )
-from pulp_smash.tests.rpm.api_v2.utils import gen_distributor, gen_repo
+from pulp_smash.tests.rpm.utils import gen_erratum
+from pulp_smash.tests.rpm.api_v2.utils import (
+    gen_distributor,
+    gen_repo,
+    get_repomd_xml,
+)
 from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+
+
+def parse_updateinfo_update(update):
+    """Create an erratum from an ``updateinfo.xml`` update.
+
+    This function creates an empty erratum, then parses a top-level ``update``
+    section from an ``updateinfo.xml`` file, and populates the empty erratum
+    from such.
+
+    .. WARNING:: There is no schema for ``updateinfo.xml`` files. Instead, this
+        function's parsing logic is reverse-engineered from the DNF source
+        code. As a result, this function may exhibit erroneous behaviour.
+
+        As of this writing, the DNF source code can be cloned from
+        ``https://github.com/rpm-software-management/dnf.git``. The files used
+        by this function are:
+
+        * `dnf/cli/commands/updateinfo.py`_
+        * `tests/repos/rpm/updateinfo.xml`_
+
+    .. NOTE:: DNF is incompatible with the openSUSE ``updateinfo.xml`` schema.
+        The schema can be found from the `openSUSE:Standards Rpm Metadata
+        UpdateInfo`_ wiki page.
+
+    :param update: An ``xml.etree`` element corresponding to an "update"
+        element in an ``updateinfo.xml`` file.
+    :returns: An erratum. In other words, a dict with keys like "description,"
+        "from," and "id."
+
+    .. _dnf/cli/commands/updateinfo.py:
+        https://github.com/rpm-software-management/dnf/blob/master/dnf/cli/commands/updateinfo.py
+    .. _tests/repos/rpm/updateinfo.xml:
+        https://github.com/rpm-software-management/dnf/blob/master/tests/repos/rpm/updateinfo.xml
+    .. _openSUSE:Standards Rpm Metadata UpdateInfo:
+        https://en.opensuse.org/openSUSE:Standards_Rpm_Metadata_UpdateInfo
+    """
+    erratum = {
+        'pkglist': _get_pkglist(update),
+        'reboot_suggested': _get_reboot_suggested(update),
+        'references': _get_references(update),
+    }
+    for key in ('from', 'status', 'type', 'version'):
+        erratum[key] = update.attrib[key]
+    for key in ('issued', 'updated'):
+        erratum[key] = update.find(key).attrib['date']
+    for key in (
+            'description',
+            'id',
+            'pushcount',
+            'rights',
+            'severity',
+            'solution',
+            'summary',
+            'title',):
+        erratum[key] = update.find(key).text
+    return erratum
+
+
+def _get_reboot_suggested(update):
+    """Tell whether an ``updateinfo.xml`` update suggests a reboot.
+
+    :param update: An ``xml.etree`` element corresponding to an "update"
+        element in an ``updateinfo.xml`` file.
+    :returns: ``True`` or ``False`` if the update has a ``reboot_suggested``
+        element with a value of ``'True'`` or ``'False'``, respectively;
+        ``False`` if no ``reboot_suggested`` element is present; or an error
+        otherwise.
+    """
+    reboot_suggested = update.find('reboot_suggested')
+    if reboot_suggested is None:
+        return False
+    legend = {'True': True, 'False': False}
+    return legend[reboot_suggested.text]
+
+
+def _get_references(update):
+    """Parse the "references" element in an ``updateinfo.xml`` update.
+
+    :param update: An ``xml.etree`` element corresponding to an "update"
+        element in an ``updateinfo.xml`` file.
+    :returns: A list of references, each in the format used by an erratum.
+    """
+    return [
+        {key: reference.attrib[key] for key in ('href', 'id', 'title', 'type')}
+        for reference in update.find('references').findall('reference')
+    ]
+
+
+def _get_pkglist(update):
+    """Parse the "pkglist" element in an ``updateinfo.xml`` update.
+
+    :param update: An ``xml.etree`` element corresponding to an "update"
+        element in an ``updateinfo.xml`` file.
+    :returns: A list of packages, each in the format used by an erratum.
+    """
+    src_pkglist = update.find('pkglist')
+    out_pkglist = [{
+        'name': src_pkglist.find('collection').find('name').text,
+        'packages': [],
+        'short': src_pkglist.find('collection').attrib['short'],
+    }]
+    for package in src_pkglist.find('collection').findall('package'):
+        checksum = package.find('sum')
+        out_pkglist[0]['packages'].append({
+            'arch': package.attrib['arch'],
+            'epoch': package.attrib['epoch'],
+            'filename': package.find('filename').text,
+            'name': package.attrib['name'],
+            'release': package.attrib['release'],
+            'src': package.attrib['src'],
+            'sum': [checksum.attrib['type'], checksum.text],
+            'version': package.attrib['version'],
+        })
+    return out_pkglist
 
 
 class UploadRpmTestCase(utils.BaseAPITestCase):
@@ -196,3 +316,83 @@ class UploadRpmTestCase(utils.BaseAPITestCase):
                 url = urljoin(url, RPM)
                 rpm = api.Client(self.cfg).get(url).content
                 self.assertEqual(rpm, self.rpm)
+
+
+class UploadErratumTestCase(utils.BaseAPITestCase):
+    """Test whether one can upload and publish erratum."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Upload an erratum to a repo, publish, and download the erratum.
+
+        Do the following:
+
+        1. Create an RPM repository with a distributor.
+        2. Upload an erratum to the repository.
+        3. Publish the repository.
+        4. Fetch the repository's ``updateinfo.xml`` file.
+        """
+        super(UploadErratumTestCase, cls).setUpClass()
+        cls.erratum = gen_erratum()
+
+        # Create an RPM repository with a feed and distributor.
+        client = api.Client(cls.cfg, api.json_handler)
+        body = gen_repo()
+        body['importer_config']['feed'] = RPM_FEED_URL
+        body['distributors'] = [gen_distributor()]
+        repo = client.post(REPOSITORY_PATH, body)
+        cls.resources.add(repo['_href'])
+
+        # Sync content into the repository, and give it an erratum.
+        utils.sync_repo(cls.cfg, repo['_href'])
+        utils.upload_import_erratum(cls.cfg, cls.erratum, repo['_href'])
+        repo = client.get(repo['_href'], params={'details': True})
+
+        # Publish the repository, and fetch and parse updateinfo.xml
+        distributor = repo['distributors'][0]
+        client.post(
+            urljoin(repo['_href'], 'actions/publish/'),
+            {'id': distributor['id']},
+        )
+        path = urljoin('/pulp/repos/', distributor['config']['relative_url'])
+        cls.updateinfo = get_repomd_xml(cls.cfg, path, 'updateinfo')
+
+    def test_updateinfo_root_tag(self):
+        """Assert ``updateinfo.xml`` has a root element named ``updates``."""
+        self.assertEqual(self.updateinfo.tag, 'updates')
+
+    def test_updates_are_present(self):
+        """Assert at least one update is present in ``updateinfo.xml``."""
+        n_updates = len(self.updateinfo.findall('update'))
+        self.assertGreater(n_updates, 0)
+
+    def test_update_is_correct(self):
+        """Assert the uploaded erratum is in ``updateinfo.xml`` and correct.
+
+        Specificially, this method does the following:
+
+        1. Select the "update" element in ``updateinfo.xml`` corresponding to
+           the uploaded erratum.
+        2. Build our own erratum from the selected "update" element.
+        3. Compare the uploaded erratum to the generated erratum.
+
+        .. WARNING:: This test may be erroneous. See
+            :func:`parse_updateinfo_update`.
+        """
+        # Find our erratum in ``updateinfo.xml``.
+        updates = [
+            update for update in self.updateinfo.findall('update')
+            if update.find('id').text == self.erratum['id']
+        ]
+        self.assertEqual(len(updates), 1)
+
+        # Parse and verify the erratum. Simply asserting that the original
+        # erratum and constructed erratum are equal produces awful failure
+        # messages. Iterating like this lets us narrow things down a bit.
+        old_erratum = self.erratum.copy()
+        if selectors.bug_is_untestable(2021, self.cfg.version):
+            del old_erratum['release']
+        new_erratum = parse_updateinfo_update(updates[0])
+        for key, value in old_erratum.items():
+            with self.subTest(key=key):
+                self.assertEqual(value, new_erratum[key])

--- a/pulp_smash/tests/rpm/utils.py
+++ b/pulp_smash/tests/rpm/utils.py
@@ -2,7 +2,12 @@
 """Utilities for RPM tests."""
 from __future__ import unicode_literals
 
-from pulp_smash import utils
+import json
+
+import requests
+
+from pulp_smash import config, selectors, utils
+from pulp_smash.constants import RPM_ERRATUM_URL
 
 
 def set_up_module():
@@ -11,3 +16,22 @@ def set_up_module():
     See :mod:`pulp_smash.tests` for more information.
     """
     utils.skip_if_type_is_unsupported('rpm')
+
+
+def gen_erratum():
+    """Return an erratum with a randomized ID.
+
+    Fetch, decode, munge and return the erratum file at
+    :data:`pulp_smash.constants.RPM_ERRATUM_URL`. This erratum can be uploaded
+    and imported into an RPM repository with
+    :meth:`pulp_smash.utils.upload_import_erratum`.
+    """
+    response = requests.get(RPM_ERRATUM_URL)
+    response.raise_for_status()
+    erratum = json.loads(response.text)
+    erratum['id'] = utils.uuid4()
+    # "Cannot provide multiple checksums when uploading an erratum"
+    if selectors.bug_is_untestable(2020, config.get_config().version):
+        for package in erratum['pkglist'][0]['packages']:
+            package['sum'] = package['sum'][:2]
+    return erratum

--- a/pulp_smash/utils.py
+++ b/pulp_smash/utils.py
@@ -153,6 +153,31 @@ def upload_import_unit(server_config, unit, unit_type_id, repo_href):
     return call_report
 
 
+def upload_import_erratum(server_config, erratum, repo_href):
+    """Upload an erratum to a Pulp server and import it into a repository.
+
+    For most content types, use :meth:`upload_import_unit`.
+
+    :param pulp_smash.config.ServerConfig server_config: Information about the
+        Pulp server being targeted.
+    :param erratum: A dict, with keys such as "id," "status," "issued," and
+        "references."
+    :param repo_href: The path to the repository into which ``erratum`` will be
+        imported.
+    :returns: The call report returned when importing the erratum.
+    """
+    client = api.Client(server_config, api.json_handler)
+    malloc = client.post(CONTENT_UPLOAD_PATH)
+    call_report = client.post(urljoin(repo_href, 'actions/import_upload/'), {
+        'unit_key': {'id': erratum['id']},
+        'unit_metadata': erratum,
+        'unit_type_id': 'erratum',
+        'upload_id': malloc['upload_id'],
+    })
+    client.delete(malloc['_href'])
+    return call_report
+
+
 class BaseAPITestCase(unittest2.TestCase):
     """A class with behaviour that is of use in many API test cases.
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -201,6 +201,28 @@ class UploadImportUnitTestCase(unittest2.TestCase):
         self.assertIs(response, client.return_value.post.return_value)
 
 
+class UploadImportErratumTestCase(unittest2.TestCase):
+    """Test :func:`pulp_smash.utils.upload_import_unit`."""
+
+    def test_post(self):
+        """Assert the function makes an HTTP POST request."""
+        with mock.patch.object(api, 'Client') as client:
+            # post() is called twice, first to start a content upload and
+            # second to import and upload. In both cases, a dict is returned.
+            # Our dict mocks the first case, and just happens to work in the
+            # second case too.
+            client.return_value.post.return_value = {
+                '_href': 'foo',
+                'upload_id': 'bar',
+            }
+            response = utils.upload_import_erratum(
+                mock.Mock(),  # server_config
+                {'id': 'abc123'},  # erratum
+                'http://example.com',  # repo_href
+            )
+        self.assertIs(response, client.return_value.post.return_value)
+
+
 class PulpAdminLoginTestCase(unittest2.TestCase):
     """Test :func:`pulp_smash.utils.pulp_admin_login`."""
 


### PR DESCRIPTION
The first commit performs a simple refactor, where a private function is moved into a `utils` module and made public. The second commit is where the real action happens: a brand new test case is added!