### PR TITLE
Fix up Pulp Smash #311

### DIFF
--- a/pulp_smash/tests/rpm/cli/test_copy_units.py
+++ b/pulp_smash/tests/rpm/cli/test_copy_units.py
@@ -8,11 +8,117 @@ import subprocess
 import unittest2
 
 from pulp_smash import cli, config, constants, selectors, utils
+from pulp_smash.compat import urljoin
 from pulp_smash.tests.rpm.utils import set_up_module
 from pulp_smash.tests.rpm.cli.utils import _count_langpacks
 
 _REPO_ID = None
 """The ID of the repository created by ``setUpModule``."""
+
+
+def _get_rpm_names_versions(server_config, repo_id):
+    """Get a dict of repo's RPMs with names as keys, mapping to version lists.
+
+    :param pulp_smash.config.ServerConfig server_config: Information about the
+        Pulp server being targeted.
+    :param repo_id: A RPM repository ID.
+    :returns: The names of all modules in a repository, with a list of all
+        versions mapped to each module, as an ``dict``.
+    """
+    keyword = 'Filename:'
+    completed_proc = cli.Client(server_config).run(
+        'pulp-admin rpm repo content rpm --repo-id {}'.format(repo_id).split()
+    )
+    filenames = [
+        line for line in completed_proc.stdout.splitlines() if keyword in line
+    ]
+    assert len(filenames) > 0
+    rpm_dict = {}
+    for file_name_str in filenames:
+        # Example of a filename string: 'Filename: walrus-0.71-1.noarch.rpm'.
+        name_version = file_name_str.split('-')
+        rpm_dict.setdefault(
+            name_version[0].split(keyword)[1].strip(),
+            []
+        ).append(name_version[1])
+    return rpm_dict
+
+
+def _copy_repo(server_config, source, destination, rpm_name, rpm_version=None):
+    """Copy specific module name and version from repo1 to repo2.
+
+    :param pulp_smash.config.ServerConfig server_config: Information about the
+        Pulp server being targeted.
+    :param source: The source module to copy from.
+    :param destination: The destination module to copy to.
+    :param rpm_name: The name of target module.
+    :param rpm_version: The version of target module.
+    :returns: A :class: `pulp_smash.cli.CompletedProcess`.
+    """
+    return cli.Client(server_config).run(
+        ' '.join([
+            'pulp-admin rpm repo copy rpm --from-repo-id {}'.format(source),
+            '--to-repo-id {}'.format(destination),
+            '--str-eq=name={}'.format(rpm_name)
+            if rpm_name is not None else '',
+            '--str-eq=version={}'.format(rpm_version)
+            if rpm_version is not None else '',
+        ]).split()
+    )
+
+
+def _get_rpm_dependencies(server_config, repo_id, rpm_name):
+    """Get a list of all required packages for a given RPM in repository.
+
+    :param pulp_smash.config.ServerConfig server_config: Information about the
+        Pulp server being targeted.
+    :param repo_id: The ID of repository which contains the module.
+    :param rpm_name: The name of module to query with. It is assumed that
+        there's no cycle in the dependecy relations; that is, a RPM cannot
+        point itself as required package.
+    """
+    keyword = 'Requires:'
+    res = []
+    stack = [rpm_name]
+    while len(stack) > 0:
+        top = stack.pop()
+        if top is not rpm_name:
+            res.append(top)
+        # Query parent modules for the current RPM `top`.
+        completed_proc = cli.Client(server_config).run(
+            'pulp-admin rpm repo content rpm --repo-id {0} --str-eq name={1} '
+            '--fields=requires'.format(repo_id, top).split()
+        )
+        # Depth-First-Search for parent's dependencies.
+        # E.g., 'walrus-0.71' <- 'whale' <- 'shark, stork' <- ''.
+        # But 'walrus-5.21' <- '', i.e., it has no parent package.
+        parent_modules = [
+            line.split(keyword)[1].strip()
+            for line in completed_proc.stdout.splitlines()
+            if keyword in line and len(line.split(keyword)[1].strip()) > 0
+        ]
+        if len(parent_modules) == 0:
+            continue
+        stack.extend(parent_modules[0].split(', '))
+    # Return [u'whale', u'stork', u'shark'] for 'walrus-0.71'.
+    return res
+
+
+def _clean_cache(server_config):
+    """Utility function to execute `yum clean`."""
+    cli.Client(server_config).run('yum clean all'.split())
+
+
+def _query_rpm(server_config, rpm_name):
+    """Utility function to query if a package is installed.
+
+    :param pulp_smash.config.ServerConfig server_config: Information about the
+        Pulp server being targeted.
+    :param rpm_name: The name of target module.
+    """
+    return cli.Client(server_config).machine.session().run(
+        'rpm -qa | grep "{}"'.format(rpm_name)
+    )[1]
 
 
 def setUpModule():  # pylint:disable=invalid-name
@@ -181,3 +287,147 @@ class CopyLangpacksTestCase(CopyBaseTestCase):
                 _count_langpacks(self.cfg, self.repo_id),
                 0,
             )
+
+
+class CopyAndPublishTwoVersionsRepoTestCase(CopyBaseTestCase):
+    """Test whether a repo can copy two versions of RPMs and publish itself.
+
+    This test case targets `Pulp Smash #311`_ and `Pulp # 1684`_.
+    The test steps are as following:
+
+    1. Create a repo1 and sync from upstream.
+    2. Find a RPM that has two different versions in this repo.
+    3. Create a new repo2 and copy the older of the RPM version into it.
+    4. Publish the repo2 as a host.
+    5. Copy a newer version into the repo2 and re-publish.
+    6. Yum update on the client and verify update would succeed.
+
+    Note that the 1st repo `_REPO_ID` has been synced in `setUpModule()`,
+    while the 2nd repo `repo_id` has been created by base class without
+    a feed.
+
+    .. _Pulp Smash #311: https://github.com/PulpQE/pulp-smash/issues/311
+    .. _Pulp # 1684: https://pulp.plan.io/issues/1684
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Create two repositories and synchronize the 1st repo only."""
+        super(CopyAndPublishTwoVersionsRepoTestCase, cls).setUpClass()
+        _clean_cache(cls.cfg)
+        # Retrieve all modules with multiple versions in the repo1.
+        cls.rpm_dict = {
+            key: value for (key, value)
+            in _get_rpm_names_versions(cls.cfg, _REPO_ID).items()
+            if len(value) > 1
+        }
+        assert len(cls.rpm_dict) > 0
+        # Choose the first module with multiple versions.
+        cls.rpm_name = list(cls.rpm_dict)[0]
+        cls.rpm_dict.get(cls.rpm_name).sort()
+
+    def test_01_copy_older_publish(self):
+        """Copy a RPM with older version into repo2 and publish repo2."""
+        # Choose the oldest version of the given RPM.
+        rpm_version = self.rpm_dict.get(self.rpm_name, [None, None])[0]
+        # Copy dependency packages of the chosen RPM.
+        for rpm in _get_rpm_dependencies(self.cfg, _REPO_ID, self.rpm_name):
+            _copy_repo(self.cfg, _REPO_ID, self.repo_id, rpm)
+        self._copy_and_publish(self.rpm_name, rpm_version)
+
+        # Setup the repo2 on the same host.
+        cli.Client(self.cfg).run(
+            'sudo yum-config-manager --add-repo {}'
+            .format(urljoin('https://dev/pulp/repos/', self.repo_id)).split()
+        )
+        cli.Client(self.cfg).run('yum repolist enabled'.split())
+
+        cli.Client(self.cfg).run(
+            'dnf --disablerepo=* --enablerepo=dev_pulp_repos_{} list available'
+            .format(self.repo_id).split()
+        )
+
+        # Execute `yum install` to deploy the RPM on the host.
+        cli.Client(self.cfg).run(
+            'sudo dnf install -y --nogpgcheck {}'.format(self.rpm_name).split()
+        )
+        self.assertIn(self.rpm_name, _query_rpm(self.cfg, self.rpm_name))
+
+    def test_02_copy_newer_publish(self):
+        """Copy a RPM with newer version into repo2 and publish repo2."""
+        if selectors.bug_is_untestable(1684, self.cfg.version):
+            self.skipTest('https://pulp.plan.io/issues/1684')
+        if self.rpm_name not in _query_rpm(self.cfg, self.rpm_name):
+            self.skipTest('https://pulp.plan.io/issues/1684')
+        # Choose the newest version of the given RPM.
+        rpm_version = self.rpm_dict.get(self.rpm_name, [None, None])[1]
+        self._copy_and_publish(self.rpm_name, rpm_version)
+        # Execute `yum update` on the RPM.
+        completed_proc = cli.Client(self.cfg).run(
+            'sudo yum update {}'.format(self.rpm_name).split()
+        )
+        # Check if the update succeeds; it should have updates.
+        self.assertNotIn('Nothing to do.', completed_proc.stdout.splitlines())
+
+    def _copy_and_publish(self, rpm_name, rpm_version):
+        """Copy the RPM with given name and version into 2nd repo and publish it.
+
+        :param rpm_name: The name of target module.
+        :param rpm_version: The version of target module.
+        """
+        # Copy the module from repo1 to repo2.
+        _copy_repo(self.cfg, _REPO_ID, self.repo_id, rpm_name, rpm_version)
+        # Search for the RPM's name/version in repo2's content.
+        self._search_rpm(self.repo_id, rpm_name, rpm_version)
+        # Publish repo2 and verify no errors.
+        completed_proc = cli.Client(self.cfg).run(
+            'pulp-admin rpm repo publish run --repo-id {}'
+            .format(self.repo_id).split()
+        )
+        for stream in ('stdout', 'stderr'):
+            with self.subTest(stream=stream):
+                self.assertNotIn(
+                    'Task Failed', getattr(completed_proc, stream)
+                )
+
+    def _search_rpm(self, repo_id, rpm_name=None, rpm_version=None):
+        """Search for a RPM in the repository with optional name or version.
+
+        :param repo_id: A RPM repository ID.
+        :param rpm_name: The name of target module.
+        :param rpm_version: The version of target module.
+        :returns: A :class: `pulp_smash.cli.CompletedProcess`.
+        """
+        completed_proc = cli.Client(self.cfg).run(
+            ' '.join([
+                'pulp-admin rpm repo content rpm --repo-id {}'.format(repo_id),
+                '--str-eq name={}'.format(rpm_name)
+                if rpm_name is not None else '',
+                '--str-eq version={}'.format(rpm_version)
+                if rpm_version is not None else ''
+            ]).split()
+        )
+        if rpm_name is None:
+            self.assertNotEqual('\x1b[0m', getattr(completed_proc, 'stdout'))
+        else:
+            self.assertIn(rpm_name, getattr(completed_proc, 'stdout'))
+            # Check if the version is matched iif rpm's name is found.
+            with self.subTest():
+                self.assertIn(rpm_version, getattr(completed_proc, 'stdout'))
+
+    @classmethod
+    def tearDownClass(cls):
+        """Delete the repositories and clean up orphans."""
+        super(CopyAndPublishTwoVersionsRepoTestCase, cls).tearDownClass()
+        # Delete the published repositories in yum.repos.d.
+        cli.Client(cls.cfg).run(
+            'sudo rm /etc/yum.repos.d/dev_pulp_repos_{}.repo'
+            .format(cls.repo_id).split()
+        )
+        # Execute `yum remove` to delete the installed RPMs.
+        # Add an error check to make the test robust.
+        if cls.rpm_name not in _query_rpm(cls.cfg, cls.rpm_name):
+            return
+        cli.Client(cls.cfg).run(
+            'sudo dnf remove -y {}'.format(cls.rpm_name).split()
+        )


### PR DESCRIPTION
This commit fixes the issue: #311.

The test steps are as following:

1. create and sync repo1 from upstream.
2. find an RPM that has two different versions in the repo1 (walrus).
3. create a new repo2, and copy the older of the rpm version (e.g., walrus-0.71) into it.
4. Also install all dependency packages of the walrus RPM (whale, shark, stork).
5. setup that repo2 on the same host of Pulp server, and install the packages:
    `sudo yum-config-manager --add-repo {url_of_repo2_after_publish}`
    `sudo yum install --nogpgcheck walrus`.

    (The repo2 will be automatically enabled after publishing in this case.)
6. copy a newer version into the repo2 and re-publish
7. yum update on the client (`sudo yum update walrus`).

Test Output:

```
[vagrant@dev pulp-smash]$ clear; python -m unittest pulp_smash.tests.rpm.cli.test_copy_units.
CopyAndPublishTwoVersionsRepoTestCase

.s
----------------------------------------------------------------------
Ran 2 tests in 71.745s

OK (skipped=1)
[vagrant@dev pulp-smash]$ 
```