### PR TITLE
Update references to Pulp documentation

### DIFF
--- a/pulp_smash/api.py
+++ b/pulp_smash/api.py
@@ -333,7 +333,7 @@ def poll_spawned_tasks(server_config, call_report):
     :raises: Same as :meth:`poll_task`.
 
     .. _call report:
-        http://pulp.readthedocs.io/en/latest/dev-guide/conventions/sync-v-async.html#call-report
+        http://docs.pulpproject.org/en/latest/dev-guide/conventions/sync-v-async.html#call-report
     """
     hrefs = (task['_href'] for task in call_report['spawned_tasks'])
     for href in hrefs:

--- a/pulp_smash/constants.py
+++ b/pulp_smash/constants.py
@@ -9,21 +9,21 @@ CALL_REPORT_KEYS = frozenset(('error', 'result', 'spawned_tasks'))
 """See: `Call Report`_.
 
 .. _Call Report:
-    http://pulp.readthedocs.io/en/latest/dev-guide/conventions/sync-v-async.html#call-report
+    http://docs.pulpproject.org/en/latest/dev-guide/conventions/sync-v-async.html#call-report
 """
 
 CONTENT_UNITS_PATH = '/pulp/api/v2/content/units/'
 """See: `Search for Units`_.
 
 .. _Search for Units:
-    http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/content/units.html#search-for-units
+    http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/content/units.html#search-for-units
 """
 
 CONTENT_UPLOAD_PATH = '/pulp/api/v2/content/uploads/'
 """See: `Creating an Upload Request`_.
 
 .. _Creating an Upload Request:
-   http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/content/upload.html#creating-an-upload-request
+   http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/content/upload.html#creating-an-upload-request
 """
 
 DOCKER_IMAGE_URL = (
@@ -62,7 +62,7 @@ ERROR_KEYS = frozenset((
 No ``href`` field should be present. See `Issue #1310`_.
 
 .. _Exception Handling:
-    https://pulp.readthedocs.io/en/latest/dev-guide/conventions/exceptions.html
+    https://docs.pulpproject.org/en/latest/dev-guide/conventions/exceptions.html
 .. _Issue #1310: https://pulp.plan.io/issues/1310
 """
 
@@ -70,28 +70,28 @@ GROUP_CALL_REPORT_KEYS = frozenset(('_href', 'group_id'))
 """See: `Group Call Report`_.
 
 .. _Group Call Report:
-    http://pulp.readthedocs.io/en/latest/dev-guide/conventions/sync-v-async.html#group-call-report
+    http://docs.pulpproject.org/en/latest/dev-guide/conventions/sync-v-async.html#group-call-report
 """
 
 LOGIN_KEYS = frozenset(('certificate', 'key'))
 """See: `User Certificates`_.
 
 .. _User Certificates:
-    http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/authentication.html#user-certificates
+    http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/authentication.html#user-certificates
 """
 
 LOGIN_PATH = '/pulp/api/v2/actions/login/'
 """See: `Authentication`_.
 
 .. _Authentication:
-    https://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/authentication.html
+    https://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/authentication.html
 """
 
 ORPHANS_PATH = 'pulp/api/v2/content/orphans/'
 """See: `Orphaned Content`_.
 
 .. _Orphaned Content:
-    http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/content/orphan.html
+    http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/content/orphan.html
 """
 
 OSTREE_FEED = (
@@ -100,21 +100,21 @@ OSTREE_FEED = (
 """The URL to a URL of OSTree branches. See OSTree `Importer Configuration`_.
 
 .. _Importer Configuration:
-    http://pulp-ostree.readthedocs.io/en/latest/tech-reference/importer.html
+    http://docs.pulpproject.org/plugins/pulp_ostree/tech-reference/importer.html
 """
 
 OSTREE_BRANCH = 'fedora-atomic/f21/x86_64/updates/docker-host'
 """A branch in :data:`OSTREE_FEED`. See OSTree `Importer Configuration`_.
 
 .. _Importer Configuration:
-    http://pulp-ostree.readthedocs.io/en/latest/tech-reference/importer.html
+    http://docs.pulpproject.org/plugins/pulp_ostree/tech-reference/importer.html
 """
 
 PLUGIN_TYPES_PATH = '/pulp/api/v2/plugins/types/'
 """See: `Retrieve All Content Unit Types`_.
 
 .. _Retrieve All Content Unit Types:
-   http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/server_plugins.html#retrieve-all-content-unit-types
+   http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/server_plugins.html#retrieve-all-content-unit-types
 """
 
 PULP_SERVICES = {
@@ -189,28 +189,28 @@ REPOSITORY_EXPORT_DISTRIBUTOR = 'export_distributor'
 """A ``distributor_type_id`` to export a repository.
 
 See: `Export Distributors
-<https://pulp-rpm.readthedocs.io/en/latest/tech-reference/export-distributor.html>`_.
+<https://docs.pulpproject.org/plugins/pulp_rpm/tech-reference/export-distributor.html>`_.
 """
 
 REPOSITORY_GROUP_EXPORT_DISTRIBUTOR = 'group_export_distributor'
 """A ``distributor_type_id`` to export a repository group.
 
 See: `Export Distributors
-<https://pulp-rpm.readthedocs.io/en/latest/tech-reference/export-distributor.html>`_.
+<https://docs.pulpproject.org/plugins/pulp_rpm/tech-reference/export-distributor.html>`_.
 """
 
 REPOSITORY_PATH = '/pulp/api/v2/repositories/'
 """See: `Repository APIs`_.
 
 .. _Repository APIs:
-    https://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/index.html
+    https://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/repo/index.html
 """
 
 REPOSITORY_GROUP_PATH = '/pulp/api/v2/repo_groups/'
 """See: `Repository Group APIs`_
 
 .. _Repository Group APIs:
-    http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/groups/index.html
+    http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/repo/groups/index.html
 """
 
 
@@ -218,7 +218,7 @@ CONSUMER_PATH = '/pulp/api/v2/consumers/'
 """See: `Consumer APIs`_.
 
 .. _Consumer APIs:
-    https://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/consumer/index.html
+    https://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/consumer/index.html
 """
 
 RPM = 'bear-4.1-1.noarch.rpm'
@@ -259,5 +259,5 @@ USER_PATH = '/pulp/api/v2/users/'
 """See: `User APIs`_.
 
 .. _User APIs:
-    https://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/user/index.html
+    https://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/user/index.html
 """

--- a/pulp_smash/exceptions.py
+++ b/pulp_smash/exceptions.py
@@ -25,9 +25,9 @@ class CallReportError(Exception):
     `Synchronous and Asynchronous Calls`_ and `Task Management`_.
 
     .. _Synchronous and Asynchronous Calls:
-        http://pulp.readthedocs.io/en/latest/dev-guide/conventions/sync-v-async.html
+        http://docs.pulpproject.org/en/latest/dev-guide/conventions/sync-v-async.html
     .. _Task Management:
-        http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/tasks.html
+        http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/tasks.html
     """
 
 
@@ -68,9 +68,9 @@ class TaskReportError(Exception):
     `Synchronous and Asynchronous Calls`_ and `Task Management`_.
 
     .. _Synchronous and Asynchronous Calls:
-        http://pulp.readthedocs.io/en/latest/dev-guide/conventions/sync-v-async.html
+        http://docs.pulpproject.org/en/latest/dev-guide/conventions/sync-v-async.html
     .. _Task Management:
-        http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/tasks.html
+        http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/tasks.html
     """
 
 

--- a/pulp_smash/selectors.py
+++ b/pulp_smash/selectors.py
@@ -16,7 +16,7 @@ from pulp_smash import exceptions
 # These statuses apply to bugs filed at https://pulp.plan.io. They are ordered
 # according to an ideal workflow. As of this writing, these is no canonical
 # public source for this information. But see:
-# http://pulp.readthedocs.io/en/latest/dev-guide/contributing/bugs.html#fixing
+# http://docs.pulpproject.org/en/latest/dev-guide/contributing/bugs.html#fixing
 _UNTESTABLE_BUGS = frozenset((
     'NEW',  # bug just entered into tracker
     'ASSIGNED',  # bug has been assigned to an engineer

--- a/pulp_smash/tests/ostree/api_v2/test_crud.py
+++ b/pulp_smash/tests/ostree/api_v2/test_crud.py
@@ -12,9 +12,9 @@ following trees of assumptions are explored in this module::
         It is not possible to update distrubutors to have conflicting paths
 
 .. _OSTree:
-    http://pulp-ostree.readthedocs.io/en/latest/
+    http://docs.pulpproject.org/plugins/pulp_ostree/
 .. _repositories:
-   http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/cud.html
+   http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/repo/cud.html
 """
 from __future__ import unicode_literals
 

--- a/pulp_smash/tests/ostree/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/ostree/api_v2/test_sync_publish.py
@@ -17,9 +17,9 @@ assumptions are explored in this module::
         (SyncWithoutFeedTestCase).
 
 .. _OSTree:
-    http://pulp-ostree.readthedocs.io/en/latest/
+    http://docs.pulpproject.org/plugins/pulp_ostree/
 .. _repositories:
-   http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/cud.html
+   http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/repo/cud.html
 """
 from __future__ import unicode_literals
 

--- a/pulp_smash/tests/platform/api_v2/test_consumer.py
+++ b/pulp_smash/tests/platform/api_v2/test_consumer.py
@@ -2,7 +2,7 @@
 """Test the `consumer`_ API endpoints.
 
 .. _consumer:
-    https://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/consumer/index.html
+    https://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/consumer/index.html
 """
 from __future__ import unicode_literals
 
@@ -16,7 +16,7 @@ class BindConsumerTestCase(utils.BaseAPITestCase):
     """Show that one can `bind a consumer to a repository`_.
 
     .. _bind a consumer to a repository:
-        https://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/consumer/bind.html#bind-a-consumer-to-a-repository
+        https://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/consumer/bind.html#bind-a-consumer-to-a-repository
     """
 
     @classmethod

--- a/pulp_smash/tests/platform/api_v2/test_content_applicability.py
+++ b/pulp_smash/tests/platform/api_v2/test_content_applicability.py
@@ -11,7 +11,7 @@ report.  (See :data:`pulp_smash.constants.CALL_REPORT_KEYS` and
 and :class:`ParallelTestCase` test these two use cases, respectively.
 
 .. _content applicability:
-    https://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/consumer/applicability.html
+    https://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/consumer/applicability.html
 """
 from __future__ import unicode_literals
 

--- a/pulp_smash/tests/platform/api_v2/test_login.py
+++ b/pulp_smash/tests/platform/api_v2/test_login.py
@@ -2,7 +2,7 @@
 """Test the API's `authentication`_ functionality.
 
 .. _authentication:
-    https://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/authentication.html
+    https://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/authentication.html
 """
 # Why The Comments?
 # =================

--- a/pulp_smash/tests/platform/api_v2/test_repository.py
+++ b/pulp_smash/tests/platform/api_v2/test_repository.py
@@ -12,7 +12,7 @@ The assumptions explored in this module have the following dependencies::
         └── It is possible to delete a repository.
 
 .. _repository:
-    https://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/index.html
+    https://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/repo/index.html
 """
 from __future__ import unicode_literals
 

--- a/pulp_smash/tests/platform/api_v2/test_search.py
+++ b/pulp_smash/tests/platform/api_v2/test_search.py
@@ -22,9 +22,9 @@ The assumptions explored in this module have the following dependencies::
             └── It is possible to limit how many search results are returned.
 
 .. _Searching:
-    https://pulp.readthedocs.io/en/latest/dev-guide/conventions/criteria.html
+    https://docs.pulpproject.org/en/latest/dev-guide/conventions/criteria.html
 .. _User APIs:
-    https://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/user/index.html
+    https://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/user/index.html
 """
 from __future__ import unicode_literals
 

--- a/pulp_smash/tests/platform/api_v2/test_user.py
+++ b/pulp_smash/tests/platform/api_v2/test_user.py
@@ -11,7 +11,7 @@ The assumptions explored in this module have the following dependencies::
     └── It is possible to delete a user.
 
 .. _user:
-    https://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/user/index.html
+    https://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/user/index.html
 """
 from __future__ import unicode_literals
 

--- a/pulp_smash/tests/puppet/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/puppet/api_v2/test_sync_publish.py
@@ -30,7 +30,7 @@ Assertions not explored in this module include:
   in single directory on pulp server over HTTPS.
 
 .. _repositories:
-   http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/cud.html
+   http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/repo/cud.html
 """
 from __future__ import unicode_literals
 
@@ -383,7 +383,7 @@ class PublishTestCase(utils.BaseAPITestCase):
         """Verify the response body for `creating an upload request`_.
 
         .. _creating an upload request:
-           http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/content/upload.html#creating-an-upload-request
+           http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/content/upload.html#creating-an-upload-request
         """
         keys = set(self.responses['malloc'].json().keys())
         self.assertLessEqual({'_href', 'upload_id'}, keys)
@@ -392,7 +392,7 @@ class PublishTestCase(utils.BaseAPITestCase):
         """Verify the response body for `uploading bits`_.
 
         .. _uploading bits:
-           http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/content/upload.html#upload-bits
+           http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/content/upload.html#upload-bits
         """
         self.assertIsNone(self.responses['upload'].json())
 
@@ -400,9 +400,9 @@ class PublishTestCase(utils.BaseAPITestCase):
         """Verify each call report has a sane structure.
 
         * `Import into a Repository
-          <http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/content/upload.html#import-into-a-repository>`_
+          <http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/content/upload.html#import-into-a-repository>`_
         * `Copying Units Between Repositories
-          <http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/content/associate.html#copying-units-between-repositories>`_
+          <http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/content/associate.html#copying-units-between-repositories>`_
         """
         for step in {'import', 'copy'}:
             with self.subTest(step=step):
@@ -419,7 +419,7 @@ class PublishTestCase(utils.BaseAPITestCase):
         """Verify the response body for ending an upload.
 
         `Delete an Upload Request
-        <http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/content/upload.html#delete-an-upload-request>`_
+        <http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/content/upload.html#delete-an-upload-request>`_
         """
         self.assertIsNone(self.responses['free'].json())
 

--- a/pulp_smash/tests/rpm/api_v2/test_crud.py
+++ b/pulp_smash/tests/rpm/api_v2/test_crud.py
@@ -3,7 +3,7 @@
 
 For information on repository CRUD operations, see `Creation, Deletion and
 Configuration
-<http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/cud.html>`_.
+<http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/repo/cud.html>`_.
 """
 from __future__ import unicode_literals
 
@@ -43,7 +43,7 @@ class RepositoryGroupCrudTestCase(utils.BaseAPITestCase):
 
     For information on repositories' groups CRUD operations, see `Creation,
     Delete, and Update
-    <http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/groups/cud.html>`
+    <http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/repo/groups/cud.html>`
     """
 
     @classmethod

--- a/pulp_smash/tests/rpm/api_v2/test_export.py
+++ b/pulp_smash/tests/rpm/api_v2/test_export.py
@@ -6,7 +6,7 @@ This module assumes that the tests in
 :mod:`pulp_smash.tests.rpm.api_v2.test_sync_publish` hold true.
 
 .. _Export Distributors:
-    http://pulp-rpm.readthedocs.io/en/latest/tech-reference/export-distributor.html
+    http://docs.pulpproject.org/plugins/pulp_rpm/tech-reference/export-distributor.html
 """
 from __future__ import unicode_literals
 

--- a/pulp_smash/tests/rpm/api_v2/test_iso_crud.py
+++ b/pulp_smash/tests/rpm/api_v2/test_iso_crud.py
@@ -204,9 +204,9 @@ class AddImporterDistributorTestCase(utils.BaseAPITestCase):
     See:
 
     * `Associate an Importer to a Repository
-      <http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/cud.html#associate-an-importer-to-a-repository>`_
+      <http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/repo/cud.html#associate-an-importer-to-a-repository>`_
     * `Associate a Distributor with a Repository
-      <http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/cud.html#associate-a-distributor-with-a-repository>`_
+      <http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/repo/cud.html#associate-a-distributor-with-a-repository>`_
     """
 
     @classmethod

--- a/pulp_smash/tests/rpm/api_v2/test_orphan_remove.py
+++ b/pulp_smash/tests/rpm/api_v2/test_orphan_remove.py
@@ -7,7 +7,7 @@ describes specific tests that should be in this module.
 .. _Pulp Fixtures: https://github.com/PulpQE/pulp-fixtures
 .. _Pulp Smash #134: https://github.com/PulpQE/pulp-smash/issues/134
 .. _orphaned content units:
-    http://pulp.readthedocs.io/en/latest/user-guide/admin-client/orphan.html
+    http://docs.pulpproject.org/en/latest/user-guide/admin-client/orphan.html
 """
 from __future__ import unicode_literals
 

--- a/pulp_smash/tests/rpm/api_v2/test_remove_unit.py
+++ b/pulp_smash/tests/rpm/api_v2/test_remove_unit.py
@@ -14,7 +14,7 @@ of repository created with valid feed and remove_missing option set.
 6. Assert that both repositories contain same units.
 
 .. _remove_missing:
-    https://pulp-rpm.readthedocs.io/en/latest/tech-reference/yum-plugins.html
+    https://docs.pulpproject.org/plugins/pulp_rpm/tech-reference/yum-plugins.html
 """
 
 from __future__ import unicode_literals

--- a/pulp_smash/tests/rpm/api_v2/test_retain_old_count.py
+++ b/pulp_smash/tests/rpm/api_v2/test_retain_old_count.py
@@ -12,7 +12,7 @@ repository created with valid feed and `retain_old_count`_ option set.
 4. Assert that number or RPMs in repo bar is less then in foo repo.
 
 .. _retain_old_count:
-    https://pulp-rpm.readthedocs.io/en/latest/tech-reference/yum-plugins.html
+    https://docs.pulpproject.org/plugins/pulp_rpm/tech-reference/yum-plugins.html
 """
 from __future__ import unicode_literals
 

--- a/pulp_smash/tests/rpm/api_v2/test_schedule_publish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_schedule_publish.py
@@ -6,7 +6,7 @@ This module assumes that the tests in
 :mod:`pulp_smash.tests.rpm.api_v2.test_sync_publish` hold true.
 
 .. _publication:
-    https://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/publish.html#scheduling-a-publish
+    https://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/repo/publish.html#scheduling-a-publish
 """
 
 from __future__ import unicode_literals
@@ -77,7 +77,7 @@ class CreateFailureTestCase(utils.BaseAPITestCase):
     """Establish that schedules are not created in `documented scenarios`_.
 
     .. _documented scenarios:
-        https://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/publish.html#scheduling-a-publish
+        https://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/repo/publish.html#scheduling-a-publish
     """
 
     @classmethod
@@ -147,11 +147,11 @@ class ReadUpdateDeleteTestCase(utils.BaseAPITestCase):
     hold true.
 
     .. _read:
-        https://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/publish.html#listing-a-single-scheduled-publish
+        https://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/repo/publish.html#listing-a-single-scheduled-publish
     .. _update:
-        https://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/publish.html#updating-a-scheduled-publish
+        https://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/repo/publish.html#updating-a-scheduled-publish
     .. _delete:
-        https://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/publish.html#deleting-a-scheduled-publish
+        https://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/repo/publish.html#deleting-a-scheduled-publish
     """
 
     @classmethod

--- a/pulp_smash/tests/rpm/api_v2/test_schedule_sync.py
+++ b/pulp_smash/tests/rpm/api_v2/test_schedule_sync.py
@@ -5,7 +5,7 @@ This module assumes that the tests in
 :mod:`pulp_smash.tests.platform.api_v2.test_repository` hold true.
 
 .. _syncronization:
-    https://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/sync.html#scheduling-a-sync
+    https://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/repo/sync.html#scheduling-a-sync
 """
 from __future__ import unicode_literals
 
@@ -93,7 +93,7 @@ class CreateFailureTestCase(CreateRepoMixin, utils.BaseAPITestCase):
     """Establish that schedules are not created in `documented scenarios`_.
 
     .. _documented scenarios:
-        https://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/sync.html#scheduling-a-sync
+        https://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/repo/sync.html#scheduling-a-sync
     """
 
     @classmethod
@@ -154,11 +154,11 @@ class ReadUpdateDeleteTestCase(CreateRepoMixin, utils.BaseAPITestCase):
     hold true.
 
     .. _read:
-        https://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/sync.html#listing-a-single-scheduled-sync
+        https://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/repo/sync.html#listing-a-single-scheduled-sync
     .. _update:
-        https://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/sync.html#updating-a-scheduled-sync
+        https://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/repo/sync.html#updating-a-scheduled-sync
     .. _delete:
-        https://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/sync.html#deleting-a-scheduled-sync
+        https://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/repo/sync.html#deleting-a-scheduled-sync
     """
 
     @classmethod

--- a/pulp_smash/tests/rpm/api_v2/test_search.py
+++ b/pulp_smash/tests/rpm/api_v2/test_search.py
@@ -9,9 +9,9 @@ The test cases in this module searches for content units by their type. See:
 
 .. _Pulp Smash #133: https://github.com/PulpQE/pulp-smash/issues/133
 .. _Search for Units:
-    http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/content/units.html#search-for-units
+    http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/content/units.html#search-for-units
 .. _Searching:
-    http://pulp.readthedocs.io/en/latest/dev-guide/conventions/criteria.html
+    http://docs.pulpproject.org/en/latest/dev-guide/conventions/criteria.html
 """
 from __future__ import unicode_literals
 

--- a/pulp_smash/tests/rpm/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_sync_publish.py
@@ -5,9 +5,9 @@ For information on repository sync and publish operations, see
 `Synchronization`_ and `Publication`_.
 
 .. _Publication:
-    http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/publish.html
+    http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/repo/publish.html
 .. _Synchronization:
-    http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/sync.html
+    http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/repo/sync.html
 """
 from __future__ import unicode_literals
 

--- a/pulp_smash/tests/rpm/api_v2/test_unassociate.py
+++ b/pulp_smash/tests/rpm/api_v2/test_unassociate.py
@@ -6,7 +6,7 @@ This module assumes that the tests in
 :mod:`pulp_smash.tests.rpm.api_v2.test_sync_publish` hold true.
 
 .. _Unassociating Content Units from a Repository:
-   http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/content/associate.html#unassociating-content-units-from-a-repository
+   http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/content/associate.html#unassociating-content-units-from-a-repository
 """
 from __future__ import unicode_literals
 

--- a/pulp_smash/tests/rpm/api_v2/test_upload_publish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_upload_publish.py
@@ -5,9 +5,9 @@ For information on repository upload and publish operations, see `Uploading
 Content`_ and `Publication`_.
 
 .. _Publication:
-    http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/publish.html
+    http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/repo/publish.html
 .. _Uploading Content:
-    http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/content/upload.html
+    http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/content/upload.html
 """
 from __future__ import unicode_literals
 
@@ -242,7 +242,7 @@ class UploadRpmTestCase(utils.BaseAPITestCase):
         """Verify the response body for `creating an upload request`_.
 
         .. _creating an upload request:
-           http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/content/upload.html#creating-an-upload-request
+           http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/content/upload.html#creating-an-upload-request
         """
         keys = set(self.responses['malloc'].json().keys())
         self.assertLessEqual({'_href', 'upload_id'}, keys)
@@ -251,7 +251,7 @@ class UploadRpmTestCase(utils.BaseAPITestCase):
         """Verify the response body for `uploading bits`_.
 
         .. _uploading bits:
-           http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/content/upload.html#upload-bits
+           http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/content/upload.html#upload-bits
         """
         self.assertIsNone(self.responses['upload'].json())
 
@@ -259,9 +259,9 @@ class UploadRpmTestCase(utils.BaseAPITestCase):
         """Verify each call report has a sane structure.
 
         * `Import into a Repository
-          <http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/content/upload.html#import-into-a-repository>`_
+          <http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/content/upload.html#import-into-a-repository>`_
         * `Copying Units Between Repositories
-          <http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/content/associate.html#copying-units-between-repositories>`_
+          <http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/content/associate.html#copying-units-between-repositories>`_
         """
         for step in {'import', 'copy'}:
             with self.subTest(step=step):
@@ -278,7 +278,7 @@ class UploadRpmTestCase(utils.BaseAPITestCase):
         """Verify the response body for ending an upload.
 
         `Delete an Upload Request
-        <http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/content/upload.html#delete-an-upload-request>`_
+        <http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/content/upload.html#delete-an-upload-request>`_
         """
         self.assertIsNone(self.responses['free'].json())
 

--- a/pulp_smash/tests/rpm/cli/test_search.py
+++ b/pulp_smash/tests/rpm/cli/test_search.py
@@ -17,7 +17,7 @@ class SearchReposWithFiltersTestCase(unittest2.TestCase):
     .. _Pulp #1784:  https://pulp.plan.io/issues/1784
     .. _Pulp Smash #184: https://github.com/PulpQE/pulp-smash/issues/184
     .. _repository search:
-        http://pulp.readthedocs.io/en/latest/user-guide/consumer-client/repositories.html
+        http://docs.pulpproject.org/en/latest/user-guide/consumer-client/repositories.html
     """
 
     @classmethod

--- a/pulp_smash/utils.py
+++ b/pulp_smash/utils.py
@@ -224,13 +224,13 @@ class BaseAPICrudTestCase(unittest2.TestCase):
     Relevant Pulp documentation:
 
     Create
-        http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/cud.html#create-a-repository
+        http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/repo/cud.html#create-a-repository
     Read
-        http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/retrieval.html#retrieve-a-single-repository
+        http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/repo/retrieval.html#retrieve-a-single-repository
     Update
-        http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/cud.html#update-a-repository
+        http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/repo/cud.html#update-a-repository
     Delete
-        http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/repo/cud.html#delete-a-repository
+        http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/repo/cud.html#delete-a-repository
     """
 
     @classmethod
@@ -412,9 +412,9 @@ def get_unit_type_ids(server_config):
     :returns: A set of content unit type IDs. For example: ``{'ostree',
         'python_package'}``.
 
-    .. [1] http://pulp-python.readthedocs.io/en/latest/
+    .. [1] http://docs.pulpproject.org/plugins/pulp_python/
     .. [2]
-        http://pulp-python.readthedocs.io/en/latest/reference/python-type.html
+       http://docs.pulpproject.org/plugins/pulp_python/reference/python-type.html
     """
     unit_types = api.Client(server_config).get(PLUGIN_TYPES_PATH).json()
     return {unit_type['id'] for unit_type in unit_types}


### PR DESCRIPTION
Pulp documentation in being moved from Read the Docs to the Pulp Project
domain. This commit update all references to the documentation to the new
location.

Close #313

`git grep readthedocs` now only shows:

```
README.rst:The `full documentation <http://pulp-smash.readthedocs.io/en/latest/>`_ is
docs/installation.rst:.. _Virtualenv: http://virtualenv.readthedocs.io/en/latest/
pulp_smash/cli.py:    .. _Plumbum: http://plumbum.readthedocs.io/en/latest/index.html
pulp_smash/cli.py:           http://plumbum.readthedocs.io/en/latest/api/commands.html#plumbum.commands.base.BaseCommand.run
pulp_smash/cli.py:        # https://plumbum.readthedocs.io/en/latest/api/commands.html#plumbum.commands.base.BaseCommand.run
```