### PR TITLE
Skip a test case affected by Pulp issue 2082

### DIFF
--- a/pulp_smash/tests/rpm/api_v2/test_iso_crud.py
+++ b/pulp_smash/tests/rpm/api_v2/test_iso_crud.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 
 from packaging.version import Version
+from unittest2 import SkipTest
 
 from pulp_smash import api, selectors, utils
 from pulp_smash.compat import urljoin, urlparse
@@ -221,6 +222,9 @@ class AddImporterDistributorTestCase(utils.BaseAPITestCase):
         4. Re-read the repository's importers and distributors.
         """
         super(AddImporterDistributorTestCase, cls).setUpClass()
+        if (cls.cfg.version >= Version('2.10') and
+                selectors.bug_is_untestable(2082, cls.cfg.version)):
+            raise SkipTest('https://pulp.plan.io/issues/2082')
 
         # Steps 1 and 2.
         client = api.Client(cls.cfg, api.json_handler)


### PR DESCRIPTION
`pulp_smash.tests.rpm.api_v2.test_iso_crud.AddImporterDistributorTestCase`
is affected by Pulp issue 2082:

> It's possible to add an ISO importer to an RPM repository by making an
> HTTP post request to /pulp/api/v2/repositories/{repo_id}/importers/,
> with a body of {"importer_type_id": "iso_importer"}. Under the current
> development version of Pulp (2.10), this fails with an HTTP 500 error.

For more information, see: https://pulp.plan.io/issues/2082