### PR TITLE
Allow the current flake8-quotes to be used

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 # For `make lint`
 flake8
 flake8-docstrings
-flake8-quotes<0.2.0
+flake8-quotes
 pylint
 astroid
 


### PR DESCRIPTION
Some time back, a `<2.0` version specifier was added to flake8-quotes.
It's no longer needed, as the current version installs and behaves
correctly. See: d070f8ff3c9b7b8278663ab6954a244f69f9fdb3