### PR TITLE
Pin flake8 version in requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 # For `make lint`
-flake8
+flake8<3
 flake8-docstrings
 flake8-quotes
 pylint


### PR DESCRIPTION
flake8-quotes is incompatible with flake8 version 3. Require flake8
version 2, so that the flake8-quotes plugin may still be used. See:

* https://github.com/zheller/flake8-quotes/issues/43
* https://github.com/zheller/flake8-quotes/issues/29