### PR TITLE
Added signatures check tests in rpm repositories

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -74,9 +74,11 @@ developers, not a gospel.
     api/pulp_smash.tests.rpm.api_v2.test_no_op_publish
     api/pulp_smash.tests.rpm.api_v2.test_orphan_remove
     api/pulp_smash.tests.rpm.api_v2.test_packages_directory
+    api/pulp_smash.tests.rpm.api_v2.test_packages_signature
     api/pulp_smash.tests.rpm.api_v2.test_remove_unit
     api/pulp_smash.tests.rpm.api_v2.test_repomd
     api/pulp_smash.tests.rpm.api_v2.test_republish
+    api/pulp_smash.tests.rpm.api_v2.test_repo_signature
     api/pulp_smash.tests.rpm.api_v2.test_retain_old_count
     api/pulp_smash.tests.rpm.api_v2.test_schedule_publish
     api/pulp_smash.tests.rpm.api_v2.test_schedule_sync

--- a/docs/api/pulp_smash.tests.rpm.api_v2.test_packages_signature.rst
+++ b/docs/api/pulp_smash.tests.rpm.api_v2.test_packages_signature.rst
@@ -1,0 +1,6 @@
+`pulp_smash.tests.rpm.api_v2.test_packages_signature`
+=====================================================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.rpm.api_v2.test_packages_signature`
+
+.. automodule:: pulp_smash.tests.rpm.api_v2.test_packages_signature

--- a/docs/api/pulp_smash.tests.rpm.api_v2.test_repo_signature.rst
+++ b/docs/api/pulp_smash.tests.rpm.api_v2.test_repo_signature.rst
@@ -1,0 +1,6 @@
+`pulp_smash.tests.rpm.api_v2.test_repo_signature`
+=================================================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.rpm.api_v2.test_repo_signature`
+
+.. automodule:: pulp_smash.tests.rpm.api_v2.test_repo_signature

--- a/pulp_smash/constants.py
+++ b/pulp_smash/constants.py
@@ -4,6 +4,9 @@ from __future__ import unicode_literals
 
 from pulp_smash.compat import quote_plus, urljoin
 
+BASE_PULP_FIXTURES_URL = 'https://repos.fedorapeople.org/repos/' \
+                         'pulp/pulp/fixtures/'
+"""The base URL to Pulp Test Fixtures."""
 
 CALL_REPORT_KEYS = frozenset(('error', 'result', 'spawned_tasks'))
 """See: `Call Report`_.
@@ -51,18 +54,31 @@ DOCKER_V2_FEED_URL = 'https://registry-1.docker.io'
 This URL can be used as the "feed" property of a Pulp Docker registry.
 """
 
-DRPM_FEED_URL = (
-    'https://repos.fedorapeople.org/repos/pulp/pulp/demo_repos/test_drpm_repo/'
+DRPM_FEED_URL = urljoin(
+    BASE_PULP_FIXTURES_URL,
+    'drpm-unsigned/'
 )
-"""The URL to an DRPM repository."""
+"""The URL to a DRPM repository."""
 
-DRPM = 'drpms/yum-3.4.3-10.fc16_3.4.3-11.fc16.noarch.drpm'
+DRPM_UNSIGNED_FEED_URL = urljoin(
+    BASE_PULP_FIXTURES_URL,
+    'drpm-unsigned/'
+)
+"""The URL to an unsigned DRPM repository."""
+
+DRPM = 'drpms/test-alpha-1.1-1_1.1-2.noarch.drpm'
 """The name of a DRPM file, relative to :data:`DRPM_FEED_URL`."""
 
 DRPM_URL = urljoin(DRPM_FEED_URL, DRPM)
 """The URL to a DRPM file.
 
 Built from :data:`DRPM_FEED_URL` and :data:`DRPM`.
+"""
+
+DRPM_UNSIGNED_URL = urljoin(DRPM_UNSIGNED_FEED_URL, DRPM)
+"""The URL to a unsigned DRPM file.
+
+Built from :data:`DRPM_UNSIGNED_FEED_URL` and :data:`DRPM`.
 """
 
 ERROR_KEYS = frozenset((
@@ -263,13 +279,22 @@ RPM_ERRATUM_URL = (
 )
 """The URL to an JSON erratum file for an RPM repository."""
 
-RPM_FEED_URL = 'https://repos.fedorapeople.org/repos/pulp/pulp/fixtures/rpm/'
+RPM_FEED_URL = urljoin(BASE_PULP_FIXTURES_URL, 'rpm/')
 """The URL to an RPM repository. See :data:`RPM_URL`."""
 
 RPM_SHA256_CHECKSUM = (
     '7a831f9f90bf4d21027572cb503d20b702de8e8785b02c0397445c2e481d81b3'
 )
 """The sha256 checksum of :data:`pulp_smash.constants.RPM`."""
+
+RPM_UNSIGNED_FEED_URL = urljoin(BASE_PULP_FIXTURES_URL, 'rpm-unsigned/')
+"""The URL to an unsigned RPM repository. See :data:`RPM_URL`."""
+
+RPM_UNSIGNED_URL = urljoin(RPM_UNSIGNED_FEED_URL, RPM)
+"""The URL to an unsigned RPM file.
+
+Built from :data:`RPM_UNSIGNED_FEED_URL` and :data:`RPM`.
+"""
 
 RPM_URL = urljoin(RPM_FEED_URL, RPM)
 """The URL to an RPM file. Built from :data:`RPM_FEED_URL` and :data:`RPM`."""
@@ -297,10 +322,29 @@ metadata/rpm
 SRPM = 'test-srpm02-1.0-1.src.rpm'
 """The name of an SRPM file at :data:`pulp_smash.constants.SRPM_FEED_URL`."""
 
-SRPM_FEED_URL = (
-    'https://repos.fedorapeople.org/repos/pulp/pulp/demo_repos/test_srpm_repo/'
+SRPM_FEED_URL = urljoin(
+    BASE_PULP_FIXTURES_URL,
+    'srpm/'
 )
 """The URL to an SRPM repository."""
+
+SRPM_UNSIGNED_FEED_URL = urljoin(
+    BASE_PULP_FIXTURES_URL,
+    'srpm-unsigned/'
+)
+"""The URL to an unsigned SRPM repository."""
+
+SRPM_UNSIGNED_URL = urljoin(SRPM_UNSIGNED_FEED_URL, SRPM)
+"""The URL to an unsigned SRPM file.
+
+Built from :data:`SRPM_UNSIGNED_FEED_URL` and :data:`SRPM`.
+"""
+
+SRPM_URL = urljoin(SRPM_FEED_URL, SRPM)
+"""The URL to an SRPM file.
+
+Built from :data:`SRPM_FEED_URL` and :data:`SRPM`.
+"""
 
 USER_PATH = '/pulp/api/v2/users/'
 """See: `User APIs`_.

--- a/pulp_smash/tests/rpm/api_v2/test_packages_signature.py
+++ b/pulp_smash/tests/rpm/api_v2/test_packages_signature.py
@@ -1,0 +1,268 @@
+# coding=utf-8
+"""Tests for how well Pulp can deal with signatures of RPMs.
+
+When RPM/DRPM/SRPM packages are added to rpm repositories, signature
+attribute should be stored for those packages.
+
+Tests for this feature include the following:
+
+* Upload signed and unsigned RPM/DRPM/SRPM packages to rpm repositories
+  (See :class:`UploadRPMSignatureTestCase`.)
+* Synchronize signed and unsigned RPM/DRPM/SRPM packages to rpm repositories
+  (See :class:`SyncRPMSignatureTestCase`.)
+
+For more information, see:
+
+* `Pulp #1156 <https://pulp.plan.io/issues/1156>`_
+"""
+from __future__ import unicode_literals
+
+import unittest2
+
+from pulp_smash import api, selectors, utils
+from pulp_smash.compat import urljoin
+from pulp_smash.constants import (
+    DRPM_UNSIGNED_FEED_URL,
+    DRPM_UNSIGNED_URL,
+    ORPHANS_PATH,
+    REPOSITORY_PATH,
+    RPM_FEED_URL,
+    RPM_UNSIGNED_FEED_URL,
+    RPM_UNSIGNED_URL,
+    RPM_URL,
+    SRPM_FEED_URL,
+    SRPM_UNSIGNED_FEED_URL,
+    SRPM_UNSIGNED_URL,
+    SRPM_URL
+)
+from pulp_smash.tests.rpm.api_v2.utils import (
+    gen_repo
+)
+
+_PACKAGE_URLS = {
+    'drpm-unsigned': {
+        'repo_url': DRPM_UNSIGNED_FEED_URL,
+        'pkg_url': DRPM_UNSIGNED_URL
+    },
+    'rpm': {
+        'repo_url': RPM_FEED_URL,
+        'pkg_url': RPM_URL
+    },
+    'rpm-unsigned': {
+        'repo_url': RPM_UNSIGNED_FEED_URL,
+        'pkg_url': RPM_UNSIGNED_URL
+    },
+    'srpm': {
+        'repo_url': SRPM_FEED_URL,
+        'pkg_url': SRPM_URL
+    },
+    'srpm-unsigned': {
+        'repo_url': SRPM_UNSIGNED_FEED_URL,
+        'pkg_url': SRPM_UNSIGNED_URL
+    }
+}
+"""A dict of information about urls of test repositories and packages."""
+
+
+class UploadRPMSignatureTestCase(utils.BaseAPITestCase):
+    """Test how well Pulp can deal with package signature.
+
+    When uploading and importing packages.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Create a shared client."""
+        super(UploadRPMSignatureTestCase, cls).setUpClass()
+        if selectors.bug_is_untestable(1156, cls.cfg.version):
+            raise unittest2.SkipTest('https://pulp.plan.io/issues/1156')
+        cls.client = api.Client(cls.cfg, api.json_handler)
+
+    def setUp(self):
+        """Set up common test variable."""
+        super(UploadRPMSignatureTestCase, self).setUp()
+        self.signature = None
+        self.package_type = None
+
+        # Create RPM Repository
+        self.repo = self.client.post(REPOSITORY_PATH, gen_repo())
+
+    def tearDown(self):
+        """Delete repo and orphans after each test case."""
+        super(UploadRPMSignatureTestCase, self).tearDown()
+        # Note: signed and unsigned packages in pulp-fixture share
+        # same file name. In order to make sure Pulp doesn't handle
+        # a package as a duplicate upload because of the package uploaded
+        # in previous tests. Make sure the repo and packages created
+        # are removed before running next tests.
+        if self.repo:
+            self.client.delete(self.repo['_href'])
+        self.client.delete(ORPHANS_PATH)
+
+    def _import_pkg_validate_signature(self):
+        """Import a package to the repo.
+
+        Validate the signature stored for the package.
+        """
+        repo_url = self.repo['_href']
+        pkg_url = _PACKAGE_URLS[self.package_type]['pkg_url']
+        if pkg_url.split('.')[-2] == 'src':
+            unit_type = 'srpm'
+        else:
+            unit_type = pkg_url.split('.')[-1]
+        unit_name = pkg_url.split('/')[-1]
+
+        # Upload and import the package to the repo
+        utils.upload_import_unit(
+            self.cfg,
+            utils.http_get(pkg_url),
+            unit_type,
+            repo_url)
+        # Get the package imported
+        units = self.client.post(
+            urljoin(repo_url, 'search/units/'),
+            {
+                'criteria': {
+                    'type_ids': [unit_type],
+                    'filters': {
+                        'unit': {
+                            'filename': {'$in': [unit_name]}
+                        }
+                    }
+                }
+            }
+        )
+        # Validate the signature of the package imported
+        self.assertEqual(len(units), 1)
+        if self.signature:
+            self.assertTrue('signature' in units[0]['metadata'])
+            self.assertEqual(units[0]['metadata']['signature'], self.signature)
+        else:
+            self.assertFalse('signature' in units[0]['metadata'])
+
+    def test_import_rpm_signed(self):
+        """Assert signature is stored for signed rpm imported."""
+        self.package_type = 'rpm'
+        self.signature = 'f78fb195'
+        self._import_pkg_validate_signature()
+
+    def test_import_srpm_signed(self):
+        """Assert signature is stored for signed srpm imported."""
+        self.package_type = 'srpm'
+        self.signature = '260f3a2b'
+        self._import_pkg_validate_signature()
+
+    def test_import_rpm_unsigned(self):
+        """Assert no signature is stored for unsigned rpm imported."""
+        self.package_type = 'rpm-unsigned'
+        self._import_pkg_validate_signature()
+
+    def test_import_srpm_unsigned(self):
+        """Assert no signature is stored for unsigned srpm imported."""
+        self.package_type = 'srpm-unsigned'
+        self._import_pkg_validate_signature()
+
+
+class SyncRPMSignatureTestCase(utils.BaseAPITestCase):
+    """Test how well Pulp can deal with package sig when syncing a repo."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create a shared client."""
+        super(SyncRPMSignatureTestCase, cls).setUpClass()
+        if selectors.bug_is_untestable(1156, cls.cfg.version):
+            raise unittest2.SkipTest('https://pulp.plan.io/issues/1156')
+        cls.client = api.Client(cls.cfg, api.json_handler)
+
+    def setUp(self):
+        """Set up common test variable."""
+        super(SyncRPMSignatureTestCase, self).setUp()
+        self.signature = None
+        self.package_type = None
+        self.repo = None
+
+    def tearDown(self):
+        """Delete repo and orphans after each test case."""
+        super(SyncRPMSignatureTestCase, self).tearDown()
+        # Note: signed and unsigned packages in pulp-fixture share
+        # same file name. In order to make sure pulp doesn't handle
+        # a package as a duplicate upload because of the package uploaded
+        # in previous tests. Make sure the repo and packages created
+        # are removed before running next tests.
+        if self.repo:
+            self.client.delete(self.repo['_href'])
+        self.client.delete(ORPHANS_PATH)
+
+    def _sync_repo_validate_package_sig(self):
+        """Sync a repo from feed.
+
+        Validate the signature stored for the package after sync.
+        """
+        # Create a rpm repository with feed
+        body = gen_repo()
+        body['importer_config']['feed'] = \
+            _PACKAGE_URLS[self.package_type]['repo_url']
+        self.repo = self.client.post(REPOSITORY_PATH, body)
+
+        # Sync content into the rpm repository
+        repo_url = self.repo['_href']
+        pkg_url = _PACKAGE_URLS[self.package_type]['pkg_url']
+        if pkg_url.split('.')[-2] == 'src':
+            unit_type = 'srpm'
+        else:
+            unit_type = pkg_url.split('.')[-1]
+        unit_name = pkg_url.split('/')[-1]
+        if unit_type == 'drpm':
+            unit_name = 'drpms/%s' % unit_name
+
+        utils.sync_repo(self.cfg, repo_url)
+
+        # Search units from repo
+        units = self.client.post(
+            urljoin(repo_url, 'search/units/'),
+            {
+                'criteria': {
+                    'type_ids': [unit_type],
+                    'filters': {
+                        'unit': {
+                            'filename': {'$in': [unit_name]}
+                        }
+                    }
+                }
+            }
+        )
+
+        # Validate the signature of the package
+        self.assertEqual(len(units), 1)
+        if self.signature:
+            self.assertTrue('signature' in units[0]['metadata'])
+            self.assertEqual(units[0]['metadata']['signature'], self.signature)
+        else:
+            self.assertFalse('signature' in units[0]['metadata'])
+
+    def test_sync_rpm_signed(self):
+        """Assert signature is stored for signed rpm during sync."""
+        self.package_type = 'rpm'
+        self.signature = 'f78fb195'
+        self._sync_repo_validate_package_sig()
+
+    def test_sync_srpm_signed(self):
+        """Assert signature is stored for signed srpm during sync."""
+        self.package_type = 'srpm'
+        self.signature = '260f3a2b'
+        self._sync_repo_validate_package_sig()
+
+    def test_sync_rpm_unsigned(self):
+        """Assert no signature is stored for unsigned rpm during sync."""
+        self.package_type = 'rpm-unsigned'
+        self._sync_repo_validate_package_sig()
+
+    def test_sync_srpm_unsigned(self):
+        """Assert no signature is stored for unsigned srpm during sync."""
+        self.package_type = 'srpm-unsigned'
+        self._sync_repo_validate_package_sig()
+
+    def test_sync_drpm_unsigned(self):
+        """Assert no signature is stored for unsigned drpm during sync."""
+        self.package_type = 'drpm-unsigned'
+        self._sync_repo_validate_package_sig()

--- a/pulp_smash/tests/rpm/api_v2/test_repo_signature.py
+++ b/pulp_smash/tests/rpm/api_v2/test_repo_signature.py
@@ -1,0 +1,506 @@
+# coding=utf-8
+"""Tests for how well Pulp can deal with repository signature checks.
+
+Pulp is able to run signature check when importing or associating
+a package to a rpm repository based on the repository importer configurations.
+
+Tests for this feature include the following:
+
+* Associate a signed rpm to a repository with different
+  repository importer configurations.
+  (See :class:`AssociateUnsignedRPMTestCase`.)
+* Associate an unsigned rpm to a repository with different
+  repository importer configurations.
+  (See :class:`AssociateSignedRPMTestCase`.)
+* Import a signed rpm to a repository with different importer
+  configurations (See :class:`ImportSignedRPMTestCase`.)
+* Import an unsigned rpm to a repository with different importer
+  configurations (See :class:`ImportUnsignedRPMTestCase`.)
+
+For more information, see:
+
+* `Pulp #1991 <https://pulp.plan.io/issues/1991>`_
+"""
+from __future__ import unicode_literals
+
+import unittest2
+
+from pulp_smash import api, selectors, utils
+from pulp_smash.compat import urljoin
+from pulp_smash.constants import (
+    ORPHANS_PATH,
+    REPOSITORY_PATH,
+    RPM_URL,
+    RPM_UNSIGNED_URL
+)
+from pulp_smash.tests.rpm.api_v2.utils import (
+    gen_repo,
+)
+
+_REPO_CONFIGS = {
+    'empty_allowed': {
+        'allow_keys': [],
+        'allow_unsigned': None
+    },
+    'matching_allowed': {
+        'allow_keys': ['260f3a2b', 'f78fb195'],
+        'allow_unsigned': None
+    },
+    'not_matching_allowed': {
+        'allow_keys': ['1111111'],
+        'allow_unsigned': None
+    },
+    'allow_unsigned': {
+        'allow_keys': None,
+        'allow_unsigned': True
+    },
+    'not_allow_unsigned': {
+        'allow_keys': None,
+        'allow_unsigned': False
+    },
+    'allow_unsigned_empty_allowed': {
+        'allow_keys': [],
+        'allow_unsigned': True
+    },
+}
+"""A dict of different combinations of repo importer configurations."""
+
+
+def _gen_repo_with_sig_options(allow_keys=None, allow_unsigned=None):
+    """Return a dict with signature related importer configurations.
+
+    For using in creating an RPM repository.
+    """
+    body = gen_repo()
+    if allow_keys:
+        body['importer_config']['allow_keys'] = allow_keys
+    if allow_unsigned:
+        body['importer_config']['allow_unsigned'] = allow_unsigned
+    return body
+
+
+class _BaseAssoicateRPMTestCase(utils.BaseAPITestCase):
+    """Provides common setup behaviors and functions.
+
+    For associating RPM tests.
+    """
+
+    @classmethod
+    def setUpClass(cls, rpm_url, unit_type):  # pylint:disable=arguments-differ
+        """Create RPM repositories."""
+        super(_BaseAssoicateRPMTestCase, cls).setUpClass()
+        if selectors.bug_is_untestable(1991, cls.cfg.version):
+            raise unittest2.SkipTest('https://pulp.plan.io/issues/1991')
+        cls.repos = {}
+        cls.client = api.Client(cls.cfg, api.json_handler)
+        cls.rpm_url = rpm_url
+        cls.unit_type = unit_type
+
+        # Create the original RPM repository that the RPM imported to
+        repo = cls.client.post(REPOSITORY_PATH, gen_repo())
+        cls.repos['origin'] = repo
+        cls.resources.add(repo['_href'])
+
+        # Create the RPM repositories with different importer configs.
+        # The RPM will later be associated to those repositories.
+        for repo_config in _REPO_CONFIGS:
+            allow_keys = _REPO_CONFIGS[repo_config]['allow_keys']
+            allow_unsigned = _REPO_CONFIGS[repo_config]['allow_unsigned']
+
+            repo = cls.client.post(
+                REPOSITORY_PATH,
+                _gen_repo_with_sig_options(allow_keys, allow_unsigned)
+            )
+            cls.repos[repo_config] = repo
+            cls.resources.add(repo['_href'])
+
+        # Import the RPM to the original RPM repository
+        utils.upload_import_unit(
+            cls.cfg,
+            utils.http_get(cls.rpm_url),
+            'rpm',
+            cls.repos['origin']['_href']
+        )
+
+    def _expect_success(self, task):
+        """Verify if the association task succeeds."""
+        self.assertTrue('units_successful' in task['result'])
+        self.assertIsNone(task['error'])
+
+    def _expect_fail(self, task):
+        """Verify if the association task fails."""
+        self.assertIsNotNone(task['error'])
+
+    def _associate_pkg_and_validate(self, repo_type, expect_success):
+        """Associate package to repo and verify result."""
+        call_report = self.client.post(
+            urljoin(self.repos[repo_type]['_href'], 'actions/associate/'),
+            {
+                'source_repo_id': self.repos['origin']['id'],
+                'criteria': {
+                    'type_ids': [self.unit_type],
+                    'filters': {
+                        'unit': {
+                            'filename': {
+                                '$in': [self.rpm_url.split('/')[-1]]
+                            }
+                        }
+                    }
+                }
+            }
+        )
+        task = next(api.poll_spawned_tasks(self.cfg, call_report))
+        if expect_success:
+            self._expect_success(task)
+        else:
+            self._expect_fail(task)
+
+
+class AssociateSignedRPMTestCase(_BaseAssoicateRPMTestCase):
+    """Test how well Pulp can deal with signature check.
+
+    When associating signed packages.
+    """
+
+    @classmethod
+    def setUpClass(cls):  # pylint:disable=arguments-differ
+        """Create RPM repositories."""
+        super(AssociateSignedRPMTestCase, cls).setUpClass(RPM_URL, 'rpm')
+
+    def test_empty_allowed(self):
+        """Verify it fails to associate a signed RPM to the repo.
+
+        Importer configs:
+            'allow_keys': [],
+        """
+        self._associate_pkg_and_validate(
+            repo_type='empty_allowed',
+            expect_success=False)
+
+    def test_matching_allowed(self):
+        """Verify it succeeds to associate a signed RPM to the repo.
+
+        Importer configs:
+            'allow_keys': ['260f3a2b', 'f78fb195'],
+        """
+        self._associate_pkg_and_validate(
+            repo_type='matching_allowed',
+            expect_success=True)
+
+    def test_no_matching_allowed(self):
+        """Verify it fails to associate a signed RPM to the repo.
+
+        Importer configs:
+            'allow_keys': ['1111111']
+        """
+        self._associate_pkg_and_validate(
+            repo_type='not_matching_allowed',
+            expect_success=False)
+
+    def test_allow_unsigned(self):
+        """Verify it succeeds to associate a signed RPM to the repo.
+
+        Importer configs:
+            "allow_unsigned": True
+        """
+        self._associate_pkg_and_validate(
+            repo_type='allow_unsigned',
+            expect_success=True)
+
+    def test_not_allow_unsigned(self):
+        """Verify it succeeds to associate a signed RPM to the repo.
+
+        Importer configs:
+            "allow_unsigned": False
+        """
+        self._associate_pkg_and_validate(
+            repo_type='not_allow_unsigned',
+            expect_success=True)
+
+    def test_allow_unsigned_emp_allowed(self):
+        """Verify it fails to associate a signed RPM to the repo.
+
+        Importer configs:
+            "allow_keys": [],
+            "allow_unsigned": True
+        """
+        self._associate_pkg_and_validate(
+            repo_type='allow_unsigned_empty_allowed',
+            expect_success=False)
+
+
+class AssociateUnsignedRPMTestCase(_BaseAssoicateRPMTestCase):
+    """Test how well Pulp can deal with signature check.
+
+    When associating unsigned packages.
+    """
+
+    @classmethod
+    def setUpClass(cls):  # pylint:disable=arguments-differ
+        """Create RPM repositories."""
+        super(AssociateUnsignedRPMTestCase, cls).setUpClass(
+            RPM_UNSIGNED_URL,
+            'rpm'
+        )
+
+    def test_empty_allow_keys(self):
+        """Verify it succeeds to associate an unsigned RPM to the repo.
+
+        Importer configs:
+            "allow_keys": []
+        """
+        self._associate_pkg_and_validate(
+            repo_type='empty_allowed',
+            expect_success=True)
+
+    def test_no_matching_allowed(self):
+        """Verify it fails to associate an unsigned RPM to the repo.
+
+        Importer configs:
+            "allow_keys": ["1111111"]
+        """
+        self._associate_pkg_and_validate(
+            repo_type='not_matching_allowed',
+            expect_success=False)
+
+    def test_allow_unsigned(self):
+        """Verify it succeeds to associate an unsigned RPM to the repo.
+
+        Importer configs:
+            "allow_unsigned": True
+        """
+        self._associate_pkg_and_validate(
+            repo_type='allow_unsigned',
+            expect_success=True)
+
+    def test_not_allow_unsigned(self):
+        """Verify it succeeds to associate an unsigned RPM to the repo.
+
+        Importer configs:
+            "allow_unsigned": False
+        """
+        self._associate_pkg_and_validate(
+            repo_type='not_allow_unsigned',
+            expect_success=True)
+
+    def test_allow_unsigned_emp_allowed(self):
+        """Verify it succeeds to associate an unsigned RPM to the repo.
+
+        Importer configs:
+            "allow_keys": [],
+            "allow_unsigned": True
+        """
+        self._associate_pkg_and_validate(
+            repo_type='allow_unsigned_empty_allowed',
+            expect_success=True)
+
+
+class _BaseImportRPMTestCase(utils.BaseAPITestCase):
+    """Provides common setup behaviors and functions.
+
+    For importing RPM tests.
+    """
+
+    @classmethod
+    def setUpClass(cls, rpm_url, unit_type):  # pylint:disable=arguments-differ
+        """Set up common set-up and variables."""
+        super(_BaseImportRPMTestCase, cls).setUpClass()
+        if selectors.bug_is_untestable(1991, cls.cfg.version):
+            raise unittest2.SkipTest('https://pulp.plan.io/issues/1991')
+
+        cls.client = api.Client(cls.cfg, api.json_handler)
+        cls.rpm_url = rpm_url
+        cls.unit_type = unit_type
+
+    def setUp(self):
+        """Set up common test variable."""
+        self.repo = None
+
+    def tearDown(self):
+        """Delete repo and orphans after each test case."""
+        # Note: Test methods are trying to import same package to
+        # different target rpm repositories. In order to make sure Pulp
+        # doesn't handle a package as a duplicate upload because of
+        # the package uploaded in previous tests. Make sure the repo
+        # and packages created are removed before running next tests.
+        if self.repo:
+            self.client.delete(self.repo['_href'])
+        self.client.delete(ORPHANS_PATH)
+
+    def create_repo(self, repo_type):
+        """Create an RPM repository.
+
+        With given signature related importer configurations.
+        """
+        allow_keys = _REPO_CONFIGS[repo_type]['allow_keys']
+        allow_unsigned = _REPO_CONFIGS[repo_type]['allow_unsigned']
+
+        return self.client.post(
+            REPOSITORY_PATH,
+            _gen_repo_with_sig_options(allow_keys, allow_unsigned)
+        )
+
+    def _expect_success(self, task):
+        """Verify the upload_import task succeeds."""
+        self.assertTrue('success_flag' in task['result'])
+        self.assertTrue(task['result']['success_flag'])
+
+    def _expect_fail(self, task):
+        """Verify the upload_import task fails."""
+        self.assertTrue('success_flag' in task['result'])
+        self.assertFalse(task['result']['success_flag'])
+
+    def _import_pkg_validate_result(self, repo_type, expect_success):
+        """Import package and validate task result."""
+        self.repo = self.create_repo(repo_type)
+
+        call_report = utils.upload_import_unit(
+            self.cfg,
+            utils.http_get(self.rpm_url),
+            self.unit_type,
+            self.repo['_href']
+        )
+        task = next(api.poll_spawned_tasks(self.cfg, call_report))
+        if expect_success:
+            self._expect_success(task)
+        else:
+            self._expect_fail(task)
+
+
+class ImportSignedRPMTestCase(_BaseImportRPMTestCase):
+    """Test how well Pulp can deal with signature check.
+
+    When importing signed packages.
+    """
+
+    @classmethod
+    def setUpClass(cls):  # pylint:disable=arguments-differ
+        """Set up common variables."""
+        super(ImportSignedRPMTestCase, cls).setUpClass(RPM_URL, 'rpm')
+
+    def test_empty_allow_keys_repo(self):
+        """Verify it fails to import a signed RPM to the repo.
+
+        Importer configs:
+            "allow_keys": []
+        """
+        self._import_pkg_validate_result(
+            repo_type='empty_allowed',
+            expect_success=False)
+
+    def test_matching_allow_keys_repo(self):
+        """Verify it succeeds to import a signed RPM to the repo.
+
+        Importer configs:
+            "allow_keys": ["260f3a2b", "f78fb195"]
+        """
+        self._import_pkg_validate_result(
+            repo_type='matching_allowed',
+            expect_success=True)
+
+    def test_no_matching_allowed(self):
+        """Verify it fails to import a signed RPM to the repo.
+
+        Importer configs:
+            "allow_keys": ["1111111"]
+        """
+        self._import_pkg_validate_result(
+            repo_type='not_matching_allowed',
+            expect_success=False)
+
+    def test_allow_unsigned_repo(self):
+        """Verify it succeeds to import a signed RPM to the repo.
+
+        Importer configs:
+            "allow_unsigned": True
+        """
+        self._import_pkg_validate_result(
+            repo_type='allow_unsigned',
+            expect_success=True)
+
+    def test_not_allow_unsigned_repo(self):
+        """Verify it succeeds to import a signed RPM to the repo.
+
+        Importer configs:
+            "allow_unsigned": False
+        """
+        self._import_pkg_validate_result(
+            repo_type='not_allow_unsigned',
+            expect_success=True)
+
+    def test_allow_unsigned_emp_allowed(self):
+        """Verify it fails to import a signed RPM to the repo.
+
+        Importer configs:
+            "allow_keys": [],
+            "allow_unsigned": True
+        """
+        self._import_pkg_validate_result(
+            repo_type='allow_unsigned_empty_allowed',
+            expect_success=False)
+
+
+class ImportUnsignedRPMTestCase(_BaseImportRPMTestCase):
+    """Test how well Pulp can deal with signature check.
+
+    When importing unsigned packages.
+    """
+
+    @classmethod
+    def setUpClass(cls):  # pylint:disable=arguments-differ
+        """Set up common variables."""
+        super(ImportUnsignedRPMTestCase, cls).setUpClass(
+            RPM_UNSIGNED_URL,
+            'rpm'
+        )
+
+    def test_empty_allowed(self):
+        """Verify it succeeds to import an unsigned RPM to the repo.
+
+        Importer configs:
+            "allow_keys": [],
+        """
+        self._import_pkg_validate_result(
+            repo_type='empty_allowed',
+            expect_success=True)
+
+    def test_not_matching_allowed(self):
+        """Verify it fails to import an unsigned RPM to the repo.
+
+        Importer configs:
+            "allow_keys": ["1111111"],
+        """
+        self._import_pkg_validate_result(
+            repo_type='not_matching_allowed',
+            expect_success=False)
+
+    def test_allow_unsigned(self):
+        """Verify it succeeds to import an unsigned RPM to the repo.
+
+        Importer configs:
+            "allow_unsigned": True,
+        """
+        self._import_pkg_validate_result(
+            repo_type='allow_unsigned',
+            expect_success=True)
+
+    def test_not_allow_unsigned(self):
+        """Verify it fails to import an unsigned RPM to the repo.
+
+        Importer configs:
+            "allow_unsigned": False,
+        """
+        self._import_pkg_validate_result(
+            repo_type='not_allow_unsigned',
+            expect_success=False)
+
+    def test_allow_unsigned_emp_allowed(self):
+        """Verify it succeeds to import an unsigned RPM to the repo.
+
+        Importer configs:
+            "allow_keys": [],
+            "allow_unsigned": True
+        """
+        self._import_pkg_validate_result(
+            repo_type='allow_unsigned_empty_allowed',
+            expect_success=True)


### PR DESCRIPTION
**Added 2 test files for signature check on packages and rpm repositories:**
- pulp_smash/tests/rpm/api_v2/test_package_signature.py (Pulp #1156)
- pulp_smash/tests/rpm/api_v2/test_repo_signature.py (Pulp #1991)

**Updated test fixture links:**
- pulp_smash/constants.py

Note: The new fixture links are valid only after PulpQE/pulp-fixtures are updated (https://github.com/PulpQE/pulp-fixtures/pull/17)