### PR TITLE
Convert documentation build warnings into errors

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -56,7 +56,7 @@ gen-api-docs: clean
 	cd ..; ./scripts/gen_api_docs.sh
 
 html: gen-api-docs
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	$(SPHINXBUILD) -W -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 


### PR DESCRIPTION
The `docs-html` make target uses `sphinx-build` to generate
documentation. Add the `-W` option, which turns warnings into errors.
This will help keep syntactic mistakes, like broken links and
incorrectly formatted code blocks, out of the documentation.