### PR TITLE
Changes the expected message when no-op publish occurs.

### DIFF
--- a/pulp_smash/tests/rpm/api_v2/test_no_op_publish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_no_op_publish.py
@@ -131,7 +131,7 @@ class NoOpPublishMixin(object):
         last_task = next(api.poll_spawned_tasks(self.cfg, call_report))
         self.assertEqual(
             last_task['result']['summary'],
-            'Skipped. Nothing changed since last publish',
+            'Skipped: Repository content has not changed since last publish.',
             last_task,
         )
 


### PR DESCRIPTION
After Pulp was modified to support using docker rsync distributor as a predistributor
for docker web distributor, Pulp skips publishing for two different reasons. As the
result of this change, the task status for skipped publishes has changed. This commit
adjusts pulp-smash tests to expect the new string.