### PR TITLE
Drop unnecessary usage of sudo

### DIFF
--- a/pulp_smash/utils.py
+++ b/pulp_smash/utils.py
@@ -103,7 +103,7 @@ def reset_pulp(server_config):
     client = cli.Client(server_config)
     prefix = '' if is_root(server_config) else 'sudo '
     client.run('mongo pulp_database --eval db.dropDatabase()'.split())
-    client.run('sudo -u apache pulp-manage-db'.split())
+    client.run((prefix + 'runuser -u apache pulp-manage-db').split())
     client.run((prefix + 'rm -rf /var/lib/pulp/content').split())
     client.run((prefix + 'rm -rf /var/lib/pulp/published').split())
 


### PR DESCRIPTION
`sudo` is not guaranteed to be present on a system, and even if it is,
there may be restrictions on its use. For example, consider this
interaction with an RHEL 7.2 system I recently laid my hands on:

    $ ssh $hostname sudo -u apache pulp-manage-db
    sudo: sorry, you must have a tty to run sudo

In this case, it is better to use `runuser` than `sudo`.