### PR TITLE
Un-pin dependency on 'flake8<3'

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 # For `make lint`
-flake8<3
+flake8
 flake8-docstrings
 flake8-quotes
 pylint


### PR DESCRIPTION
Allow the current version of flake8 to be installed, instead of some
version before version 3. See:

* b5309f6bab0a99c8a5f5dba70a14a4c5fe19dd16
* https://github.com/zheller/flake8-quotes/issues/29