### PR TITLE
Drop a spurious reference to `self`

### DIFF
--- a/pulp_smash/tests/rpm/api_v2/utils.py
+++ b/pulp_smash/tests/rpm/api_v2/utils.py
@@ -203,7 +203,7 @@ class DisableSELinuxMixin(object):  # pylint:disable=too-few-public-methods
             return
 
         # Temporarily disable SELinux.
-        sudo = '' if utils.is_root(self.cfg) else 'sudo '
+        sudo = '' if utils.is_root(cfg) else 'sudo '
         cmd = (sudo + 'setenforce 0').split()
         client.run(cmd)
         cmd = (sudo + 'setenforce 1').split()


### PR DESCRIPTION
Method `maybe_disable_selinux` accepts a `cfg` parameter. Using this
parameter instead of the instance attribute on the current object lets
it be used in a wider variety of situations, i.e. any class at all
inheriting from `unittest.TestCase`.