### PR TITLE
Fixes rsync distributor test in situations where SELinux is Disabled

### DIFF
--- a/pulp_smash/tests/rpm/api_v2/test_rsync_distributor.py
+++ b/pulp_smash/tests/rpm/api_v2/test_rsync_distributor.py
@@ -151,10 +151,12 @@ class _RsyncDistUtilsMixin(object):  # pylint:disable=too-few-public-methods
         client.run((sudo + 'chown apache ' + ssh_identity_file).split())
         # Pulp's SELinux policy requires files handled by Pulp to have the
         # httpd_sys_rw_content_t label
-        client.run(
-            (sudo + 'chcon -t httpd_sys_rw_content_t ' + ssh_identity_file)
-            .split()
-        )
+        enforcing = client.run(['getenforce']).stdout.strip()
+        if enforcing != 'Disabled':
+            client.run(
+                (sudo + 'chcon -t httpd_sys_rw_content_t ' + ssh_identity_file)
+                .split()
+            )
         return ssh_identity_file
 
     def make_repo(self, cfg, remote):


### PR DESCRIPTION
This commit adds a check for the state of SELinux in the rsynx distributor
test. On systems where SELinux is disabled, running chcon produces a non-zero
exit code.