### PR TITLE
Add constant RPM_FEED_COUNT

### DIFF
--- a/pulp_smash/constants.py
+++ b/pulp_smash/constants.py
@@ -288,6 +288,9 @@ RPM_ERRATUM_URL = (
 )
 """The URL to an JSON erratum file for an RPM repository."""
 
+RPM_FEED_COUNT = 32
+"""The number of RPMs available at :data:`RPM_FEED_URL`."""
+
 RPM_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'rpm/')
 """The URL to an RPM repository. See :data:`RPM_URL`."""
 

--- a/pulp_smash/tests/rpm/api_v2/test_rsync_distributor.py
+++ b/pulp_smash/tests/rpm/api_v2/test_rsync_distributor.py
@@ -26,7 +26,7 @@ from requests.exceptions import HTTPError
 
 from pulp_smash import api, cli, config, selectors, utils
 from pulp_smash.compat import urljoin, urlparse
-from pulp_smash.constants import REPOSITORY_PATH, RPM_FEED_URL
+from pulp_smash.constants import REPOSITORY_PATH, RPM_FEED_COUNT, RPM_FEED_URL
 from pulp_smash.tests.rpm.api_v2.utils import (
     DisableSELinuxMixin,
     gen_distributor,
@@ -227,7 +227,8 @@ class _RsyncDistUtilsMixin(object):  # pylint:disable=too-few-public-methods
         """Verify the RPM rsync distributor has placed RPMs in the given path.
 
         Verify that path ``{root}/{remote_units_path}/rpm`` exists in the
-        target system's filesystem, and that 32 RPMs are present in this
+        target system's filesystem, and that
+        :data:`pulp_smash.constants.RPM_FEED_COUNT` RPMs are present in this
         directory.
 
         :param pulp_smash.config.ServerConfig cfg: Information about the system
@@ -252,7 +253,7 @@ class _RsyncDistUtilsMixin(object):  # pylint:disable=too-few-public-methods
             path = os.path.join(path, segment)
         cmd = sudo + ('find', path, '-name', '*.rpm')
         files = cli_client.run(cmd).stdout.strip().split('\n')
-        self.assertEqual(len(files), 32, files)
+        self.assertEqual(len(files), RPM_FEED_COUNT, files)
 
 
 class PublishBeforeYumDistTestCase(

--- a/pulp_smash/tests/rpm/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_sync_publish.py
@@ -21,6 +21,7 @@ from pulp_smash.compat import urljoin
 from pulp_smash.constants import (
     DRPM_FEED_URL,
     REPOSITORY_PATH,
+    RPM_FEED_COUNT,
     RPM_FEED_URL,
     SRPM_FEED_URL,
 )
@@ -95,7 +96,7 @@ class SyncRpmRepoTestCase(SyncRepoBaseTestCase):
         Expected values are currently hard-coded into this test.
         """
         content_unit_counts = {
-            'rpm': 32,
+            'rpm': RPM_FEED_COUNT,
             'erratum': 4,
             'package_group': 2,
             'package_category': 1,


### PR DESCRIPTION
This new constant represents the number of RPMs available in the
repository at `RPM_FEED_URL`.