### PR TITLE
Rename PublishTestCase to ForceFullTestCase

### DIFF
--- a/pulp_smash/tests/rpm/api_v2/test_rsync_distributor.py
+++ b/pulp_smash/tests/rpm/api_v2/test_rsync_distributor.py
@@ -298,11 +298,11 @@ class PublishBeforeYumDistTestCase(
         self.assertNotIn('content', dirs)
 
 
-class PublishTestCase(
+class ForceFullTestCase(
         _RsyncDistUtilsMixin,
         DisableSELinuxMixin,
         utils.BaseAPITestCase):
-    """Publish a repository with the RPM rsync distributor, several times.
+    """Use the ``force_full`` RPM rsync distributor option.
 
     Do the following:
 
@@ -330,7 +330,7 @@ class PublishTestCase(
     """
 
     def test_all(self):
-        """Publish a repository several times with the rsync distributor."""
+        """Use the ``force_full`` RPM rsync distributor option."""
         api_client = api.Client(self.cfg)
         cli_client = cli.Client(self.cfg)
         sudo = '' if utils.is_root(self.cfg) else 'sudo '


### PR DESCRIPTION
`PublishTestCase` has five steps:

1. Create a repository with a yum distributor and RPM rsync distributor,
   and add content units to the repository.
2. Publish with the yum distributor.
3. Publish with the RPM rsync distributor.
4. Remove files from the target directory. Publish, and verify that no
   files are added to the target directory.
5. Publish with `force_full` set to true, and verify that files are
   placed in the target directory.

Both current and potential test cases will require steps 1–3. For
example, good tests for the `delete` and `remote_units_path` options
require that these steps be performed. Thus, when naming test cases, it
makes more sense to focus on what happens in later steps.

`DeleteTestCase` (https://github.com/PulpQE/pulp-smash/pull/377) also
uses this naming convention.