### PR TITLE
Expand test for pulp-admin's --force-sync option

### DIFF
--- a/pulp_smash/tests/rpm/api_v2/test_rsync_distributor.py
+++ b/pulp_smash/tests/rpm/api_v2/test_rsync_distributor.py
@@ -298,11 +298,11 @@ class PublishBeforeYumDistTestCase(
         self.assertNotIn('content', dirs)
 
 
-class PublishTestCase(
+class ForceFullTestCase(
         _RsyncDistUtilsMixin,
         DisableSELinuxMixin,
         utils.BaseAPITestCase):
-    """Publish a repository with the RPM rsync distributor, several times.
+    """Use the ``force_full`` RPM rsync distributor option.
 
     Do the following:
 
@@ -330,7 +330,7 @@ class PublishTestCase(
     """
 
     def test_all(self):
-        """Publish a repository several times with the rsync distributor."""
+        """Use the ``force_full`` RPM rsync distributor option."""
         api_client = api.Client(self.cfg)
         cli_client = cli.Client(self.cfg)
         sudo = '' if utils.is_root(self.cfg) else 'sudo '

--- a/pulp_smash/tests/rpm/cli/test_sync.py
+++ b/pulp_smash/tests/rpm/cli/test_sync.py
@@ -111,10 +111,11 @@ class ForceSyncTestCase(unittest2.TestCase):
     procedure is as follows:
 
     1. Create and sync a repository.
-    2. Remove one or more random RPMs from
-       ``/var/lib/pulp/content/units/rpm/``.
-    3. Sync the repository.
-    4. Verify that all removed units have been re-downloaded to the directory.
+    2. Remove some number of RPMs from ``/var/lib/pulp/content/units/rpm/``.
+       Verify they are missing.
+    3. Sync the repository. Verify the RPMs are still missing.
+    4. Sync the repository with ``--force-full true``. Verify all RPMs are
+       present.
 
     .. _Pulp #1982: https://pulp.plan.io/issues/1982
     .. _Pulp Smash #353: https://github.com/PulpQE/pulp-smash/issues/353
@@ -153,6 +154,11 @@ class ForceSyncTestCase(unittest2.TestCase):
             random.choice(rpms),
         ).split())
         with self.subTest(comment='Verify the RPM was removed.'):
+            self.assertEqual(len(self._list_rpms(cfg)), len(rpms) - 1)
+
+        # Sync the repository *without* force_sync.
+        sync_repo(cfg, repo_id)
+        with self.subTest(comment='Verify the RPM has not been restored.'):
             self.assertEqual(len(self._list_rpms(cfg)), len(rpms) - 1)
 
         # Sync the repository again


### PR DESCRIPTION
Expand `pulp_smash.tests.rpm.cli.test_sync.ForceSyncTestCase`.
Currently, the test case will:

1. Create and sync a repo.
2. Remove an RPM. Verify one RPM is missing.
3. Sync the repo with `--force-full true`. Verify all RPMs are present.

This test procedure shows that the second sync restores the removed RPM,
but it doesn't show that the `--force-sync true` option was the cause of
that restoration. It could be that syncs *always* restore removed RPMs.
(This would indicate a different issue with the fast-forward logic.)
Update the test so that it will:

1. Create and sync a repo.
2. Remove an RPM. Verify one RPM is missing.
3. Sync the repo. Verify one RPM is missing.
4. Sync the repo with `--force-full true`. Verify all RPMs are present.