### PR TITLE
Test key ID checks when syncing packages

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -82,6 +82,7 @@ developers, not a gospel.
     api/pulp_smash.tests.rpm.api_v2.test_schedule_publish
     api/pulp_smash.tests.rpm.api_v2.test_schedule_sync
     api/pulp_smash.tests.rpm.api_v2.test_search
+    api/pulp_smash.tests.rpm.api_v2.test_signatures_checked_for_syncs
     api/pulp_smash.tests.rpm.api_v2.test_signatures_checked_for_uploads
     api/pulp_smash.tests.rpm.api_v2.test_signatures_saved_for_packages
     api/pulp_smash.tests.rpm.api_v2.test_sync_publish

--- a/docs/api/pulp_smash.tests.rpm.api_v2.test_signatures_checked_for_syncs.rst
+++ b/docs/api/pulp_smash.tests.rpm.api_v2.test_signatures_checked_for_syncs.rst
@@ -1,0 +1,6 @@
+`pulp_smash.tests.rpm.api_v2.test_signatures_checked_for_syncs`
+===============================================================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.rpm.api_v2.test_signatures_checked_for_syncs`
+
+.. automodule:: pulp_smash.tests.rpm.api_v2.test_signatures_checked_for_syncs

--- a/pulp_smash/constants.py
+++ b/pulp_smash/constants.py
@@ -72,6 +72,9 @@ This URL can be used as the "feed" property of a Pulp Docker registry.
 DRPM_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'drpm-unsigned/')
 """The URL to a DRPM repository."""
 
+DRPM_UNSIGNED_FEED_COUNT = 4
+"""The number of packages available at :data:`DRPM_UNSIGNED_FEED_URL`."""
+
 DRPM_UNSIGNED_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'drpm-unsigned/')
 """The URL to an unsigned DRPM repository."""
 
@@ -289,7 +292,7 @@ RPM_ERRATUM_URL = (
 """The URL to an JSON erratum file for an RPM repository."""
 
 RPM_FEED_COUNT = 32
-"""The number of RPMs available at :data:`RPM_FEED_URL`."""
+"""The number of packages available at :data:`RPM_FEED_URL`."""
 
 RPM_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'rpm/')
 """The URL to an RPM repository. See :data:`RPM_URL`."""
@@ -298,6 +301,9 @@ RPM_SHA256_CHECKSUM = (
     '4fe8d0e21ee6d56d420c396a02aeaeb59feb00b625811b6a2b4d8f0c1aad80ca'
 )
 """The sha256 checksum of :data:`pulp_smash.constants.RPM`."""
+
+RPM_UNSIGNED_FEED_COUNT = 32
+"""The number of packages available at :data:`RPM_UNSIGNED_FEED_URL`."""
 
 RPM_UNSIGNED_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'rpm-unsigned/')
 """The URL to an unsigned RPM repository. See :data:`RPM_URL`."""
@@ -334,8 +340,14 @@ metadata/rpm
 SRPM = 'test-srpm02-1.0-1.src.rpm'
 """The name of an SRPM file at :data:`pulp_smash.constants.SRPM_FEED_URL`."""
 
+SRPM_FEED_COUNT = 3
+"""The number of packages available at :data:`SRPM_FEED_URL`."""
+
 SRPM_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'srpm/')
 """The URL to an SRPM repository."""
+
+SRPM_UNSIGNED_FEED_COUNT = 3
+"""The number of packages available at :data:`SRPM_UNSIGNED_FEED_COUNT`."""
 
 SRPM_UNSIGNED_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'srpm-unsigned/')
 """The URL to an unsigned SRPM repository."""

--- a/pulp_smash/tests/rpm/api_v2/test_signatures_checked_for_syncs.py
+++ b/pulp_smash/tests/rpm/api_v2/test_signatures_checked_for_syncs.py
@@ -1,0 +1,466 @@
+# coding=utf-8
+"""Tests for repository signature checks when syncing packages.
+
+This module mimics
+:mod:`pulp_smash.tests.rpm.api_v2.test_signatures_checked_for_uploads`, except
+that packages are synced in to Pulp instead of being uploaded.
+
+.. NOTE:: Pulp's signature checking logic is subtle. Please read
+    :mod:`pulp_smash.tests.rpm.api_v2.test_signatures_checked_for_uploads`.
+"""
+# NOTE to test authors: It's important to remove all content units after each
+# test. Let's say that you create a repository with an importer that requires
+# signatures and with a feed pointing at a repository with unsigned RPMs. When
+# this repository is synced, none of the RPMs from the remote repository will
+# be added. However, if Pulp has local content units matching what's listed in
+# the remote repository's `repodata` directory, then the local content units
+# will be added to the repository.
+#
+# The easiest way to avoid these confusing situations is to ensure that Pulp
+# retains no local content units after each test.
+from __future__ import unicode_literals
+
+import inspect
+
+import unittest2
+
+from pulp_smash import api, config, selectors, utils
+from pulp_smash.constants import (
+    DRPM_UNSIGNED_FEED_COUNT,
+    DRPM_UNSIGNED_FEED_URL,
+    ORPHANS_PATH,
+    PULP_FIXTURES_KEY_ID,
+    REPOSITORY_PATH,
+    RPM_FEED_COUNT,
+    RPM_FEED_URL,
+    RPM_UNSIGNED_FEED_COUNT,
+    RPM_UNSIGNED_FEED_URL,
+    SRPM_FEED_COUNT,
+    SRPM_FEED_URL,
+    SRPM_UNSIGNED_FEED_COUNT,
+    SRPM_UNSIGNED_FEED_URL,
+)
+from pulp_smash.tests.rpm.api_v2.utils import gen_repo
+from pulp_smash.tests.rpm.utils import set_up_module
+
+
+def setUpModule():  # pylint:disable=invalid-name
+    """Conditionally skip tests."""
+    if selectors.bug_is_untestable(1991, config.get_config().version):
+        raise unittest2.SkipTest('https://pulp.plan.io/issues/1991')
+    set_up_module()
+
+
+def tearDownModule():  # pylint:disable=invalid-name
+    """Delete orphan content units."""
+    api.Client(config.get_config()).delete(ORPHANS_PATH)
+
+
+class _BaseTestCase(unittest2.TestCase):
+    """Common logic for the test cases in this module."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Skip this test case if no child inherits from it."""
+        if inspect.getmro(cls)[0] == _BaseTestCase:
+            raise unittest2.SkipTest('Abstract base class.')
+
+    def setUp(self):
+        """Set common variables."""
+        self.cfg = config.get_config()
+
+    def create_sync_repo(self, importer_config):
+        """Create and sync a repository, and schedule tear-down logic.
+
+        The tear-down logic deletes the created repository and all orphans.
+        (``addCleanup()`` is used.) An up-to-date dict of information about the
+        repo is returned.
+        """
+        client = api.Client(self.cfg, api.json_handler)
+        body = gen_repo()
+        body['importer_config'] = importer_config
+        self.addCleanup(client.delete, ORPHANS_PATH)
+        repo_href = client.post(REPOSITORY_PATH, body)['_href']
+        self.addCleanup(client.delete, repo_href)
+        utils.sync_repo(self.cfg, repo_href)
+        return client.get(repo_href)
+
+
+class RequireValidKeyTestCase(_BaseTestCase):
+    """Use an importer that requires signatures and has a valid key ID.
+
+    The importer should have the following pseudocode configuration:
+
+    .. code-block:: json
+
+        {"require_signature": true, "allowed_keys": ["valid key id"]}
+    """
+
+    def test_signed_rpm(self):
+        """Sync signed RPMs into the repository.
+
+        Assert packages are synced in.
+        """
+        cu_counts = self.create_sync_repo({
+            'allowed_keys': [PULP_FIXTURES_KEY_ID],
+            'feed': RPM_FEED_URL,
+            'require_signature': True,
+        })['content_unit_counts']
+        self.assertEqual(cu_counts['rpm'], RPM_FEED_COUNT, cu_counts)
+
+    def test_signed_srpm(self):
+        """Sync signed SRPMs into the repository.
+
+        Assert packages are synced in.
+        """
+        cu_counts = self.create_sync_repo({
+            'allowed_keys': [PULP_FIXTURES_KEY_ID],
+            'feed': SRPM_FEED_URL,
+            'require_signature': True,
+        })['content_unit_counts']
+        self.assertEqual(cu_counts['srpm'], SRPM_FEED_COUNT, cu_counts)
+
+    def test_unsigned_packages(self):
+        """Sync unsigned RPMs, DRPMs and SRPMS into repositories.
+
+        Assert no packages are synced in.
+        """
+        variants = (
+            (RPM_UNSIGNED_FEED_URL, 'rpm'),
+            (DRPM_UNSIGNED_FEED_URL, 'drpm'),
+            (SRPM_UNSIGNED_FEED_URL, 'srpm'),
+        )
+        for feed, type_id in variants:
+            with self.subTest(type_id=type_id):
+                cu_counts = self.create_sync_repo({
+                    'allowed_keys': [PULP_FIXTURES_KEY_ID],
+                    'feed': feed,
+                    'require_signature': True,
+                })['content_unit_counts']
+                self.assertNotIn(type_id, cu_counts, cu_counts)
+
+
+class RequireInvalidKeyTestCase(_BaseTestCase):
+    """Use an importer that requires signatures and has an invalid key ID.
+
+    The importer should have the following pseudocode configuration:
+
+    .. code-block:: json
+
+        {"require_signature": true, "allowed_keys": ["invalid key id"]}
+    """
+
+    def test_packages(self):
+        """Sync signed and unsigned RPMs, DRPMs and SRPMs into repositories.
+
+        No signed DRPMs are synced in due to `Pulp Fixtures #25
+        <https://github.com/PulpQE/pulp-fixtures/issues/25>`_.
+
+        Assert no packages are synced in.
+        """
+        variants = (
+            (RPM_FEED_URL, 'rpm'),
+            (SRPM_FEED_URL, 'srpm'),
+            (RPM_UNSIGNED_FEED_URL, 'rpm'),
+            (DRPM_UNSIGNED_FEED_URL, 'drpm'),
+            (SRPM_UNSIGNED_FEED_URL, 'srpm'),
+        )
+        for feed, type_id in variants:
+            with self.subTest(type_id=type_id):
+                cu_counts = self.create_sync_repo({
+                    'allowed_keys': ['01234567'],
+                    'feed': feed,
+                    'require_signature': True,
+                })['content_unit_counts']
+                self.assertNotIn(type_id, cu_counts, cu_counts)
+
+
+class RequireAnyKeyTestCase(_BaseTestCase):
+    """Use an importer that requires signatures and has no key IDs.
+
+    The importer should have the following pseudocode configuration:
+
+    .. code-block:: json
+
+        {"require_signature": true, "allowed_keys": []}
+    """
+
+    def test_signed_rpm(self):
+        """Sync signed RPMs into the repository.
+
+        Assert packages are synced in.
+        """
+        cu_counts = self.create_sync_repo({
+            'allowed_keys': [],
+            'feed': RPM_FEED_URL,
+            'require_signature': True,
+        })['content_unit_counts']
+        self.assertEqual(cu_counts['rpm'], RPM_FEED_COUNT, cu_counts)
+
+    def test_signed_srpm(self):
+        """Sync signed SRPMs into the repository.
+
+        Assert packages are synced in.
+        """
+        cu_counts = self.create_sync_repo({
+            'allowed_keys': [],
+            'feed': SRPM_FEED_URL,
+            'require_signature': True,
+        })['content_unit_counts']
+        self.assertEqual(cu_counts['srpm'], SRPM_FEED_COUNT, cu_counts)
+
+    def test_unsigned_packages(self):
+        """Sync unsigned RPMs, DRPMs and SRPMS into repositories.
+
+        Assert no packages are synced in.
+        """
+        variants = (
+            (RPM_UNSIGNED_FEED_URL, 'rpm'),
+            (DRPM_UNSIGNED_FEED_URL, 'drpm'),
+            (SRPM_UNSIGNED_FEED_URL, 'srpm'),
+        )
+        for feed, type_id in variants:
+            with self.subTest(type_id=type_id):
+                cu_counts = self.create_sync_repo({
+                    'allowed_keys': [],
+                    'feed': feed,
+                    'require_signature': True,
+                })['content_unit_counts']
+                self.assertNotIn(type_id, cu_counts, cu_counts)
+
+
+class AllowInvalidKeyTestCase(_BaseTestCase):
+    """Use an importer that allows unsigned packages and has an invalid key ID.
+
+    The importer should have the following pseudocode configuration:
+
+    .. code-block:: json
+
+        {"require_signature": false, "allowed_keys": ["invalid key id"]}
+    """
+
+    def test_signed_packages(self):
+        """Import signed RPMs and SRPMs into repositories.
+
+        No signed DRPMs are synced in due to `Pulp Fixtures #25
+        <https://github.com/PulpQE/pulp-fixtures/issues/25>`_.
+
+        Assert no packages are synced.
+        """
+        variants = (
+            (RPM_FEED_URL, 'rpm'),
+            (SRPM_FEED_URL, 'srpm'),
+        )
+        for feed, type_id in variants:
+            with self.subTest(type_id=type_id):
+                cu_counts = self.create_sync_repo({
+                    'allowed_keys': ['01234567'],
+                    'feed': feed,
+                    'require_signature': False,
+                })['content_unit_counts']
+                self.assertNotIn(type_id, cu_counts, cu_counts)
+
+    def test_unsigned_rpms(self):
+        """Import unsigned RPMs into a repository.
+
+        Assert packages are synced.
+        """
+        cu_counts = self.create_sync_repo({
+            'allowed_keys': ['01234567'],
+            'feed': RPM_UNSIGNED_FEED_URL,
+            'require_signature': False,
+        })['content_unit_counts']
+        self.assertEqual(cu_counts['rpm'], RPM_UNSIGNED_FEED_COUNT, cu_counts)
+
+    def test_unsigned_drpms(self):
+        """Import unsigned DRPMs into a repository.
+
+        Assert packages are synced.
+        """
+        cu_counts = self.create_sync_repo({
+            'allowed_keys': ['01234567'],
+            'feed': DRPM_UNSIGNED_FEED_URL,
+            'require_signature': False,
+        })['content_unit_counts']
+        self.assertEqual(
+            cu_counts['drpm'],
+            DRPM_UNSIGNED_FEED_COUNT,
+            cu_counts,
+        )
+
+    def test_unsigned_srpms(self):
+        """Import unsigned SRPMs into a repository.
+
+        Assert packages are synced.
+        """
+        cu_counts = self.create_sync_repo({
+            'allowed_keys': ['01234567'],
+            'feed': SRPM_UNSIGNED_FEED_URL,
+            'require_signature': False,
+        })['content_unit_counts']
+        self.assertEqual(
+            cu_counts['srpm'],
+            SRPM_UNSIGNED_FEED_COUNT,
+            cu_counts,
+        )
+
+
+class AllowValidKeyTestCase(_BaseTestCase):
+    """Use an importer that allows unsigned packages and has a valid key ID.
+
+    The importer should have the following pseudocode configuration:
+
+    .. code-block:: json
+
+        {"require_signature": false, "allowed_keys": ["valid key id"]}
+
+    .. NOTE:: Pulp's signature checking logic is subtle. Please read
+        :mod:`pulp_smash.tests.rpm.api_v2.test_signatures_checked_for_uploads`.
+    """
+
+    def test_signed_rpm(self):
+        """Sync signed RPMs into the repository.
+
+        Assert packages are synced in.
+        """
+        cu_counts = self.create_sync_repo({
+            'allowed_keys': [PULP_FIXTURES_KEY_ID],
+            'feed': RPM_FEED_URL,
+            'require_signature': False,
+        })['content_unit_counts']
+        self.assertEqual(cu_counts['rpm'], RPM_FEED_COUNT, cu_counts)
+
+    def test_signed_srpm(self):
+        """Sync signed SRPMs into the repository.
+
+        Assert packages are synced in.
+        """
+        cu_counts = self.create_sync_repo({
+            'allowed_keys': [PULP_FIXTURES_KEY_ID],
+            'feed': SRPM_FEED_URL,
+            'require_signature': False,
+        })['content_unit_counts']
+        self.assertEqual(cu_counts['srpm'], SRPM_FEED_COUNT, cu_counts)
+
+    def test_unsigned_rpms(self):
+        """Import unsigned RPMs into a repository.
+
+        Assert packages are synced.
+        """
+        cu_counts = self.create_sync_repo({
+            'allowed_keys': [PULP_FIXTURES_KEY_ID],
+            'feed': RPM_UNSIGNED_FEED_URL,
+            'require_signature': False,
+        })['content_unit_counts']
+        self.assertEqual(cu_counts['rpm'], RPM_UNSIGNED_FEED_COUNT, cu_counts)
+
+    def test_unsigned_drpms(self):
+        """Import unsigned DRPMs into a repository.
+
+        Assert packages are synced.
+        """
+        cu_counts = self.create_sync_repo({
+            'allowed_keys': [PULP_FIXTURES_KEY_ID],
+            'feed': DRPM_UNSIGNED_FEED_URL,
+            'require_signature': False,
+        })['content_unit_counts']
+        self.assertEqual(
+            cu_counts['drpm'],
+            DRPM_UNSIGNED_FEED_COUNT,
+            cu_counts
+        )
+
+    def test_unsigned_srpms(self):
+        """Import unsigned SRPMs into a repository.
+
+        Assert packages are synced.
+        """
+        cu_counts = self.create_sync_repo({
+            'allowed_keys': [PULP_FIXTURES_KEY_ID],
+            'feed': SRPM_UNSIGNED_FEED_URL,
+            'require_signature': False,
+        })['content_unit_counts']
+        self.assertEqual(
+            cu_counts['srpm'],
+            SRPM_UNSIGNED_FEED_COUNT,
+            cu_counts,
+        )
+
+
+class AllowAnyKeyTestCase(_BaseTestCase):
+    """Use an importer that allows unsigned packages and has no key IDs.
+
+    The importer should have the following pseudocode configuration:
+
+    .. code-block:: json
+
+        {"require_signature": false, "allowed_keys": []}
+    """
+
+    def test_signed_rpm(self):
+        """Sync signed RPMs into the repository.
+
+        Assert packages are synced in.
+        """
+        cu_counts = self.create_sync_repo({
+            'allowed_keys': [],
+            'feed': RPM_FEED_URL,
+            'require_signature': False,
+        })['content_unit_counts']
+        self.assertEqual(cu_counts['rpm'], RPM_FEED_COUNT, cu_counts)
+
+    def test_signed_srpm(self):
+        """Sync signed SRPMs into the repository.
+
+        Assert packages are synced in.
+        """
+        cu_counts = self.create_sync_repo({
+            'allowed_keys': [],
+            'feed': SRPM_FEED_URL,
+            'require_signature': False,
+        })['content_unit_counts']
+        self.assertEqual(cu_counts['srpm'], SRPM_FEED_COUNT, cu_counts)
+
+    def test_unsigned_rpms(self):
+        """Import unsigned RPMs into a repository.
+
+        Verify packages are synced.
+        """
+        cu_counts = self.create_sync_repo({
+            'allowed_keys': [],
+            'feed': RPM_UNSIGNED_FEED_URL,
+            'require_signature': False,
+        })['content_unit_counts']
+        self.assertEqual(cu_counts['rpm'], RPM_UNSIGNED_FEED_COUNT, cu_counts)
+
+    def test_unsigned_drpms(self):
+        """Import unsigned DRPMs into a repository.
+
+        Verify packages are synced.
+        """
+        cu_counts = self.create_sync_repo({
+            'allowed_keys': [],
+            'feed': DRPM_UNSIGNED_FEED_URL,
+            'require_signature': False,
+        })['content_unit_counts']
+        self.assertEqual(
+            cu_counts['drpm'],
+            DRPM_UNSIGNED_FEED_COUNT,
+            cu_counts
+        )
+
+    def test_unsigned_srpms(self):
+        """Import unsigned SRPMs into a repository.
+
+        Verify packages are synced.
+        """
+        cu_counts = self.create_sync_repo({
+            'allowed_keys': [],
+            'feed': SRPM_UNSIGNED_FEED_URL,
+            'require_signature': False,
+        })['content_unit_counts']
+        self.assertEqual(
+            cu_counts['srpm'],
+            SRPM_UNSIGNED_FEED_COUNT,
+            cu_counts,
+        )

--- a/pulp_smash/tests/rpm/api_v2/test_signatures_checked_for_uploads.py
+++ b/pulp_smash/tests/rpm/api_v2/test_signatures_checked_for_uploads.py
@@ -12,6 +12,11 @@ are available:
     A list of 32-bit key IDs, as hex characters. (e.g. ``["deadbeef"]``) An
     empty list is treated as the list of all possible key IDs.
 
+Beware that if a package has a signature, its signature *must* be listed in
+``allowed_keys``, even when ``require_signature`` is false. The only importer
+configuration that allows all packages is ``{'require_signature': False,
+'allowed_keys': []}``.
+
 To test this feature, importers with at least the following options should be
 created::
 
@@ -36,7 +41,10 @@ gracefully handle those changes.
 
 For more information, see `Pulp #1991`_ and `Pulp Smash #347`_.
 
+..NOTE:: No signed DRPMs are used due to `Pulp Fixtures #25`_.
+
 .. _Pulp #1991: https://pulp.plan.io/issues/1991
+.. _Pulp Fixtures #25: https://github.com/PulpQE/pulp-fixtures/issues/25
 .. _Pulp Smash #347: https://github.com/PulpQE/pulp-smash/issues/347
 """
 from __future__ import unicode_literals


### PR DESCRIPTION
Add a new module,
`pulp_smash.tests.rpm.api_v2.test_signatures_checked_for_syncs`. This
new module verifies whether RPM repository importers configured to
perform package signature ID checks do so when packages are synced in to
repositories.

The new test cases exercise importers that:

* allow unsigned packages and specify a valid key ID.
* allow unsigned packages and specify an invalid key ID.
* allow unsigned packages and specify no key ID.
* require signed packages and specify a valid key ID.
* require signed packages and specify an invalid key ID.
* require signed packages and specify no key ID.

See: https://github.com/PulpQE/pulp-smash/issues/347

See: 7779cea52adeb009b280190fd4050c6abebdb2af