### PR TITLE
Make test failure messages more succinct

### DIFF
--- a/pulp_smash/tests/rpm/api_v2/test_signatures_checked_for_syncs.py
+++ b/pulp_smash/tests/rpm/api_v2/test_signatures_checked_for_syncs.py
@@ -139,7 +139,7 @@ class RequireValidKeyTestCase(_BaseTestCase):
                     'feed': feed,
                     'require_signature': True,
                 })['content_unit_counts']
-                self.assertNotIn(type_id, cu_counts, cu_counts)
+                self.assertNotIn(type_id, cu_counts)
 
 
 class RequireInvalidKeyTestCase(_BaseTestCase):
@@ -174,7 +174,7 @@ class RequireInvalidKeyTestCase(_BaseTestCase):
                     'feed': feed,
                     'require_signature': True,
                 })['content_unit_counts']
-                self.assertNotIn(type_id, cu_counts, cu_counts)
+                self.assertNotIn(type_id, cu_counts)
 
 
 class RequireAnyKeyTestCase(_BaseTestCase):
@@ -228,7 +228,7 @@ class RequireAnyKeyTestCase(_BaseTestCase):
                     'feed': feed,
                     'require_signature': True,
                 })['content_unit_counts']
-                self.assertNotIn(type_id, cu_counts, cu_counts)
+                self.assertNotIn(type_id, cu_counts)
 
 
 class AllowInvalidKeyTestCase(_BaseTestCase):
@@ -260,7 +260,7 @@ class AllowInvalidKeyTestCase(_BaseTestCase):
                     'feed': feed,
                     'require_signature': False,
                 })['content_unit_counts']
-                self.assertNotIn(type_id, cu_counts, cu_counts)
+                self.assertNotIn(type_id, cu_counts)
 
     def test_unsigned_rpms(self):
         """Import unsigned RPMs into a repository.


### PR DESCRIPTION
Given the following assertion:

    d = {1: 2, 3: 4}
    self.assertNotIn(1, d)

At least the nose and unittest2 test runners will print a message like
the following:

    AssertionError: 1 unexpectedly found in {1: 2, 3: 4}

Thus, the following assertion produces an unnecessarily verbose failure
message.

    d = {1: 2, 3: 4}
    self.assertNotIn(1, d, d)