### PR TITLE
Skip tests affected by Pulp issue 2242

### DIFF
--- a/pulp_smash/tests/rpm/api_v2/test_signatures_checked_for_syncs.py
+++ b/pulp_smash/tests/rpm/api_v2/test_signatures_checked_for_syncs.py
@@ -48,6 +48,8 @@ def setUpModule():  # pylint:disable=invalid-name
     """Conditionally skip tests."""
     if selectors.bug_is_untestable(1991, config.get_config().version):
         raise unittest2.SkipTest('https://pulp.plan.io/issues/1991')
+    if selectors.bug_is_untestable(2242, config.get_config().version):
+        raise unittest2.SkipTest('https://pulp.plan.io/issues/2242')
     set_up_module()
 
 


### PR DESCRIPTION
According to Pulp issue 2242, package signature ID checking is not done
when packages are synced into a repository. Skip the relevant tests.

See: https://pulp.plan.io/issues/2242