### PR TITLE
Test Pulp issue 2230

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -24,6 +24,7 @@ developers, not a gospel.
     api/pulp_smash.tests.docker.api_v2
     api/pulp_smash.tests.docker.api_v2.test_crud
     api/pulp_smash.tests.docker.api_v2.test_duplicate_uploads
+    api/pulp_smash.tests.docker.api_v2.test_sync
     api/pulp_smash.tests.docker.api_v2.utils
     api/pulp_smash.tests.docker.cli
     api/pulp_smash.tests.docker.cli.test_copy

--- a/docs/api/pulp_smash.tests.docker.api_v2.test_sync.rst
+++ b/docs/api/pulp_smash.tests.docker.api_v2.test_sync.rst
@@ -1,0 +1,6 @@
+`pulp_smash.tests.docker.api_v2.test_sync`
+==========================================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.docker.api_v2.test_sync`
+
+.. automodule:: pulp_smash.tests.docker.api_v2.test_sync

--- a/pulp_smash/constants.py
+++ b/pulp_smash/constants.py
@@ -57,6 +57,9 @@ CONTENT_UPLOAD_PATH = '/pulp/api/v2/content/uploads/'
 DOCKER_IMAGE_URL = urljoin(PULP_FIXTURES_BASE_URL, 'docker/busybox:latest.tar')
 """The URL to a Docker image as created by ``docker save``."""
 
+DOCKER_UPSTREAM_NAME = 'library/busybox'
+"""The name of a repository present in each of the two docker feeds."""
+
 DOCKER_V1_FEED_URL = 'https://index.docker.io'
 """The URL to a V1 Docker registry.
 

--- a/pulp_smash/tests/docker/api_v2/test_sync.py
+++ b/pulp_smash/tests/docker/api_v2/test_sync.py
@@ -1,0 +1,103 @@
+# coding=utf-8
+"""Tests that sync docker repositories."""
+from __future__ import unicode_literals
+
+import unittest2
+from packaging.version import Version
+
+from pulp_smash import api, config, selectors, utils
+from pulp_smash.compat import urljoin
+from pulp_smash.constants import (
+    DOCKER_UPSTREAM_NAME,
+    DOCKER_V1_FEED_URL,
+    DOCKER_V2_FEED_URL,
+    REPOSITORY_PATH,
+)
+from pulp_smash.tests.docker.api_v2.utils import gen_repo
+from pulp_smash.tests.docker.utils import set_up_module
+
+
+def setUpModule():  # pylint:disable=invalid-name
+    """Skip tests on Pulp versions lower than 2.8."""
+    set_up_module()
+    if config.get_config().version < Version('2.8'):
+        raise unittest2.SkipTest('These tests require at least Pulp 2.8.')
+
+
+class UpstreamNameTestsMixin(object):
+    """Provides tests that sync a repository and override ``upstream_name``.
+
+    Any class inheriting from this mixin must also inherit from
+    :class:`pulp_smash.utils.BaseAPITestCase`.
+    """
+
+    def test_valid_upstream_name(self):
+        """Sync the repository and pass a valid ``upstream_name``.
+
+        Verify the sync succeeds.
+        """
+        api.Client(self.cfg).post(
+            urljoin(self.repo_href, 'actions/sync/'),
+            {'override_config': {'upstream_name': DOCKER_UPSTREAM_NAME}},
+        )
+
+    def test_invalid_upstream_name(self):
+        """Sync the repository and pass an invalid ``upstream_name``.
+
+        Verify the sync request is rejected with an HTTP 400 status code.
+        """
+        if selectors.bug_is_untestable(2230, self.cfg.version):
+            self.skipTest('https://pulp.plan.io/issues/2230')
+        docker_upstream_name = DOCKER_UPSTREAM_NAME.replace('/', ' ')
+        response = api.Client(self.cfg, api.echo_handler).post(
+            urljoin(self.repo_href, 'actions/sync/'),
+            {'override_config': {'upstream_name': docker_upstream_name}},
+        )
+        self.assertEqual(response.status_code, 400)
+
+
+class UpstreamNameV1TestCase(UpstreamNameTestsMixin, utils.BaseAPITestCase):
+    """Sync a v1 docker repository with various ``upstream_name`` options.
+
+    This test targets `Pulp #2230 <https://pulp.plan.io/issues/2230-docker>`_.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Create a docker repository with an importer.
+
+        The importer has no ``upstream_name`` set. it must be passed via
+        ``override_config`` when a sync is requested.
+        """
+        super(UpstreamNameV1TestCase, cls).setUpClass()
+        body = gen_repo()
+        body['importer_config'] = {
+            'enable_v1': True,
+            'feed': DOCKER_V1_FEED_URL,
+        }
+        cls.repo_href = (
+            api.Client(cls.cfg).post(REPOSITORY_PATH, body).json()['_href']
+        )
+        cls.resources.add(cls.repo_href)
+
+
+class UpstreamNameV2TestCase(UpstreamNameTestsMixin, utils.BaseAPITestCase):
+    """Sync a v2 docker repository with various ``upstream_name`` options.
+
+    This test targets `Pulp #2230 <https://pulp.plan.io/issues/2230-docker>`_.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Create a docker repository with an importer.
+
+        The importer has no ``upstream_name`` set. it must be passed via
+        ``override_config`` when a sync is requested.
+        """
+        super(UpstreamNameV2TestCase, cls).setUpClass()
+        body = gen_repo()
+        body['importer_config'] = {'feed': DOCKER_V2_FEED_URL}
+        cls.repo_href = (
+            api.Client(cls.cfg).post(REPOSITORY_PATH, body).json()['_href']
+        )
+        cls.resources.add(cls.repo_href)

--- a/pulp_smash/tests/docker/cli/test_sync_publish.py
+++ b/pulp_smash/tests/docker/cli/test_sync_publish.py
@@ -9,12 +9,15 @@ import unittest2
 from packaging.version import Version
 
 from pulp_smash import api, cli, config, selectors, utils
-from pulp_smash.constants import DOCKER_V1_FEED_URL, DOCKER_V2_FEED_URL
+from pulp_smash.constants import (
+    DOCKER_UPSTREAM_NAME,
+    DOCKER_V1_FEED_URL,
+    DOCKER_V2_FEED_URL,
+)
 from pulp_smash.tests.docker.cli import utils as docker_utils
 from pulp_smash.tests.docker.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 _BYTE_UNICODE = (type(b''), type(u''))
-_UPSTREAM_NAME = 'library/busybox'
 
 
 class _BaseTestCase(unittest2.TestCase):
@@ -57,7 +60,7 @@ class SyncV1TestCase(_SuccessMixin, _BaseTestCase):
             cls.cfg,
             feed=DOCKER_V1_FEED_URL,
             repo_id=cls.repo_id,
-            upstream_name=_UPSTREAM_NAME,
+            upstream_name=DOCKER_UPSTREAM_NAME,
         )
         cls.completed_proc = docker_utils.repo_sync(cls.cfg, cls.repo_id)
 
@@ -110,7 +113,7 @@ class SyncPublishV2TestCase(_SuccessMixin, _BaseTestCase):
             cls.cfg,
             feed=DOCKER_V2_FEED_URL,
             repo_id=cls.repo_id,
-            upstream_name=_UPSTREAM_NAME,
+            upstream_name=DOCKER_UPSTREAM_NAME,
         )
         cls.completed_proc = docker_utils.repo_sync(cls.cfg, cls.repo_id)
         cls.app_file = _get_app_file(cls.cfg, cls.repo_id)
@@ -243,11 +246,12 @@ class SyncUnnamespacedV2TestCase(_SuccessMixin, _BaseTestCase):
         if (cls.cfg.version >= Version('2.9') and
                 selectors.bug_is_untestable(1909, cls.cfg.version)):
             raise unittest2.SkipTest('https://pulp.plan.io/issues/1909')
+        # The split() drops 'library/'.
         docker_utils.repo_create(
             cls.cfg,
             feed=DOCKER_V2_FEED_URL,
             repo_id=cls.repo_id,
-            upstream_name=_UPSTREAM_NAME.split('/')[-1],  # drop 'library/'
+            upstream_name=DOCKER_UPSTREAM_NAME.split('/')[-1],
         )
         cls.completed_proc = docker_utils.repo_sync(cls.cfg, cls.repo_id)
 
@@ -263,7 +267,7 @@ class InvalidFeedTestCase(_BaseTestCase):
             cls.cfg,
             feed='https://docker.example.com',
             repo_id=cls.repo_id,
-            upstream_name=_UPSTREAM_NAME,
+            upstream_name=DOCKER_UPSTREAM_NAME,
         )
         cls.completed_proc = cli.Client(cls.cfg, cli.echo_handler).run(
             'pulp-admin docker repo sync run --repo-id {}'


### PR DESCRIPTION
The first commit performs a simple refactor: it makes a private constant public. This is a useful standalone change, and it's used by the second commit.

The second commit adds tests for [Pulp issue 2230](https://pulp.plan.io/issues/2230).