### PR TITLE
Drop references to nonexistent signed DRPMs

### DIFF
--- a/pulp_smash/constants.py
+++ b/pulp_smash/constants.py
@@ -72,9 +72,6 @@ DOCKER_V2_FEED_URL = 'https://registry-1.docker.io'
 This URL can be used as the "feed" property of a Pulp Docker registry.
 """
 
-DRPM_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'drpm-unsigned/')
-"""The URL to a DRPM repository."""
-
 DRPM_UNSIGNED_FEED_COUNT = 4
 """The number of packages available at :data:`DRPM_UNSIGNED_FEED_URL`."""
 
@@ -82,13 +79,7 @@ DRPM_UNSIGNED_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'drpm-unsigned/')
 """The URL to an unsigned DRPM repository."""
 
 DRPM = 'drpms/test-alpha-1.1-1_1.1-2.noarch.drpm'
-"""The name of a DRPM file, relative to :data:`DRPM_FEED_URL`."""
-
-DRPM_URL = urljoin(DRPM_FEED_URL, DRPM)
-"""The URL to a DRPM file.
-
-Built from :data:`DRPM_FEED_URL` and :data:`DRPM`.
-"""
+"""The name of a DRPM file, relative to :data:`DRPM_UNSIGNED_FEED_URL`."""
 
 DRPM_UNSIGNED_URL = urljoin(DRPM_UNSIGNED_FEED_URL, DRPM)
 """The URL to a unsigned DRPM file.

--- a/pulp_smash/tests/rpm/api_v2/test_signatures_checked_for_uploads.py
+++ b/pulp_smash/tests/rpm/api_v2/test_signatures_checked_for_uploads.py
@@ -55,7 +55,6 @@ from requests.exceptions import HTTPError
 from pulp_smash import api, config, exceptions, selectors, utils
 from pulp_smash.constants import (
     DRPM_UNSIGNED_URL,
-    DRPM_URL,
     PULP_FIXTURES_KEY_ID,
     REPOSITORY_PATH,
     RPM_UNSIGNED_URL,
@@ -86,7 +85,6 @@ def setUpModule():  # pylint:disable=invalid-name
     global _PACKAGES  # pylint:disable=global-statement
     try:
         _PACKAGES = {
-            'signed drpm': utils.http_get(DRPM_URL),
             'signed rpm': utils.http_get(RPM_URL),
             'signed srpm': utils.http_get(SRPM_URL),
             'unsigned drpm': utils.http_get(DRPM_UNSIGNED_URL),

--- a/pulp_smash/tests/rpm/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_sync_publish.py
@@ -19,7 +19,7 @@ from packaging.version import Version
 from pulp_smash import api, selectors, utils
 from pulp_smash.compat import urljoin
 from pulp_smash.constants import (
-    DRPM_FEED_URL,
+    DRPM_UNSIGNED_FEED_URL,
     REPOSITORY_PATH,
     RPM_FEED_COUNT,
     RPM_FEED_URL,
@@ -113,7 +113,7 @@ class SyncDrpmRepoTestCase(SyncRepoBaseTestCase):
     @staticmethod
     def get_feed_url():
         """Return an DRPM repository feed URL."""
-        return DRPM_FEED_URL
+        return DRPM_UNSIGNED_FEED_URL
 
 
 class SyncSrpmRepoTestCase(SyncRepoBaseTestCase):

--- a/pulp_smash/tests/rpm/api_v2/test_upload_publish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_upload_publish.py
@@ -22,7 +22,7 @@ from pulp_smash.constants import (
     CALL_REPORT_KEYS,
     CONTENT_UPLOAD_PATH,
     DRPM,
-    DRPM_URL,
+    DRPM_UNSIGNED_URL,
     REPOSITORY_PATH,
     RPM,
     RPM_FEED_URL,
@@ -177,7 +177,7 @@ class UploadDrpmTestCase(utils.BaseAPITestCase):
         client = api.Client(cls.cfg)
         repo = client.post(REPOSITORY_PATH, gen_repo()).json()
         cls.resources.add(repo['_href'])
-        drpm = utils.http_get(DRPM_URL)
+        drpm = utils.http_get(DRPM_UNSIGNED_URL)
         upload_import_unit(cls.cfg, drpm, 'drpm', repo['_href'])
         cls.repo_units = client.post(
             urljoin(repo['_href'], 'search/units/'),

--- a/pulp_smash/tests/rpm/cli/test_upload.py
+++ b/pulp_smash/tests/rpm/cli/test_upload.py
@@ -7,7 +7,7 @@ import os
 import unittest2
 
 from pulp_smash import cli, config, selectors, utils
-from pulp_smash.constants import DRPM, DRPM_URL
+from pulp_smash.constants import DRPM, DRPM_UNSIGNED_URL
 from pulp_smash.tests.rpm.utils import set_up_module
 
 
@@ -55,7 +55,9 @@ class UploadDrpmTestCase(unittest2.TestCase):
         temp_dir = client.run('mktemp --directory'.split()).stdout.strip()
         self.addCleanup(client.run, 'rm -rf {}'.format(temp_dir).split())
         drpm_file = os.path.join(temp_dir, os.path.split(DRPM)[-1])
-        client.run('curl -o {} {}'.format(drpm_file, DRPM_URL).split())
+        client.run(
+            'curl -o {} {}'.format(drpm_file, DRPM_UNSIGNED_URL).split()
+        )
 
         # Upload the DRPM into the repository. Don't use subTest, as if this
         # test fails, the following one is invalid anyway.


### PR DESCRIPTION
Pulp Fixtures currently has:

* signed RPMs
* signed SRPMs
* unsigned DRPMs
* unsigned RPMs
* unsigned SRPMs

Pulp Fixtures does *not* have signed DRPMs. [1] Drop the `DRPM_FEED_URL`
and `DRPM_URL` constants, and update affected tests by either:

* referencing `DRPM_UNSIGNED_FEED_URL` and `DRPM_UNSIGNED_URL`, or
* dropping the test.

When signed DRPMs are made available through Pulp Fixtures, this topic
should be revisited.

[1] https://github.com/PulpQE/pulp-fixtures/issues/25