### PR TITLE
Drop RPM_SHA256_CHECKSUM constant

### DIFF
--- a/pulp_smash/constants.py
+++ b/pulp_smash/constants.py
@@ -289,11 +289,6 @@ RPM_FEED_COUNT = 32
 RPM_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'rpm/')
 """The URL to an RPM repository. See :data:`RPM_URL`."""
 
-RPM_SHA256_CHECKSUM = (
-    '4fe8d0e21ee6d56d420c396a02aeaeb59feb00b625811b6a2b4d8f0c1aad80ca'
-)
-"""The sha256 checksum of :data:`pulp_smash.constants.RPM`."""
-
 RPM_UNSIGNED_FEED_COUNT = 32
 """The number of packages available at :data:`RPM_UNSIGNED_FEED_URL`."""
 

--- a/pulp_smash/tests/rpm/api_v2/test_download_policies.py
+++ b/pulp_smash/tests/rpm/api_v2/test_download_policies.py
@@ -17,7 +17,7 @@ from pulp_smash.constants import (
     RPM,
     RPM_ABS_PATH,
     RPM_FEED_URL,
-    RPM_SHA256_CHECKSUM,
+    RPM_URL,
 )
 from pulp_smash.tests.rpm.api_v2.utils import gen_distributor, gen_repo
 from pulp_smash.tests.rpm.utils import set_up_module
@@ -120,8 +120,9 @@ class BackgroundTestCase(utils.BaseAPITestCase):
 
     def test_rpm_checksum(self):
         """Assert the checksum of the downloaded RPM matches the metadata."""
-        checksum = hashlib.sha256(self.rpm.content).hexdigest()
-        self.assertEqual(RPM_SHA256_CHECKSUM, checksum)
+        actual = hashlib.sha256(self.rpm.content).hexdigest()
+        expect = utils.get_sha256_checksum(RPM_URL)
+        self.assertEqual(actual, expect)
 
     def test_spawned_download_task(self):
         """Assert that a download task was spawned as a result of the sync."""
@@ -193,8 +194,9 @@ class OnDemandTestCase(utils.BaseAPITestCase):
 
     def test_rpm_checksum(self):
         """Assert the checksum of the downloaded RPM matches the metadata."""
-        checksum = hashlib.sha256(self.rpm.content).hexdigest()
-        self.assertEqual(RPM_SHA256_CHECKSUM, checksum)
+        actual = hashlib.sha256(self.rpm.content).hexdigest()
+        expect = utils.get_sha256_checksum(RPM_URL)
+        self.assertEqual(actual, expect)
 
     def test_rpm_cache_lookup_header(self):
         """Assert the first request resulted in a cache miss from Squid."""
@@ -209,8 +211,9 @@ class OnDemandTestCase(utils.BaseAPITestCase):
 
     def test_same_rpm_checksum(self):
         """Assert the checksum of the second RPM matches the metadata."""
-        checksum = hashlib.sha256(self.same_rpm.content).hexdigest()
-        self.assertEqual(RPM_SHA256_CHECKSUM, checksum)
+        actual = hashlib.sha256(self.same_rpm.content).hexdigest()
+        expect = utils.get_sha256_checksum(RPM_URL)
+        self.assertEqual(actual, expect)
 
     def test_same_rpm_cache_header(self):
         """Assert the second request resulted in a cache hit from Squid."""

--- a/pulp_smash/tests/rpm/api_v2/test_export.py
+++ b/pulp_smash/tests/rpm/api_v2/test_export.py
@@ -25,7 +25,7 @@ from pulp_smash.constants import (
     REPOSITORY_PATH,
     RPM,
     RPM_FEED_URL,
-    RPM_SHA256_CHECKSUM,
+    RPM_URL,
 )
 from pulp_smash.tests.rpm.api_v2.utils import (
     DisableSELinuxMixin,
@@ -455,8 +455,8 @@ class ExportDistributorTestCase(ExportDirMixin, utils.BaseAPITestCase):
     def test_publish_to_dir(self):
         """Publish the repository to a directory on the Pulp server.
 
-        Verify that :data:`pulp_smash.constants.RPM` is present and has a
-        checksum of :data:`pulp_smash.constants.RPM_SHA256_CHECKSUM`.
+        gerify that :data:`pulp_smash.constants.RPM` is present and has a
+        correct checksum.
 
         This test is skipped if selinux is installed and enabled on the target
         system an `Pulp issue 616 <https://pulp.plan.io/issues/616>`_ is open.
@@ -465,9 +465,10 @@ class ExportDistributorTestCase(ExportDirMixin, utils.BaseAPITestCase):
             self.repo['_href'],
             self.distributor['id'],
         )
-        checksum = cli.Client(self.cfg).run(('sha256sum', os.path.join(
+        actual = cli.Client(self.cfg).run(('sha256sum', os.path.join(
             export_dir,
             self.distributor['config']['relative_url'],
             RPM,
         ))).stdout.strip().split()[0]
-        self.assertEqual(checksum, RPM_SHA256_CHECKSUM)
+        expect = utils.get_sha256_checksum(RPM_URL)
+        self.assertEqual(actual, expect)


### PR DESCRIPTION
As a replacement, add a get_sha256_checksum() function. The advantage of
calculating a checksum at runtime is that some details of the fixtures
used by the tests can change between test runs. For example, an RPM
fixture might gain or lose a PGP signature.

See: https://github.com/PulpQE/pulp-fixtures/pull/28