### PR TITLE
Add signed DRPMs to test suite

### DIFF
--- a/pulp_smash/constants.py
+++ b/pulp_smash/constants.py
@@ -70,14 +70,30 @@ DOCKER_V2_FEED_URL = 'https://registry-1.docker.io'
 This URL can be used as the "feed" property of a Pulp Docker registry.
 """
 
+DRPM = 'drpms/test-alpha-1.1-1_1.1-2.noarch.drpm'
+"""The path to a DRPM file in one of the DRPM repositories.
+
+This path may be joined with :data:`DRPM_FEED_URL` or
+:data:`DRPM_UNSIGNED_FEED_URL`.
+"""
+
+DRPM_FEED_COUNT = 4
+"""The number of packages available at :data:`DRPM_FEED_URL`."""
+
+DRPM_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'drpm/')
+"""The URL to a DRPM repository."""
+
+DRPM_URL = urljoin(DRPM_FEED_URL, DRPM)
+"""The URL to a DRPM file.
+
+Built from :data:`DRPM_FEED_URL` and :data:`DRPM`.
+"""
+
 DRPM_UNSIGNED_FEED_COUNT = 4
 """The number of packages available at :data:`DRPM_UNSIGNED_FEED_URL`."""
 
 DRPM_UNSIGNED_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'drpm-unsigned/')
 """The URL to an unsigned DRPM repository."""
-
-DRPM = 'drpms/test-alpha-1.1-1_1.1-2.noarch.drpm'
-"""The name of a DRPM file, relative to :data:`DRPM_UNSIGNED_FEED_URL`."""
 
 DRPM_UNSIGNED_URL = urljoin(DRPM_UNSIGNED_FEED_URL, DRPM)
 """The URL to a unsigned DRPM file.

--- a/pulp_smash/tests/rpm/api_v2/test_signatures_checked_for_copies.py
+++ b/pulp_smash/tests/rpm/api_v2/test_signatures_checked_for_copies.py
@@ -28,6 +28,7 @@ from urllib.parse import urljoin
 from pulp_smash import api, config, selectors, utils
 from pulp_smash.constants import (
     DRPM_UNSIGNED_URL,
+    DRPM_URL,
     ORPHANS_PATH,
     PULP_FIXTURES_KEY_ID,
     REPOSITORY_PATH,
@@ -58,6 +59,7 @@ def setUpModule():  # pylint:disable=invalid-name
     _UNSIGNED_PACKAGES['rpm'] = utils.http_get(RPM_UNSIGNED_URL)
     _UNSIGNED_PACKAGES['srpm'] = utils.http_get(SRPM_UNSIGNED_URL)
     if selectors.bug_is_testable(1806, cfg.version):
+        _SIGNED_PACKAGES['drpm'] = utils.http_get(DRPM_URL)
         _UNSIGNED_PACKAGES['drpm'] = utils.http_get(DRPM_UNSIGNED_URL)
 
     # Create repos, and upload RPMs to them.

--- a/pulp_smash/tests/rpm/api_v2/test_signatures_checked_for_syncs.py
+++ b/pulp_smash/tests/rpm/api_v2/test_signatures_checked_for_syncs.py
@@ -23,6 +23,8 @@ import unittest
 
 from pulp_smash import api, config, selectors, utils
 from pulp_smash.constants import (
+    DRPM_FEED_COUNT,
+    DRPM_FEED_URL,
     DRPM_UNSIGNED_FEED_COUNT,
     DRPM_UNSIGNED_FEED_URL,
     ORPHANS_PATH,
@@ -107,6 +109,18 @@ class RequireValidKeyTestCase(_BaseTestCase):
         })['content_unit_counts']
         self.assertEqual(cu_counts['rpm'], RPM_FEED_COUNT, cu_counts)
 
+    def test_signed_drpm(self):
+        """Sync signed DRPMs into the repository.
+
+        Assert packages are synced in.
+        """
+        cu_counts = self.create_sync_repo({
+            'allowed_keys': [PULP_FIXTURES_KEY_ID],
+            'feed': DRPM_FEED_URL,
+            'require_signature': True,
+        })['content_unit_counts']
+        self.assertEqual(cu_counts['drpm'], DRPM_FEED_COUNT, cu_counts)
+
     def test_signed_srpm(self):
         """Sync signed SRPMs into the repository.
 
@@ -152,13 +166,11 @@ class RequireInvalidKeyTestCase(_BaseTestCase):
     def test_packages(self):
         """Sync signed and unsigned RPMs, DRPMs and SRPMs into repositories.
 
-        No signed DRPMs are synced in due to `Pulp Fixtures #25
-        <https://github.com/PulpQE/pulp-fixtures/issues/25>`_.
-
         Assert no packages are synced in.
         """
         variants = (
             (RPM_FEED_URL, 'rpm'),
+            (DRPM_FEED_URL, 'drpm'),
             (SRPM_FEED_URL, 'srpm'),
             (RPM_UNSIGNED_FEED_URL, 'rpm'),
             (DRPM_UNSIGNED_FEED_URL, 'drpm'),
@@ -195,6 +207,18 @@ class RequireAnyKeyTestCase(_BaseTestCase):
             'require_signature': True,
         })['content_unit_counts']
         self.assertEqual(cu_counts['rpm'], RPM_FEED_COUNT, cu_counts)
+
+    def test_signed_drpm(self):
+        """Sync signed DRPMs into the repository.
+
+        Assert packages are synced in.
+        """
+        cu_counts = self.create_sync_repo({
+            'allowed_keys': [],
+            'feed': DRPM_FEED_URL,
+            'require_signature': True,
+        })['content_unit_counts']
+        self.assertEqual(cu_counts['drpm'], DRPM_FEED_COUNT, cu_counts)
 
     def test_signed_srpm(self):
         """Sync signed SRPMs into the repository.
@@ -239,15 +263,13 @@ class AllowInvalidKeyTestCase(_BaseTestCase):
     """
 
     def test_signed_packages(self):
-        """Import signed RPMs and SRPMs into repositories.
-
-        No signed DRPMs are synced in due to `Pulp Fixtures #25
-        <https://github.com/PulpQE/pulp-fixtures/issues/25>`_.
+        """Import signed RPMs, DRPMs and SRPMs into repositories.
 
         Assert no packages are synced.
         """
         variants = (
             (RPM_FEED_URL, 'rpm'),
+            (DRPM_FEED_URL, 'drpm'),
             (SRPM_FEED_URL, 'srpm'),
         )
         for feed, type_id in variants:
@@ -329,6 +351,18 @@ class AllowValidKeyTestCase(_BaseTestCase):
         })['content_unit_counts']
         self.assertEqual(cu_counts['rpm'], RPM_FEED_COUNT, cu_counts)
 
+    def test_signed_drpm(self):
+        """Sync signed DRPMs into the repository.
+
+        Assert packages are synced in.
+        """
+        cu_counts = self.create_sync_repo({
+            'allowed_keys': [PULP_FIXTURES_KEY_ID],
+            'feed': DRPM_FEED_URL,
+            'require_signature': False,
+        })['content_unit_counts']
+        self.assertEqual(cu_counts['drpm'], DRPM_FEED_COUNT, cu_counts)
+
     def test_signed_srpm(self):
         """Sync signed SRPMs into the repository.
 
@@ -407,6 +441,18 @@ class AllowAnyKeyTestCase(_BaseTestCase):
             'require_signature': False,
         })['content_unit_counts']
         self.assertEqual(cu_counts['rpm'], RPM_FEED_COUNT, cu_counts)
+
+    def test_signed_drpm(self):
+        """Sync signed DRPMs into the repository.
+
+        Assert packages are synced in.
+        """
+        cu_counts = self.create_sync_repo({
+            'allowed_keys': [],
+            'feed': DRPM_FEED_URL,
+            'require_signature': False,
+        })['content_unit_counts']
+        self.assertEqual(cu_counts['drpm'], DRPM_FEED_COUNT, cu_counts)
 
     def test_signed_srpm(self):
         """Sync signed SRPMs into the repository.

--- a/pulp_smash/tests/rpm/api_v2/test_signatures_checked_for_uploads.py
+++ b/pulp_smash/tests/rpm/api_v2/test_signatures_checked_for_uploads.py
@@ -55,6 +55,7 @@ from requests.exceptions import HTTPError
 from pulp_smash import api, config, exceptions, selectors, utils
 from pulp_smash.constants import (
     DRPM_UNSIGNED_URL,
+    DRPM_URL,
     PULP_FIXTURES_KEY_ID,
     REPOSITORY_PATH,
     RPM_UNSIGNED_URL,
@@ -90,6 +91,7 @@ def setUpModule():  # pylint:disable=invalid-name
         _UNSIGNED_PACKAGES['rpm'] = utils.http_get(RPM_UNSIGNED_URL)
         _UNSIGNED_PACKAGES['srpm'] = utils.http_get(SRPM_UNSIGNED_URL)
         if selectors.bug_is_testable(1806, cfg.version):
+            _SIGNED_PACKAGES['drpm'] = utils.http_get(DRPM_URL)
             _UNSIGNED_PACKAGES['drpm'] = utils.http_get(DRPM_UNSIGNED_URL)
     except:
         _SIGNED_PACKAGES.clear()

--- a/pulp_smash/tests/rpm/api_v2/test_signatures_saved_for_packages.py
+++ b/pulp_smash/tests/rpm/api_v2/test_signatures_saved_for_packages.py
@@ -21,8 +21,10 @@ from urllib.parse import urljoin, urlparse
 
 from pulp_smash import api, config, selectors, utils
 from pulp_smash.constants import (
+    DRPM_FEED_URL,
     DRPM_UNSIGNED_FEED_URL,
     DRPM_UNSIGNED_URL,
+    DRPM_URL,
     ORPHANS_PATH,
     PULP_FIXTURES_KEY_ID,
     REPOSITORY_PATH,
@@ -122,6 +124,14 @@ class UploadPackageTestCase(_BaseTestCase):
 
         return repo_href
 
+    def test_signed_drpm(self):
+        """Import a signed DRPM into Pulp. Verify its signature."""
+        if selectors.bug_is_untestable(1806, self.cfg.version):
+            self.skipTest('https://pulp.plan.io/issues/1806')
+        repo_href = self._create_repo_import_unit(DRPM_URL)
+        unit = self._find_unit(repo_href, DRPM_URL)
+        self._verify_pkg_key(unit, PULP_FIXTURES_KEY_ID)
+
     def test_signed_rpm(self):
         """Import a signed RPM into Pulp. Verify its signature."""
         repo_href = self._create_repo_import_unit(RPM_URL)
@@ -170,6 +180,12 @@ class SyncPackageTestCase(_BaseTestCase):
         self.addCleanup(self.client.delete, repo_href)
         utils.sync_repo(self.cfg, repo_href)
         return repo_href
+
+    def test_signed_drpm(self):
+        """Assert signature is stored for signed drpm during sync."""
+        repo_href = self._create_sync_repo(DRPM_FEED_URL)
+        unit = self._find_unit(repo_href, DRPM_URL)
+        self._verify_pkg_key(unit, PULP_FIXTURES_KEY_ID)
 
     def test_signed_rpm(self):
         """Assert signature is stored for signed rpm during sync."""


### PR DESCRIPTION
Signed DRPMs are now provided by Pulp Fixtures. Update tests to make use
of signed DRPMs where appropriate.

Fix: https://github.com/PulpQE/pulp-fixtures/issues/25