### PR TITLE
Drop constant RPM_ABS_PATH

### DIFF
--- a/pulp_smash/constants.py
+++ b/pulp_smash/constants.py
@@ -287,12 +287,6 @@ The erratum ID is defined by :data:`pulp_smash.constants.RPM_ERRATUM_ID`.
 RPM = 'bear-4.1-1.noarch.rpm'
 """The name of an RPM file. See :data:`pulp_smash.constants.RPM_URL`."""
 
-RPM_ABS_PATH = (
-    '/var/lib/pulp/content/units/rpm/'
-    '62/7c493152b5de3cfccb681fb98b0f56089425db3030328767c0cc031b2235b3/' + RPM
-)
-"""The absolute path to :data:`pulp_smash.constants.RPM` in the filesystem."""
-
 RPM_ERRATUM_URL = (
     'https://repos.fedorapeople.org'
     '/repos/pulp/pulp/fixtures/rpm-erratum/erratum.json'


### PR DESCRIPTION
The `RPM_ABS_PATH` constant defines the absolute path to the `RPM`
content unit on the Pulp filesystem.

For this constant to hold true, the `RPM` content unit must not change.
However, it has changed at least twice during the history of Pulp
Fixtures, as signatures have been added and removed. Also, its signature
might change in the future if the public/private keypair in Pulp
Fixtures changes for some reason, and the exact path to the content unit
is supposed to be an implementation detail.

Rewrite the one test case that uses this constant to use the `find` CLI
executable instead.