### PR TITLE
Strengthen tests in FixFileCorruptionTestCase

### DIFF
--- a/pulp_smash/tests/rpm/api_v2/test_download_policies.py
+++ b/pulp_smash/tests/rpm/api_v2/test_download_policies.py
@@ -302,17 +302,35 @@ class FixFileCorruptionTestCase(utils.BaseAPITestCase):
         )
 
     def test_corruption_occurred(self):
-        """Assert the checksum after corrupting an RPM isn't the same.
+        """Assert corrupting a unit changes its checksum.
 
         This is to ensure we actually corrupted the RPM and validates further
         testing.
         """
         self.assertNotEqual(self.sha_pre_corruption, self.sha_post_corruption)
 
-    def test_unverified_file_unchanged(self):
-        """Assert a download without verify_all_units doesn't verify files."""
+    def test_verify_all_units_false(self):
+        """Verify Pulp's behaviour when ``verify_all_units`` is false.
+
+        Assert that the checksum of the corrupted unit is unchanged, indicating
+        that Pulp did not verify (or re-download) the checksum of the corrupted
+        unit.
+        """
         self.assertEqual(self.sha_post_corruption, self.unverified_file_sha)
 
-    def test_verified_file_changed(self):
-        """Assert a download task with verify_all_units fixes corruption."""
+    def test_verify_all_units_true(self):
+        """Verify Pulp's behaviour when ``verify_all_units`` is true.
+
+        Assert that the checksum of the corrupted unit is changed, indicating
+        that Pulp did verify the checksum of the corrupted unit, and
+        subsequently re-downloaded the unit.
+        """
+        self.assertNotEqual(self.unverified_file_sha, self.verified_file_sha)
+
+    def test_start_end_checksums(self):
+        """Verify Pulp's behaviour when ``verify_all_units`` is true.
+
+        Assert that the pre-corruption checksum of the unit is the same as the
+        post-redownload checksum of the unit.
+        """
         self.assertEqual(self.sha_pre_corruption, self.verified_file_sha)


### PR DESCRIPTION
Among other things, `FixFileCorruptionTestCase` does the following:

1. Corrupt a content unit on disk.
2. Tell Pulp to download a repository with ``verify_all_units`` set to
   false.
3. Tell Pulp to download a repository with ``verify_all_units`` set to
   true.

One can make at least the following assertions about this:

1. The content unit's checksum changed as a result of step 1.
2. The content unit's checksum stayed the same as a result of step 2.
3. The content unit's checksum changed as a result of step 3.
4. The content unit's checksum is the same before step 1 and after step
   3.

Add the third assertion. Revamp the test names and docstrings for the
other three steps.