### PR TITLE
Skip tests affected by Pulp issue 2272

### DIFF
--- a/pulp_smash/tests/rpm/api_v2/test_download_policies.py
+++ b/pulp_smash/tests/rpm/api_v2/test_download_policies.py
@@ -34,6 +34,8 @@ def setUpModule():  # pylint:disable=invalid-name
     cfg = config.get_config()
     if cfg.version < Version('2.8'):
         raise unittest.SkipTest('This module requires Pulp 2.8 or greater.')
+    if selectors.bug_is_untestable(2272, cfg.version):
+        raise unittest.SkipTest('https://pulp.plan.io/issues/2272')
     if selectors.bug_is_untestable(2144, cfg.version):
         raise unittest.SkipTest('https://pulp.plan.io/issues/2144')
 
@@ -69,8 +71,6 @@ class BackgroundTestCase(utils.BaseAPITestCase):
         4. Download an RPM from the repository.
         """
         super(BackgroundTestCase, cls).setUpClass()
-        if selectors.bug_is_untestable(2272, cls.cfg.version):
-            raise unittest.SkipTest('https://pulp.plan.io/issues/2272')
         if (selectors.bug_is_untestable(1905, cls.cfg.version) and
                 _os_is_rhel6(cls.cfg)):
             raise unittest.SkipTest('https://pulp.plan.io/issues/1905')
@@ -234,8 +234,6 @@ class FixFileCorruptionTestCase(utils.BaseAPITestCase):
         7. Trigger a repository download, with unit verification.
         """
         super(FixFileCorruptionTestCase, cls).setUpClass()
-        if selectors.bug_is_untestable(2272, cls.cfg.version):
-            raise unittest.SkipTest('https://pulp.plan.io/issues/2272')
         if (selectors.bug_is_untestable(1905, cls.cfg.version) and
                 _os_is_rhel6(cls.cfg)):
             raise unittest.SkipTest('https://pulp.plan.io/issues/1905')


### PR DESCRIPTION
All of the test cases in module
`pulp_smash.tests.rpm.api_v2.test_download_policies` are affected by
Pulp issue 2272. Skip them.

See: https://pulp.plan.io/issues/2272