### PR TITLE
Pin dependency on pydocstyle==1.0.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@
 flake8
 flake8-docstrings
 flake8-quotes
+pydocstyle==1.0.0  # https://github.com/PyCQA/pydocstyle/issues/207
 pylint
 astroid
 


### PR DESCRIPTION
pydocstyle 1.1.0 is not compatible with flake8.

See: https://github.com/PyCQA/pydocstyle/issues/207