### PR TITLE
Refactor RPM copy test cases

### DIFF
--- a/pulp_smash/tests/rpm/cli/test_copy_units.py
+++ b/pulp_smash/tests/rpm/cli/test_copy_units.py
@@ -1,12 +1,12 @@
 # coding=utf-8
 """Tests that copy units from one repository to another."""
-import inspect
 import os
-import random
 import subprocess
 import unittest
 from io import StringIO
 from urllib.parse import urljoin
+
+from packaging.version import Version
 
 from pulp_smash import cli, config, constants, selectors, utils
 from pulp_smash.tests.rpm.cli.utils import count_langpacks
@@ -15,65 +15,6 @@ from pulp_smash.utils import is_root
 
 _REPO_ID = utils.uuid4()
 """The ID of the repository created by ``setUpModule``."""
-
-
-def generate_repo_file(server_config, name, **kwargs):
-    """Generate a repository file and returns its remote path.
-
-    :param server_config: A :class:`pulp_smash.config.ServerConfig` object.
-    :param name: file name and repo id (string inside []).
-    :param kwargs: each item will be converted to repository properties where
-        the key is the property name and the value its value.
-    :returns: the remote path of the created repository file.
-    """
-    repo = StringIO()
-    repo.write('[{}]\n'.format(name))
-    path = os.path.join(
-        '{}'.format('/etc/yum.repos.d/'), '{}.repo'.format(name))
-    if 'name' not in kwargs:
-        repo.write('{}: {}\n'.format('name', name))
-    for key, value in kwargs.items():
-        repo.write('{}: {}\n'.format(key, value))
-    client = cli.Client(server_config)
-    sudo = '' if is_root(server_config) else 'sudo '
-    client.machine.session().run(
-        'echo "{}" | {}tee {} > /dev/null'.format(
-            repo.getvalue(),
-            sudo,
-            path
-        )
-    )
-    repo.close()
-    return path
-
-
-def _get_rpm_names_versions(server_config, repo_id):
-    """Get a dict of repo's RPMs with names as keys, mapping to version lists.
-
-    :param pulp_smash.config.ServerConfig server_config: Information about the
-        Pulp server being targeted.
-    :param repo_id: A RPM repository ID.
-    :returns: The names of all modules in a repository, with a list of all
-        versions mapped to each module, as an ``dict``.
-    """
-    keyword = 'Filename:'
-    completed_proc = cli.Client(server_config).run(
-        'pulp-admin rpm repo content rpm --repo-id {}'.format(repo_id).split()
-    )
-    filenames = [
-        line.lstrip(keyword).strip()
-        for line in completed_proc.stdout.splitlines()
-        if keyword in line
-    ]
-    assert len(filenames) > 0
-    rpms = {}
-    for filename in filenames:
-        # Example of a filename string: 'walrus-0.71-1.noarch.rpm'.
-        filename_parts = filename.split('-')[:-1]
-        name = '-'.join(filename_parts[:-1])
-        version = filename_parts[-1]
-        rpms.setdefault(name, []).append(version)
-    return rpms
 
 
 def setUpModule():  # pylint:disable=invalid-name
@@ -116,60 +57,112 @@ def tearDownModule():  # pylint:disable=invalid-name
     )
 
 
-class CopyBaseTestCase(unittest.TestCase):
-    """An abstract base class for test cases that copy units between repos."""
+class UtilsMixin(object):  # pylint:disable=too-few-public-methods
+    """A mixin providing useful tools to unittest subclasses.
 
-    @classmethod
-    def setUpClass(cls):
-        """Create a repository."""
-        if inspect.getmro(cls)[0] == CopyBaseTestCase:
-            raise unittest.SkipTest('Abstract base class.')
-        cls.cfg = config.get_config()
-        cls.repo_id = utils.uuid4()
-        cli.Client(cls.cfg).run(
-            'pulp-admin rpm repo create --repo-id {}'
-            .format(cls.repo_id).split()
+    Any class inheriting from this mixin must also inherit from
+    ``unittest.TestCase`` or a compatible clone.
+    """
+
+    def create_repo(self, cfg):
+        """Create a repository and schedule it for deletion.
+
+        :param pulp_smash.config.ServerConfig cfg: The Pulp system on which to
+            create a repository.
+        :return: The repository's ID.
+        """
+        repo_id = utils.uuid4()
+        client = cli.Client(cfg)
+        client.run(
+            'pulp-admin rpm repo create --repo-id {}'.format(repo_id).split()
         )
-
-    @classmethod
-    def tearDownClass(cls):
-        """Delete the repository created by :meth:`setUpClass`."""
-        cli.Client(cls.cfg).run(
-            'pulp-admin rpm repo delete --repo-id {}'
-            .format(cls.repo_id).split()
+        self.addCleanup(
+            client.run,
+            'pulp-admin rpm repo delete --repo-id {}'.format(repo_id).split()
         )
+        return repo_id
 
 
-class CopyTestCase(CopyBaseTestCase):
+def gen_yum_config_file(cfg, repositoryid, **kwargs):
+    """Generate a yum configuration file and write it to ``/etc/yum.repos.d/``.
+
+    Generate a yum configuration file containing a single repository section,
+    and write it to ``/etc/yum.repos.d/{repositoryid}.repo``.
+
+    :param pulp_smash.config.ServerConfig cfg: The system on which to create a
+        yum configuration file.
+    :param repositoryid: The section's ``repositoryid``. Used when naming the
+        configuration file and populating the brackets at the head of the file.
+        For details, see yum.conf(5).
+    :param kwargs: Section options. Each kwarg corresponds to one option. For
+        details, see yum.conf(5).
+    :returns: The path to the yum configuration file.
+    """
+    path = os.path.join('/etc/yum.repos.d/', repositoryid + '.repo')
+    with StringIO() as section:
+        section.write('[{}]\n'.format(repositoryid))
+        for key, value in kwargs.items():
+            section.write('{}: {}\n'.format(key, value))
+        cli.Client(cfg).machine.session().run(
+            'echo "{}" | {}tee {} > /dev/null'
+            .format(section.getvalue(), '' if is_root(cfg) else 'sudo ', path)
+        )
+    return path
+
+
+def _get_rpm_names_versions(server_config, repo_id):
+    """Get a dict of repo's RPMs with names as keys, mapping to version lists.
+
+    :param pulp_smash.config.ServerConfig server_config: Information about the
+        Pulp server being targeted.
+    :param repo_id: A RPM repository ID.
+    :returns: The name and versions of each package in the repository. For
+        example: ``{'walrus': ['5.21', '0.71']}``.
+    """
+    keyword = 'Filename:'
+    completed_proc = cli.Client(server_config).run(
+        'pulp-admin rpm repo content rpm --repo-id {}'.format(repo_id).split()
+    )
+    filenames = [
+        line.lstrip(keyword).strip()
+        for line in completed_proc.stdout.splitlines()
+        if keyword in line
+    ]
+    assert len(filenames) > 0
+    rpms = {}
+    for filename in filenames:
+        # Example of a filename string: 'walrus-0.71-1.noarch.rpm'.
+        filename_parts = filename.split('-')[:-1]
+        name = '-'.join(filename_parts[:-1])
+        version = filename_parts[-1]
+        rpms.setdefault(name, []).append(version)
+    return rpms
+
+
+class CopyTestCase(UtilsMixin, unittest.TestCase):
     """Copy a "chimpanzee" unit from one repository to another.
 
     This test case verifies that it is possible to use the ``pulp-admin rpm
     repo copy`` command to copy a single unit from one repository to another.
     """
 
-    @classmethod
-    def setUpClass(cls):
-        """Copy a unit into a repository and list the units in it."""
-        super(CopyTestCase, cls).setUpClass()
-        cli.Client(cls.cfg).run(
+    def test_all(self):
+        """Copy a "chimpanzee" unit from one repository to another.
+
+        Verify that only the "chimpanzee" unit is in the target repository.
+        """
+        cfg = config.get_config()
+        repo_id = self.create_repo(cfg)
+        cli.Client(cfg).run(
             'pulp-admin rpm repo copy rpm --from-repo-id {} --to-repo-id {} '
-            '--str-eq name=chimpanzee'.format(_REPO_ID, cls.repo_id).split()
+            '--str-eq name=chimpanzee'.format(_REPO_ID, repo_id).split()
         )
-
-    def test_units_copied(self):
-        """Assert only the "chimpanzee" unit is in the target repository."""
-        response = cli.Client(self.cfg).run(
-            'pulp-admin rpm repo content rpm --repo-id {}'
-            .format(self.repo_id).split()
-        )
-        names = tuple((
-            line.split()[1] for line in response.stdout.split('\n')
-            if line.startswith('Name:')
-        ))
-        self.assertEqual(names, ('chimpanzee',))
+        rpms = _get_rpm_names_versions(cfg, repo_id)
+        self.assertEqual(list(rpms.keys()), ['chimpanzee'])
+        self.assertEqual(len(rpms['chimpanzee']), 1, rpms)
 
 
-class CopyRecursiveTestCase(CopyBaseTestCase):
+class CopyRecursiveTestCase(UtilsMixin, unittest.TestCase):
     """Recursively copy a "chimpanzee" unit from one repository to another.
 
     This test case verifies that it is possible to use the ``pulp-admin rpm
@@ -179,36 +172,34 @@ class CopyRecursiveTestCase(CopyBaseTestCase):
     .. _Pulp Smash #107: https://github.com/PulpQE/pulp-smash/issues/107
     """
 
-    @classmethod
-    def setUpClass(cls):
-        """Recursively copy a unit into a repo and list the units in it."""
-        super(CopyRecursiveTestCase, cls).setUpClass()
-        if selectors.bug_is_untestable(1895, cls.cfg.version):
-            raise unittest.SkipTest('https://pulp.plan.io/issues/1895')
-        cli.Client(cls.cfg).run(
+    def test_all(self):
+        """Recursively copy a "chimpanzee" unit from one repository to another.
+
+        "chimpanzee" depends on "walrus," and there are multiple versions of
+        "walrus" in the source repository. Verify that one "walrus" unit has
+        been copied to the target repository, and that the newer one has been
+        copied.
+        """
+        cfg = config.get_config()
+        repo_id = self.create_repo(cfg)
+        cli.Client(cfg).run(
             'pulp-admin rpm repo copy rpm --from-repo-id {} --to-repo-id {} '
             '--str-eq name=chimpanzee --recursive'
-            .format(_REPO_ID, cls.repo_id).split()
+            .format(_REPO_ID, repo_id).split()
         )
 
-    def test_units_copied(self):
-        """Assert only one "walrus" unit has been copied to the target repo.
+        # Verify only one "walrus" unit has been copied
+        dst_rpms = _get_rpm_names_versions(cfg, repo_id)
+        self.assertIn('walrus', dst_rpms)
+        self.assertEqual(len(dst_rpms['walrus']), 1, dst_rpms)
 
-        There are two "walrus" units in the source repository, Only the newest
-        version should be copied over.
-        """
-        response = cli.Client(self.cfg).run(
-            'pulp-admin rpm repo content rpm --repo-id {}'
-            .format(self.repo_id).split()
-        )
-        names = tuple((
-            line.split()[1] for line in response.stdout.split('\n')
-            if line.startswith('Name:')
-        ))
-        self.assertEqual(names.count('walrus'), 1, names)
+        # Verify the version of the "walrus" unit
+        src_rpms = _get_rpm_names_versions(cfg, _REPO_ID)
+        src_rpms['walrus'].sort(key=lambda ver: Version(ver))  # noqa pylint:disable=unnecessary-lambda
+        self.assertEqual(src_rpms['walrus'][-1], dst_rpms['walrus'][0])
 
 
-class CopyLangpacksTestCase(CopyBaseTestCase):
+class CopyLangpacksTestCase(UtilsMixin, unittest.TestCase):
     """Copy langpacks from one repository to another.
 
     This test case verifies that it is possible to use the ``pulp-admin rpm
@@ -218,7 +209,7 @@ class CopyLangpacksTestCase(CopyBaseTestCase):
     .. _Pulp Smash #255: https://github.com/PulpQE/pulp-smash/issues/255
     """
 
-    def test_copy_langpacks(self):
+    def test_all(self):
         """Copy langpacks from one repository to another.
 
         Assert that:
@@ -226,133 +217,108 @@ class CopyLangpacksTestCase(CopyBaseTestCase):
         * ``pulp-admin`` does not produce any errors.
         * A non-zero number of langpacks are present in the target repository.
         """
-        if selectors.bug_is_untestable(1367, self.cfg.version):
+        cfg = config.get_config()
+        if selectors.bug_is_untestable(1367, cfg.version):
             self.skipTest('https://pulp.plan.io/issues/1367')
-        completed_proc = cli.Client(self.cfg).run(
-            'pulp-admin rpm repo copy langpacks '
-            '--from-repo-id {} --to-repo-id {}'
-            .format(_REPO_ID, self.repo_id).split()
+        repo_id = self.create_repo(cfg)
+        completed_proc = cli.Client(cfg).run(
+            'pulp-admin rpm repo copy langpacks --from-repo-id {} '
+            '--to-repo-id {}'.format(_REPO_ID, repo_id).split()
         )
         with self.subTest(comment='verify copy command stdout'):
             self.assertNotIn('Task Failed', completed_proc.stdout)
         with self.subTest(comment='verify langpack count in repo'):
-            self.assertGreater(
-                count_langpacks(self.cfg, self.repo_id),
-                0,
-            )
+            self.assertGreater(count_langpacks(cfg, repo_id), 0)
 
 
-class CopyAndPublishTwoVersionsRepoTestCase(CopyBaseTestCase):
-    """Test whether a repo can copy two versions of RPMs and publish itself.
+class UpdateRpmTestCase(UtilsMixin, unittest.TestCase):
+    """Update an RPM in a repository and on a host.
 
-    This test case targets `Pulp Smash #311`_. The test steps are as following:
+    Do the following:
 
-    1. Create a repo1 and sync from upstream.
-    2. Find a RPM that has two different versions in this repo.
-    3. Create a new repo2 and copy the older of the RPM version into it.
-    4. Publish the repo2 as a host.
-    5. Copy a newer version into the repo2 and re-publish.
-    6. Yum update on the client and verify update would succeed.
+    1. Create two repositories. Populate the first, and leave the second empty.
+    2. Pick an RPM with at least two versions.
+    3. Copy the older version of the RPM from the first repository to the
+       second, and publish the second repository.
+    4. Pick a host system capable of installing RPMs. (By default, this is the
+       system hosting Pulp.) Make it add the second repository as a source of
+       packages, and make it install the RPM.
+    5. Copy the newer version of the RPM from the first repository to the
+       second, and publish the second repository.
+    6. Make the host install the newer RPM with ``yum update rpm_name``, or a
+       similar command.
 
-    Note that the 1st repo `_REPO_ID` has been synced in `setUpModule()`,
-    while the 2nd repo `repo_id` has been created by base class without
-    a feed.
-
-    .. _Pulp Smash #311: https://github.com/PulpQE/pulp-smash/issues/311
+    This test case targets `Pulp Smash #311
+    <https://github.com/PulpQE/pulp-smash/issues/311>`_.
     """
 
-    @classmethod
-    def setUpClass(cls):
-        """Find a RPM with more than one version on repo1."""
-        super(CopyAndPublishTwoVersionsRepoTestCase, cls).setUpClass()
-        if selectors.bug_is_untestable(2277, cls.cfg.version):
+    def test_all(self):
+        """Update an RPM in a repository and on a host."""
+        cfg = config.get_config()
+        if selectors.bug_is_untestable(2277, cfg.version):
             raise unittest.SkipTest('https://pulp.plan.io/issues/2277')
-        cls.client = cli.Client(cls.cfg)
-        cls.sudo = '' if is_root(cls.cfg) else 'sudo '
-        # Retrieve all modules with multiple versions in the repo1.
-        rpms = {
-            key: value
-            for key, value in _get_rpm_names_versions(
-                cls.cfg, _REPO_ID).items()
-            if len(value) > 1
-        }
-        assert len(rpms) > 0
-        # Choose a random module with multiple versions.
-        cls.rpm_name = random.choice(list(rpms.keys()))
-        versions = rpms[cls.rpm_name]
-        versions.sort()
-        cls.rpm_old_version = versions[-2]
-        cls.rpm_new_version = versions[-1]
+        client = cli.Client(cfg)
+        sudo = '' if is_root(cfg) else 'sudo '
 
-    def test_update_copied_rpm(self):
-        """Check if a client can update a copied RPM.
+        # Create the second repository.
+        repo_id = self.create_repo(cfg)
 
-        Do the following:
+        # Pick an RPM with two versions.
+        rpms = _get_rpm_names_versions(cfg, _REPO_ID)
+        rpm_name = 'walrus'
+        rpm_versions = rpms[rpm_name]
 
-        1. Copy an old version of a RPM and its dependencies from one repo to
-           another.
-        2. Publish the target repository.
-        3. Install the RPM.
-        4. Copy an updated version of the RPM copied on step 1.
-        5. Publish the target repository again.
-        6. Check if the yum will install the updated RPM.
-        """
-        # Copy and publish the old RPM package version.
-        self._copy_and_publish(self.rpm_name, self.rpm_old_version)
+        # Copy the older RPM to the second repository, and publish it.
+        self._copy_and_publish(cfg, rpm_name, rpm_versions[0], repo_id)
 
-        repo_path = generate_repo_file(
-            self.cfg,
-            self.repo_id,
-            baseurl=urljoin(
-                self.cfg.base_url, 'pulp/repos/{}'.format(self.repo_id)),
+        # Install the RPM on a host.
+        repo_path = gen_yum_config_file(
+            cfg,
+            baseurl=urljoin(cfg.base_url, 'pulp/repos/' + repo_id),
             enabled=1,
             gpgcheck=0,
             metadata_expire=0,  # force metadata to load every time
+            repositoryid=repo_id,
         )
         self.addCleanup(
-            self.client.run,
-            '{}rm {}'.format(self.sudo, repo_path).split()
+            client.run,
+            '{}rm {}'.format(sudo, repo_path).split()
         )
-        self.client.run(
-            '{}yum install -y {}'
-            .format(self.sudo, self.rpm_name).split()
-        )
+        client.run('{}yum install -y {}'.format(sudo, rpm_name).split())
         self.addCleanup(
-            self.client.run,
-            '{}yum remove -y {}'.format(self.sudo, self.rpm_name).split()
+            client.run,
+            '{}yum remove -y {}'.format(sudo, rpm_name).split()
         )
-        self.assertEqual(
-            cli.Client(self.cfg, cli.echo_handler).run(
-                'rpm -q {}'.format(self.rpm_name).split()).returncode,
-            0
-        )
-        self._copy_and_publish(self.rpm_name, self.rpm_new_version)
-        # Execute `yum update` on the RPM.
-        completed_proc = self.client.run(
-            '{}yum -y update {}'
-            .format(self.sudo, self.rpm_name).split()
-        )
-        # Check if the update succeeds; it should have updates.
-        self.assertNotIn('Nothing to do.', completed_proc.stdout)
+        client.run(['rpm', '-q', rpm_name])
 
-    def _copy_and_publish(self, rpm_name, rpm_version):
-        """Copy the RPM with given name and version into repo2 and publish it.
+        # Copy the newer RPM to the second repository, and publish it.
+        self._copy_and_publish(cfg, rpm_name, rpm_versions[1], repo_id)
 
-        :param rpm_name: The name of target module.
-        :param rpm_version: The version of target module.
+        # Update the installed RPM on the host.
+        proc = client.run('{}yum -y update {}'.format(sudo, rpm_name).split())
+        self.assertNotIn('Nothing to do.', proc.stdout)
+
+    def _copy_and_publish(self, cfg, rpm_name, rpm_version, repo_id):
+        """Copy an RPM from repository ``_REPO_ID`` to the given repository.
+
+        :param rpm_name: The name of the RPM to copy.
+        :param rpm_version: The version of the RPM to copy.
+        :param repo_id: The repository to which the RPM is copied.
         """
+        client = cli.Client(cfg)
+
         # Copy the package and its dependencies to the new repo
-        self.client.run(
+        client.run(
             'pulp-admin rpm repo copy rpm --from-repo-id {} --to-repo-id {} '
             '--str-eq=name={} --str-eq=version={} --recursive'
-            .format(_REPO_ID, self.repo_id, rpm_name, rpm_version).split()
+            .format(_REPO_ID, repo_id, rpm_name, rpm_version).split()
         )
 
         # Search for the RPM's name/version in repo2's content.
-        result = self.client.run(
+        result = client.run(
             'pulp-admin rpm repo content rpm --repo-id {} --str-eq name={} '
             '--str-eq version={}'
-            .format(self.repo_id, rpm_name, rpm_version).split()
+            .format(repo_id, rpm_name, rpm_version).split()
         )
         with self.subTest(comment='rpm name present'):
             self.assertIn(rpm_name, result.stdout)
@@ -360,12 +326,10 @@ class CopyAndPublishTwoVersionsRepoTestCase(CopyBaseTestCase):
             self.assertIn(rpm_version, result.stdout)
 
         # Publish repo2 and verify no errors.
-        completed_proc = self.client.run(
+        proc = client.run(
             'pulp-admin rpm repo publish run --repo-id {}'
-            .format(self.repo_id).split()
+            .format(repo_id).split()
         )
         for stream in ('stdout', 'stderr'):
             with self.subTest(stream=stream):
-                self.assertNotIn(
-                    'Task Failed', getattr(completed_proc, stream)
-                )
+                self.assertNotIn('Task Failed', getattr(proc, stream))


### PR DESCRIPTION
Refactor module `pulp_smash.tests.rpm.cli.test_copy_units`. Aside from a
(hopeful) improvement in readability, fixture tear-down logic is more
robust.