### PR TITLE
Set repository type when creating Python repos

### DIFF
--- a/pulp_smash/tests/python/api_v2/utils.py
+++ b/pulp_smash/tests/python/api_v2/utils.py
@@ -9,4 +9,5 @@ def gen_repo():
         'id': utils.uuid4(),
         'importer_config': {},
         'importer_type_id': 'python_importer',
+        'notes': {'_repo-type': 'PYTHON'},
     }


### PR DESCRIPTION
Pulp repositories don't have a "type" per se. However, practical
experience shows that repositories should include only a closely related
set of content types. This is reflected in repository metadata. If a
repository's type is listed in its metadata, then front-ends (like
pulp-admin) can better display repository information to users.