### PR TITLE
Split Python repo sync test case in two

### DIFF
--- a/pulp_smash/constants.py
+++ b/pulp_smash/constants.py
@@ -225,14 +225,22 @@ to Pulp.
     http://projects.puppetlabs.com/projects/module-site/wiki/Server-api
 """
 
-PYTHON_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'python/')
-"""The URL to a Python repository."""
+PYTHON_PULP_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'python/')
+"""The URL to a Pulp Python repository."""
 
 PYTHON_EGG_URL = urljoin(
-    PYTHON_FEED_URL,
+    PYTHON_PULP_FEED_URL,
     'packages/source/s/shelf-reader/shelf-reader-0.1.tar.gz'
 )
-"""The URL to a Python egg at :data:`PYTHON_FEED_URL`."""
+"""The URL to a Python egg at :data:`PYTHON_PULP_FEED_URL`."""
+
+PYTHON_PYPI_FEED_URL = 'https://pypi.python.org'
+"""The URL to the PyPI Python repository.
+
+.. NOTE:: This should be changed after `Pulp Fixtures #40`_ is fixed.
+
+.. _Pulp Fixtures #40: https://github.com/PulpQE/pulp-fixtures/issues/40
+"""
 
 REPOSITORY_EXPORT_DISTRIBUTOR = 'export_distributor'
 """A ``distributor_type_id`` to export a repository.

--- a/pulp_smash/tests/python/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/python/api_v2/test_sync_publish.py
@@ -1,39 +1,44 @@
 # coding=utf-8
 """Test the sync and publish API endpoints for Python repositories."""
+import unittest
 from urllib.parse import urljoin
 
 from packaging.version import Version
 
-from pulp_smash import api, constants, selectors, utils
+from pulp_smash import api, config, constants, selectors, utils
 from pulp_smash.tests.python.api_v2.utils import gen_repo
 from pulp_smash.tests.python.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 
-class SyncTestCase(utils.BaseAPITestCase):
-    """If a valid feed is given, the sync completes without reported errors."""
+class UtilsMixin(object):
+    """Methods for use by the test cases in this module.
 
-    @classmethod
-    def setUpClass(cls):
-        """Create a Python repo and sync it."""
-        super(SyncTestCase, cls).setUpClass()
-        client = api.Client(cls.cfg, api.json_handler)
-        body = gen_repo()
-        body['importer_config'] = {
-            'feed': constants.PYTHON_FEED_URL,
-            'package_names': 'shelf-reader',
-        }
-        cls.repo_href = client.post(constants.REPOSITORY_PATH, body)['_href']
-        cls.resources.add(cls.repo_href)
+    Classes inheriting from this mixin must also inherit from
+    ``unittest.TestCase``.
+    """
 
-    def test_01_sync(self):
-        """Sync the repository.
+    def create_repo(self, cfg, importer_config):
+        """Create a Python repository with the given importer config.
 
-        Assert the call to sync the repository returns an HTTP 202. Assert none
-        of the task reports contain error details.
+        Schedule it for deletion. Return its href.
         """
-        report = utils.sync_repo(self.cfg, self.repo_href)
-        self.assertEqual(report.status_code, 202)
-        tasks = tuple(api.poll_spawned_tasks(self.cfg, report.json()))
+        client = api.Client(cfg, api.json_handler)
+        body = gen_repo()
+        body['importer_config'] = importer_config
+        repo_href = client.post(constants.REPOSITORY_PATH, body)['_href']
+        self.addCleanup(client.delete, repo_href)
+        return repo_href
+
+    def verify_sync(self, cfg, call_report):
+        """Verify the call to sync the Python repository succeeded.
+
+        Assert that:
+
+        * The call report has an HTTP 202 status code.
+        * None of the tasks spawned by the "sync" request contain errors.
+        """
+        self.assertEqual(call_report.status_code, 202)
+        tasks = tuple(api.poll_spawned_tasks(cfg, call_report.json()))
         for i, task in enumerate(tasks):
             step_reports = task['progress_report']['python_importer']
             for step in step_reports:
@@ -41,21 +46,76 @@ class SyncTestCase(utils.BaseAPITestCase):
                     error_details = step['error_details']
                     self.assertEqual(error_details, [], task)
 
-    def test_02_package_types(self):
-        """Assert sdist and bdist_wheel versions of the package were synced.
+    def verify_package_types(self, cfg, repo_href):
+        """Assert sdist and bdist_wheel shelf-reader packages were synced.
 
-        This test targets:
-
-        * `Pulp issue #1882 <https://pulp.plan.io/issues/1882>`_
-        * `Pulp issue #2330 <https://pulp.plan.io/issues/2330>`_
+        This test targets `Pulp #1883 <https://pulp.plan.io/issues/1883>`_.
         """
-        if self.cfg.version < Version('2.11'):
-            self.skipTest('https://pulp.plan.io/issues/1882')
-        if selectors.bug_is_untestable(2230, self.cfg.version):
-            self.skipTest('https://pulp.plan.io/issues/2330')
-        units = api.Client(self.cfg).post(
-            urljoin(self.repo_href, 'search/units/'),
+        if selectors.bug_is_untestable(1883, cfg.version):
+            return
+        units = api.Client(cfg).post(
+            urljoin(repo_href, 'search/units/'),
             {'criteria': {}},
         ).json()
         unit_types = {unit['metadata']['packagetype'] for unit in units}
         self.assertEqual(unit_types, {'sdist', 'bdist_wheel'})
+
+
+class PulpToPulpSyncTestCase(UtilsMixin, unittest.TestCase):
+    """Test whether Pulp can sync from a Pulp Python repository.
+
+    As of pulp_python 2.0, the Python repositories published by Pulp may be
+    consumed by other Pulp systems. pulp_python 2.0 is likely to be included in
+    Pulp 2.11. This test case will do the following when executed:
+
+    1. Create a Python repository, and set its feed to a Python repository
+       created by another Pulp system.
+    2. Sync the repository.
+
+    For more information, see:
+
+    * `Pulp #1882 <https://pulp.plan.io/issues/1882>`_
+    * `Pulp Smash #416 <https://github.com/PulpQE/pulp-smash/issues/416>`_
+    """
+
+    def test_all(self):
+        """Test whether Pulp can sync from a Pulp Python repository."""
+        cfg = config.get_config()
+        if cfg.version < Version('2.11'):
+            self.skipTest('https://pulp.plan.io/issues/1882')
+        repo_href = self.create_repo(cfg, {
+            'feed': constants.PYTHON_PULP_FEED_URL,
+            'package_names': 'shelf-reader',
+        })
+        call_report = utils.sync_repo(cfg, repo_href)
+        self.verify_sync(cfg, call_report)
+        self.verify_package_types(cfg, repo_href)
+
+
+class PypiToPulpSyncTestCase(UtilsMixin, unittest.TestCase):
+    """Test whether Pulp can sync from a PyPI Python repository.
+
+    As of pulp_python 2.0, the Python repositories published by Pulp may be
+    consumed by other Pulp systems. pulp_python 2.0 is likely to be included in
+    Pulp 2.11. This test case will do the following when executed:
+
+    1. Create a Python repository, and set its feed to a Python repository
+       created by another Pulp system.
+    2. Sync the repository.
+
+    For more information, see:
+
+    * `Pulp #1882 <https://pulp.plan.io/issues/1882>`_
+    * `Pulp Smash #416 <https://github.com/PulpQE/pulp-smash/issues/416>`_
+    """
+
+    def test_all(self):
+        """Test whether Pulp can sync from a PyPI Python repository."""
+        cfg = config.get_config()
+        repo_href = self.create_repo(cfg, {
+            'feed': constants.PYTHON_PYPI_FEED_URL,
+            'package_names': 'shelf-reader',
+        })
+        call_report = utils.sync_repo(cfg, repo_href)
+        self.verify_sync(cfg, call_report)
+        self.verify_package_types(cfg, repo_href)


### PR DESCRIPTION
Pulp is currently able to sync Python packages from PyPI. As of the
pulp_python plugin version 2.0, it should also be able to sync Python
packages from other Pulp systems. Update module
`pulp_smash.tests.python.api_v2.test_sync_publish` to test both of these
scenarios.

Fix: https://github.com/PulpQE/pulp-smash/issues/416