### PR TITLE
Remove references to pulp.readthedocs.io

### DIFF
--- a/pulp_smash/constants.py
+++ b/pulp_smash/constants.py
@@ -42,7 +42,7 @@ CONTENT_SOURCES_PATH = '/etc/pulp/content/sources/conf.d'
 """See: `Content Sources`_.
 
 .. _Content Sources:
-    http://pulp.readthedocs.io/en/latest/user-guide/content-sources.html
+    https://docs.pulpproject.org/user-guide/content-sources.html
 """
 
 CONTENT_UNITS_PATH = '/pulp/api/v2/content/units/'

--- a/pulp_smash/tests/platform/cli/test_content_sources.py
+++ b/pulp_smash/tests/platform/cli/test_content_sources.py
@@ -79,7 +79,7 @@ class RefreshAndDeleteContentSourcesTestCase(unittest.TestCase):
     .. _Pulp #1692:  https://pulp.plan.io/issues/1692
     .. _Pulp Smash #141: https://github.com/PulpQE/pulp-smash/issues/141
     .. _content sources:
-        http://pulp.readthedocs.io/en/latest/user-guide/content-sources.html
+        https://docs.pulpproject.org/user-guide/content-sources.html
     """
 
     @classmethod

--- a/pulp_smash/tests/rpm/api_v2/utils.py
+++ b/pulp_smash/tests/rpm/api_v2/utils.py
@@ -105,7 +105,7 @@ def get_unit_unassociate_criteria(unit_name):
     units from a repository`_.
 
     ..  _unassociate content units from a repository:
-        http://pulp.readthedocs.io/en/latest/dev-guide/integration/rest-api/content/associate.html#unassociating-content-units-from-a-repository
+        http://docs.pulpproject.org/dev-guide/integration/rest-api/content/associate.html#unassociating-content-units-from-a-repository
 
     :param unit_name: The name of the unit that will be unassociated from the
         repository.


### PR DESCRIPTION
Reference https://docs.pulpproject.org instead.