### PR TITLE
Skip tests affected by Pulp issue 2387

### DIFF
--- a/pulp_smash/tests/rpm/api_v2/test_download_policies.py
+++ b/pulp_smash/tests/rpm/api_v2/test_download_policies.py
@@ -19,18 +19,7 @@ from pulp_smash.constants import (
     RPM_SIGNED_URL,
 )
 from pulp_smash.tests.rpm.api_v2.utils import gen_distributor, gen_repo
-from pulp_smash.tests.rpm.utils import set_up_module
-
-
-def _os_is_rhel6(server_config):
-    """Return ``True`` if the server runs RHEL 6, or ``False`` otherwise."""
-    response = cli.Client(server_config, cli.echo_handler).run((
-        'grep',
-        '-i',
-        'red hat enterprise linux server release 6',
-        '/etc/redhat-release',
-    ))
-    return response.returncode == 0
+from pulp_smash.tests.rpm.utils import os_is_rhel6, set_up_module
 
 
 def setUpModule():  # pylint:disable=invalid-name
@@ -39,6 +28,8 @@ def setUpModule():  # pylint:disable=invalid-name
     cfg = config.get_config()
     if cfg.version < Version('2.8'):
         raise unittest.SkipTest('This module requires Pulp 2.8 or greater.')
+    if selectors.bug_is_untestable(2387, cfg.version) and os_is_rhel6(cfg):
+        raise unittest.SkipTest('https://pulp.plan.io/issues/2387')
     if selectors.bug_is_untestable(2272, cfg.version):
         raise unittest.SkipTest('https://pulp.plan.io/issues/2272')
     if selectors.bug_is_untestable(2144, cfg.version):
@@ -77,7 +68,7 @@ class BackgroundTestCase(utils.BaseAPITestCase):
         """
         super(BackgroundTestCase, cls).setUpClass()
         if (selectors.bug_is_untestable(1905, cls.cfg.version) and
-                _os_is_rhel6(cls.cfg)):
+                os_is_rhel6(cls.cfg)):
             raise unittest.SkipTest('https://pulp.plan.io/issues/1905')
 
         # Required to ensure content is actually downloaded.
@@ -240,7 +231,7 @@ class FixFileCorruptionTestCase(utils.BaseAPITestCase):
         """
         super(FixFileCorruptionTestCase, cls).setUpClass()
         if (selectors.bug_is_untestable(1905, cls.cfg.version) and
-                _os_is_rhel6(cls.cfg)):
+                os_is_rhel6(cls.cfg)):
             raise unittest.SkipTest('https://pulp.plan.io/issues/1905')
 
         # Ensure Pulp is empty of units otherwise we might just associate pre-

--- a/pulp_smash/tests/rpm/api_v2/test_upload_publish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_upload_publish.py
@@ -33,7 +33,7 @@ from pulp_smash.tests.rpm.api_v2.utils import (
     gen_repo,
     get_repomd_xml,
 )
-from pulp_smash.tests.rpm.utils import check_issue_2277
+from pulp_smash.tests.rpm.utils import check_issue_2277, os_is_rhel6
 from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 
@@ -260,6 +260,9 @@ class UploadRpmTestCase(utils.BaseAPITestCase):
         4. Add a distributor to both repositories and publish them.
         """
         super(UploadRpmTestCase, cls).setUpClass()
+        if (selectors.bug_is_untestable(2387, cls.cfg.version) and
+                os_is_rhel6(cls.cfg)):
+            raise unittest.SkipTest('https://pulp.plan.io/issues/2387')
         utils.reset_pulp(cls.cfg)  # See: https://pulp.plan.io/issues/1406
         cls.responses = {}
 
@@ -433,6 +436,9 @@ class UploadErratumTestCase(utils.BaseAPITestCase):
         4. Fetch the repository's ``updateinfo.xml`` file.
         """
         super(UploadErratumTestCase, cls).setUpClass()
+        if (selectors.bug_is_untestable(2387, cls.cfg.version) and
+                os_is_rhel6(cls.cfg)):
+            raise unittest.SkipTest('https://pulp.plan.io/issues/2387')
         if check_issue_2277(cls.cfg):
             raise unittest.SkipTest('https://pulp.plan.io/issues/2277')
         cls.erratum = gen_erratum()

--- a/pulp_smash/tests/rpm/utils.py
+++ b/pulp_smash/tests/rpm/utils.py
@@ -5,7 +5,7 @@ import json
 import requests
 from packaging.version import Version
 
-from pulp_smash import config, selectors, utils
+from pulp_smash import cli, config, selectors, utils
 from pulp_smash.constants import RPM_ERRATUM_URL
 
 
@@ -47,3 +47,19 @@ def check_issue_2277(cfg):
             selectors.bug_is_untestable(2277, cfg.version)):
         return True
     return False
+
+
+def os_is_rhel6(cfg):
+    """Return ``True`` if the server runs RHEL 6, or ``False`` otherwise.
+
+    :param pulp_smash.config.ServerConfig cfg: Information about the system
+        being targeted.
+    :returns: True or false.
+    """
+    response = cli.Client(cfg, cli.echo_handler).run((
+        'grep',
+        '-i',
+        'red hat enterprise linux server release 6',
+        '/etc/redhat-release',
+    ))
+    return response.returncode == 0


### PR DESCRIPTION
Also, add function `pulp_smash.tests.rpm.utils.os_is_rhel6`. Remove a
corresponding private function.

See: https://pulp.plan.io/issues/2387