### PR TITLE
Expand and clean up skips for Pulp issue 2387

### DIFF
--- a/pulp_smash/tests/rpm/api_v2/test_broker.py
+++ b/pulp_smash/tests/rpm/api_v2/test_broker.py
@@ -36,7 +36,7 @@ from pulp_smash.constants import (
     RPM_SIGNED_URL,
 )
 from pulp_smash.tests.rpm.api_v2.utils import gen_distributor, gen_repo
-from pulp_smash.tests.rpm.utils import check_issue_2277
+from pulp_smash.tests.rpm.utils import check_issue_2277, check_issue_2387
 from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 
@@ -48,6 +48,8 @@ class BrokerTestCase(unittest.TestCase):
         self.cfg = config.get_config()
         if check_issue_2277(self.cfg):
             self.skipTest('https://pulp.plan.io/issues/2277')
+        if check_issue_2387(self.cfg):
+            self.skipTest('https://pulp.plan.io/issues/2387')
         self.broker = utils.get_broker(self.cfg)
         self.services = tuple((
             cli.Service(self.cfg, service) for service in PULP_SERVICES

--- a/pulp_smash/tests/rpm/api_v2/test_download_policies.py
+++ b/pulp_smash/tests/rpm/api_v2/test_download_policies.py
@@ -19,7 +19,11 @@ from pulp_smash.constants import (
     RPM_SIGNED_URL,
 )
 from pulp_smash.tests.rpm.api_v2.utils import gen_distributor, gen_repo
-from pulp_smash.tests.rpm.utils import os_is_rhel6, set_up_module
+from pulp_smash.tests.rpm.utils import (
+    check_issue_2387,
+    os_is_rhel6,
+    set_up_module,
+)
 
 
 def setUpModule():  # pylint:disable=invalid-name
@@ -28,7 +32,7 @@ def setUpModule():  # pylint:disable=invalid-name
     cfg = config.get_config()
     if cfg.version < Version('2.8'):
         raise unittest.SkipTest('This module requires Pulp 2.8 or greater.')
-    if selectors.bug_is_untestable(2387, cfg.version) and os_is_rhel6(cfg):
+    if check_issue_2387(cfg):
         raise unittest.SkipTest('https://pulp.plan.io/issues/2387')
     if selectors.bug_is_untestable(2272, cfg.version):
         raise unittest.SkipTest('https://pulp.plan.io/issues/2272')

--- a/pulp_smash/tests/rpm/api_v2/test_upload_publish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_upload_publish.py
@@ -27,13 +27,16 @@ from pulp_smash.constants import (
     SRPM,
     SRPM_UNSIGNED_URL,
 )
-from pulp_smash.tests.rpm.utils import gen_erratum
 from pulp_smash.tests.rpm.api_v2.utils import (
     gen_distributor,
     gen_repo,
     get_repomd_xml,
 )
-from pulp_smash.tests.rpm.utils import check_issue_2277, os_is_rhel6
+from pulp_smash.tests.rpm.utils import (
+    check_issue_2277,
+    check_issue_2387,
+    gen_erratum,
+)
 from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 
@@ -260,8 +263,7 @@ class UploadRpmTestCase(utils.BaseAPITestCase):
         4. Add a distributor to both repositories and publish them.
         """
         super(UploadRpmTestCase, cls).setUpClass()
-        if (selectors.bug_is_untestable(2387, cls.cfg.version) and
-                os_is_rhel6(cls.cfg)):
+        if check_issue_2387(cls.cfg):
             raise unittest.SkipTest('https://pulp.plan.io/issues/2387')
         utils.reset_pulp(cls.cfg)  # See: https://pulp.plan.io/issues/1406
         cls.responses = {}
@@ -436,8 +438,7 @@ class UploadErratumTestCase(utils.BaseAPITestCase):
         4. Fetch the repository's ``updateinfo.xml`` file.
         """
         super(UploadErratumTestCase, cls).setUpClass()
-        if (selectors.bug_is_untestable(2387, cls.cfg.version) and
-                os_is_rhel6(cls.cfg)):
+        if check_issue_2387(cls.cfg):
             raise unittest.SkipTest('https://pulp.plan.io/issues/2387')
         if check_issue_2277(cls.cfg):
             raise unittest.SkipTest('https://pulp.plan.io/issues/2277')

--- a/pulp_smash/tests/rpm/utils.py
+++ b/pulp_smash/tests/rpm/utils.py
@@ -49,6 +49,19 @@ def check_issue_2277(cfg):
     return False
 
 
+def check_issue_2387(cfg):
+    """Return true if `Pulp #2387`_ affects the targeted Pulp system.
+
+    :param pulp_smash.config.ServerConfig cfg: The Pulp system under test.
+
+    .. _Pulp #2387: https://pulp.plan.io/issues/2387
+    """
+    if (cfg.version >= Version('2.10') and os_is_rhel6(cfg) and
+            selectors.bug_is_untestable(2387, cfg.version)):
+        return True
+    return False
+
+
 def os_is_rhel6(cfg):
     """Return ``True`` if the server runs RHEL 6, or ``False`` otherwise.
 


### PR DESCRIPTION
Add a new function, `check_issue_2387`, that checks whether the system
under test is affected by Pulp issue 2387. Use this function wherever
issue 2387 is referenced.

Add a check for issue 2387 into module
`pulp_smash.tests.rpm.api_v2.test_broker`. The tests in this module are
affected but not yet skipped.

See: https://pulp.plan.io/issues/2387