### PR TITLE
Improve clean-up logic in several modules

### DIFF
--- a/pulp_smash/tests/rpm/api_v2/test_mirrorlist.py
+++ b/pulp_smash/tests/rpm/api_v2/test_mirrorlist.py
@@ -20,6 +20,7 @@ from packaging.version import Version
 
 from pulp_smash import api, config, selectors, utils
 from pulp_smash.constants import (
+    ORPHANS_PATH,
     REPOSITORY_PATH,
     RPM,
     RPM_MIRRORLIST_BAD,
@@ -36,6 +37,11 @@ from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pyli
 def _gen_rel_url():
     """Generate a relative URL."""
     return utils.uuid4() + '/'
+
+
+def tearDownModule():  # pylint:disable=invalid-name
+    """Delete orphan content units."""
+    api.Client(config.get_config()).delete(ORPHANS_PATH)
 
 
 class UtilsMixin(object):


### PR DESCRIPTION
Ensure that
``pulp_smash.tests.rpm.api_v2.test_{mirrorlist,no_op_publish}`` clean up
orphans when exiting. This ensures that later modules, namely
``pulp_smash.tests.rpm.api-v2.test_orphan_remove``, can successfully
execute.