### PR TITLE
Add and use two new utility functions

### DIFF
--- a/pulp_smash/tests/rpm/api_v2/test_comps_xml.py
+++ b/pulp_smash/tests/rpm/api_v2/test_comps_xml.py
@@ -22,6 +22,7 @@ from pulp_smash.tests.rpm.api_v2.utils import (
     gen_distributor,
     gen_repo,
     get_repomd_xml,
+    publish_repo,
 )
 from pulp_smash.tests.rpm.utils import check_issue_2277
 from pulp_smash.tests.rpm.utils import set_up_module
@@ -136,15 +137,11 @@ class SyncRepoTestCase(utils.BaseAPITestCase):
         body['distributors'] = [gen_distributor()]
         repo = client.post(REPOSITORY_PATH, body)
         cls.resources.add(repo['_href'])
+        repo = client.get(repo['_href'], params={'details': True})
 
         # Sync and publish the repo.
-        repo = client.get(repo['_href'], params={'details': True})
         utils.sync_repo(cls.cfg, repo['_href'])
-        client.post(
-            urljoin(repo['_href'], 'actions/publish/'),
-            {'id': repo['distributors'][0]['id']},
-        )
-        repo = client.get(repo['_href'], params={'details': True})
+        publish_repo(cls.cfg, repo)
 
         # Fetch and parse comps.xml.
         dist = repo['distributors'][0]
@@ -199,12 +196,11 @@ class UploadPackageGroupsTestCase(utils.BaseAPITestCase):
 
         # Create a repository and add a distributor to it.
         client = api.Client(cls.cfg, api.json_handler)
-        repo = client.post(REPOSITORY_PATH, gen_repo())
+        body = gen_repo()
+        body['distributors'] = [gen_distributor()]
+        repo = client.post(REPOSITORY_PATH, body)
         cls.resources.add(repo['_href'])
-        distributor = client.post(
-            urljoin(repo['_href'], 'distributors/'),
-            gen_distributor(),
-        )
+        repo = client.get(repo['_href'], params={'details': True})
 
         # Generate several package groups, import them into the repository, and
         # publish the repository.
@@ -216,15 +212,15 @@ class UploadPackageGroupsTestCase(utils.BaseAPITestCase):
         for key, package_group in cls.package_groups.items():
             report = _upload_import_package_group(cls.cfg, repo, package_group)
             cls.tasks[key] = tuple(api.poll_spawned_tasks(cls.cfg, report))
-        client.post(
-            urljoin(repo['_href'], 'actions/publish/'),
-            {'id': distributor['id']},
-        )
+        publish_repo(cls.cfg, repo)
 
         # Fetch the generated repodata of type 'group' (a.k.a. 'comps')
         cls.root_element = get_repomd_xml(
             cls.cfg,
-            urljoin('/pulp/repos/', distributor['config']['relative_url']),
+            urljoin(
+                '/pulp/repos/',
+                repo['distributors'][0]['config']['relative_url'],
+            ),
             'group'
         )
 

--- a/pulp_smash/tests/rpm/api_v2/test_mirrorlist.py
+++ b/pulp_smash/tests/rpm/api_v2/test_mirrorlist.py
@@ -14,7 +14,6 @@ both valid and invalid references, and a "bad" file contains only invalid
 references.
 """
 import unittest
-from urllib.parse import urljoin
 
 from packaging.version import Version
 
@@ -29,7 +28,12 @@ from pulp_smash.constants import (
     RPM_UNSIGNED_URL,
 )
 from pulp_smash.exceptions import TaskReportError
-from pulp_smash.tests.rpm.api_v2.utils import gen_distributor, gen_repo
+from pulp_smash.tests.rpm.api_v2.utils import (
+    gen_distributor,
+    gen_repo,
+    get_unit,
+    publish_repo,
+)
 from pulp_smash.tests.rpm.utils import check_issue_2277
 from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
@@ -61,7 +65,7 @@ class UtilsMixin(object):
         :param feed: A value for the yum importer's ``feed`` option.
         :param relative_url: A value for the yum distributor's ``relative_url``
             option. If ``None``, this option is not passed to Pulp.
-        :returns: The repository's href.
+        :returns: A detailed dict of information about the repository.
         """
         body = gen_repo()
         body['importer_config']['feed'] = feed
@@ -70,50 +74,9 @@ class UtilsMixin(object):
             distributor['distributor_config']['relative_url'] = relative_url
         body['distributors'] = [distributor]
         client = api.Client(cfg, api.json_handler)
-        repo_href = client.post(REPOSITORY_PATH, body)['_href']
-        self.addCleanup(client.delete, repo_href)
-        return repo_href
-
-    @staticmethod
-    def publish_repo(cfg, repo_href):
-        """Publish a repository.
-
-        The given repository should have only one distributor.
-
-        :param pulp_smash.config.ServerConfig cfg: The Pulp server on which the
-            repository is hosted.
-        :param repo_href: The href of the repository to publish.
-        :returns: The decoded body of the server's reponse. (A call report.)
-        """
-        client = api.Client(cfg, api.json_handler)
-        repo = client.get(repo_href, params={'details': True})
-        assert len(repo['distributors']) == 1
-        return client.post(urljoin(repo_href, 'actions/publish/'), {
-            'id': repo['distributors'][0]['id'],
-        })
-
-    @staticmethod
-    def get_unit(cfg, repo_href, unit_name):
-        """Download an RPM from a published repository.
-
-        The given repository should have only one distributor.
-
-        :param pulp_smash.config.ServerConfig cfg: The Pulp server on which the
-            repository is hosted.
-        :param repo_href: The href of the published repository.
-        :param unit_name: The name of the content unit in the published
-            repository.
-        :returns: A binary blob.
-        """
-        client = api.Client(cfg)
-        repo = client.get(repo_href, params={'details': True}).json()
-        assert len(repo['distributors']) == 1
-        path = urljoin(
-            '/pulp/repos/',
-            repo['distributors'][0]['config']['relative_url'],
-        )
-        path = urljoin(path, unit_name)
-        return client.get(path).content
+        repo = client.post(REPOSITORY_PATH, body)
+        self.addCleanup(client.delete, repo['_href'])
+        return client.get(repo['_href'], params={'details': True})
 
     def check_issue_2277(self, cfg):
         """Skip the current test method if Pulp `issue #2277`_ affects us.
@@ -167,10 +130,10 @@ class GoodMirrorlistTestCase(UtilsMixin, unittest.TestCase):
         cfg = config.get_config()
         self.check_issue_2277(cfg)
         self.check_issue_2326(cfg)
-        repo_href = self.create_repo(cfg, RPM_MIRRORLIST_GOOD)
-        utils.sync_repo(cfg, repo_href)
-        self.publish_repo(cfg, repo_href)
-        actual_rpm = self.get_unit(cfg, repo_href, RPM)
+        repo = self.create_repo(cfg, RPM_MIRRORLIST_GOOD)
+        utils.sync_repo(cfg, repo['_href'])
+        publish_repo(cfg, repo)
+        actual_rpm = get_unit(cfg, repo, RPM).content
         target_rpm = utils.http_get(RPM_UNSIGNED_URL)
         self.assertEqual(actual_rpm, target_rpm)
 
@@ -183,10 +146,10 @@ class GoodRelativeUrlTestCase(UtilsMixin, unittest.TestCase):
         cfg = config.get_config()
         self.check_issue_2277(cfg)
         self.check_issue_2326(cfg)
-        repo_href = self.create_repo(cfg, RPM_MIRRORLIST_GOOD, _gen_rel_url())
-        utils.sync_repo(cfg, repo_href)
-        self.publish_repo(cfg, repo_href)
-        actual_rpm = self.get_unit(cfg, repo_href, RPM)
+        repo = self.create_repo(cfg, RPM_MIRRORLIST_GOOD, _gen_rel_url())
+        utils.sync_repo(cfg, repo['_href'])
+        publish_repo(cfg, repo)
+        actual_rpm = get_unit(cfg, repo, RPM).content
         target_rpm = utils.http_get(RPM_UNSIGNED_URL)
         self.assertEqual(actual_rpm, target_rpm)
 
@@ -205,10 +168,10 @@ class MixedMirrorlistTestCase(UtilsMixin, unittest.TestCase):
         cfg = config.get_config()
         self.check_issue_2277(cfg)
         self.check_issue_2321(cfg)
-        repo_href = self.create_repo(cfg, RPM_MIRRORLIST_MIXED)
-        utils.sync_repo(cfg, repo_href)
-        self.publish_repo(cfg, repo_href)
-        actual_rpm = self.get_unit(cfg, repo_href, RPM)
+        repo = self.create_repo(cfg, RPM_MIRRORLIST_MIXED)
+        utils.sync_repo(cfg, repo['_href'])
+        publish_repo(cfg, repo)
+        actual_rpm = get_unit(cfg, repo, RPM).content
         target_rpm = utils.http_get(RPM_UNSIGNED_URL)
         self.assertEqual(actual_rpm, target_rpm)
 
@@ -221,10 +184,10 @@ class MixedRelativeUrlTestCase(UtilsMixin, unittest.TestCase):
         cfg = config.get_config()
         self.check_issue_2277(cfg)
         self.check_issue_2321(cfg)
-        repo_href = self.create_repo(cfg, RPM_MIRRORLIST_MIXED, _gen_rel_url())
-        utils.sync_repo(cfg, repo_href)
-        self.publish_repo(cfg, repo_href)
-        actual_rpm = self.get_unit(cfg, repo_href, RPM)
+        repo = self.create_repo(cfg, RPM_MIRRORLIST_MIXED, _gen_rel_url())
+        utils.sync_repo(cfg, repo['_href'])
+        publish_repo(cfg, repo)
+        actual_rpm = get_unit(cfg, repo, RPM).content
         target_rpm = utils.http_get(RPM_UNSIGNED_URL)
         self.assertEqual(actual_rpm, target_rpm)
 
@@ -243,9 +206,9 @@ class BadMirrorlistTestCase(UtilsMixin, unittest.TestCase):
         """Execute the test case business logic."""
         cfg = config.get_config()
         self.check_issue_2363(cfg)
-        repo_href = self.create_repo(cfg, RPM_MIRRORLIST_BAD)
+        repo = self.create_repo(cfg, RPM_MIRRORLIST_BAD)
         with self.assertRaises(TaskReportError):
-            utils.sync_repo(cfg, repo_href)
+            utils.sync_repo(cfg, repo['_href'])
 
 
 class BadRelativeUrlTestCase(UtilsMixin, unittest.TestCase):
@@ -255,6 +218,6 @@ class BadRelativeUrlTestCase(UtilsMixin, unittest.TestCase):
         """Execute the test case business logic."""
         cfg = config.get_config()
         self.check_issue_2363(cfg)
-        repo_href = self.create_repo(cfg, RPM_MIRRORLIST_BAD, _gen_rel_url())
+        repo = self.create_repo(cfg, RPM_MIRRORLIST_BAD, _gen_rel_url())
         with self.assertRaises(TaskReportError):
-            utils.sync_repo(cfg, repo_href)
+            utils.sync_repo(cfg, repo['_href'])

--- a/pulp_smash/tests/rpm/api_v2/test_package_paths.py
+++ b/pulp_smash/tests/rpm/api_v2/test_package_paths.py
@@ -30,7 +30,6 @@ The tests in this module verify that Pulp can correctly handle these
 situations.
 """
 import unittest
-from urllib.parse import urljoin
 
 from pulp_smash import api, config, utils
 from pulp_smash.constants import (
@@ -39,65 +38,14 @@ from pulp_smash.constants import (
     RPM_ALT_LAYOUT_FEED_URL,
     RPM_UNSIGNED_FEED_URL,
 )
-from pulp_smash.tests.rpm.api_v2.utils import gen_distributor, gen_repo
+from pulp_smash.tests.rpm.api_v2.utils import (
+    gen_distributor,
+    gen_repo,
+    get_unit,
+    publish_repo,
+)
 from pulp_smash.tests.rpm.utils import check_issue_2354
 from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
-
-
-def publish_repo(cfg, repo, distributor_id=None):
-    """Publish a repository.
-
-    :param pulp_smash.config.ServerConfig cfg: Information about the Pulp host.
-    :param repo: A dict of detailed information about the repository to be
-        published.
-    :param distributor_id: The ID of the distributor to publish. If not
-        specified, the distributor described in the ``repo`` dict is used.
-    :raises: ``ValueError`` when ``distributor_id`` is not passed, and ``repo``
-        does not have exactly one distributor.
-    :returns: The decoded body of the server's reponse. (A call report.)
-    """
-    if distributor_id is None:
-        if len(repo['distributors']) != 1:
-            raise ValueError(
-                'No distributor ID was passed, and the given repository does '
-                'not have exactly one distributor. Repository distributors: {}'
-                .format(repo['distributors'])
-            )
-        distributor_id = repo['distributors'][0]['id']
-    return api.Client(cfg).post(
-        urljoin(repo['_href'], 'actions/publish/'),
-        {'id': distributor_id},
-    )
-
-
-def get_unit(cfg, unit_name, repo, distributor_id=None):
-    """Download a file from a published repository.
-
-    :param pulp_smash.config.ServerConfig cfg: Information about the Pulp host.
-    :param unit_name: The name of the content unit in the published repository.
-    :param repo: A dict of detailed information about the repository.
-    :param distributor_id: The ID of the distributor used to publish the
-        content unit. If not passed, the distributor described in the ``repo``
-        dict is used.
-    :raises: ``ValueError`` when ``distributor_id`` is not passed, and ``repo``
-        does not have exactly one distributor.
-    :returns: The raw response. The fetched unit is available as
-        ``response.content``.
-    """
-    if distributor_id is None:
-        if len(repo['distributors']) != 1:
-            raise ValueError(
-                'No distributor ID was passed, and the given repository does '
-                'not have exactly one distributor. Repository distributors: {}'
-                .format(repo['distributors'])
-            )
-        distributor_id = repo['distributors'][0]['id']
-    path = urljoin(
-        '/pulp/repos/',
-        repo['distributors'][0]['config']['relative_url'] + '/',
-    )
-    path = urljoin(path, unit_name)
-    return api.Client(cfg).get(path)
 
 
 class ReuseContentTestCase(unittest.TestCase):
@@ -126,30 +74,18 @@ class ReuseContentTestCase(unittest.TestCase):
         cfg = config.get_config()
         if check_issue_2354(cfg):
             self.skipTest('https://pulp.plan.io/issues/2354')
-        client = api.Client(cfg, api.json_handler)
-
         repos = [
             self.create_repo(cfg, feed, 'on_demand')
             for feed in (RPM_ALT_LAYOUT_FEED_URL, RPM_UNSIGNED_FEED_URL)
         ]
         for repo in repos:
             utils.sync_repo(cfg, repo['_href'])
-
-        repos = [
-            client.get(repo['_href'], params={'details': True})
-            for repo in repos
-        ]
         for repo in repos:
             publish_repo(cfg, repo)
-
-        repos = [
-            client.get(repo['_href'], params={'details': True})
-            for repo in repos
-        ]
         rpms = []
         for repo in repos:
             with self.subTest(repo=repo):
-                rpms.append(get_unit(cfg, RPM, repo).content)
+                rpms.append(get_unit(cfg, repo, RPM).content)
         self.assertEqual(len(rpms), len(repos))
         self.assertEqual(rpms[0], rpms[1], repos)
 
@@ -160,13 +96,13 @@ class ReuseContentTestCase(unittest.TestCase):
         test. Return a detailed dict of information about the just-created
         repository.
         """
-        client = api.Client(cfg)
+        client = api.Client(cfg, api.json_handler)
         body = gen_repo()
         body['importer_config']['feed'] = feed
         body['importer_config']['download_policy'] = download_policy
         distributor = gen_distributor()
         distributor['distributor_config']['relative_url'] = body['id']
         body['distributors'] = [distributor]
-        repo = client.post(REPOSITORY_PATH, body).json()
+        repo = client.post(REPOSITORY_PATH, body)
         self.addCleanup(client.delete, repo['_href'])
-        return repo
+        return client.get(repo['_href'], params={'details': True})


### PR DESCRIPTION
Add several functions to module `pulp_smash.tests.rpm.api_v2.utils`:

* `get_unit`
* `publish_repo`

Use these functions in the following modules:

* `pulp_smash.tests.rpm.api_v2.test_broker`
* `pulp_smash.tests.rpm.api_v2.test_comps_xml`
* `pulp_smash.tests.rpm.api_v2.test_mirrorlist`
* `pulp_smash.tests.rpm.api_v2.test_package_paths`

Similar refactors can likely be performed in additional modules. Work
has been restricted to just these modules to verify that the new
functions are useful in a broad variety of situations.