### PR TITLE
Add and use two new utility functions

### DIFF
--- a/pulp_smash/tests/ostree/api_v2/test_publish.py
+++ b/pulp_smash/tests/ostree/api_v2/test_publish.py
@@ -1,7 +1,6 @@
 # coding=utf-8
 """Tests that publish OSTree repositories."""
 import unittest
-from urllib.parse import urljoin
 
 from pulp_smash import api, config, utils
 from pulp_smash.constants import OSTREE_BRANCH, OSTREE_FEED, REPOSITORY_PATH
@@ -41,9 +40,7 @@ class PublishTestCase(unittest.TestCase):
             self.assertIsNone(repo['distributors'][0]['last_publish'])
 
         # Publish the repository.
-        client.post(urljoin(repo['_href'], 'actions/publish/'), {
-            'id': repo['distributors'][0]['id'],
-        })
+        utils.publish_repo(cfg, repo)
         repo = client.get(repo['_href'], params={'details': True})
         with self.subTest(comment='verify last_publish after publish'):
             self.assertIsNotNone(repo['distributors'][0]['last_publish'])

--- a/pulp_smash/tests/rpm/api_v2/test_broker.py
+++ b/pulp_smash/tests/rpm/api_v2/test_broker.py
@@ -25,7 +25,6 @@ Both scenarios are executed by
 """
 import time
 import unittest
-from urllib.parse import urljoin
 
 from pulp_smash import api, cli, config, selectors, utils
 from pulp_smash.constants import (
@@ -35,7 +34,11 @@ from pulp_smash.constants import (
     RPM_SIGNED_FEED_URL,
     RPM_SIGNED_URL,
 )
-from pulp_smash.tests.rpm.api_v2.utils import gen_distributor, gen_repo
+from pulp_smash.tests.rpm.api_v2.utils import (
+    gen_distributor,
+    gen_repo,
+    get_unit,
+)
 from pulp_smash.tests.rpm.utils import check_issue_2277, check_issue_2387
 from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
@@ -111,21 +114,13 @@ class BrokerTestCase(unittest.TestCase):
         client = api.Client(self.cfg, api.json_handler)
         body = gen_repo()
         body['importer_config']['feed'] = RPM_SIGNED_FEED_URL
+        body['distributors'] = [gen_distributor()]
         repo = client.post(REPOSITORY_PATH, body)
-        self.addCleanup(api.Client(self.cfg).delete, repo['_href'])
+        self.addCleanup(client.delete, repo['_href'])
+        repo = client.get(repo['_href'], params={'details': True})
         utils.sync_repo(self.cfg, repo['_href'])
-        distributor = client.post(
-            urljoin(repo['_href'], 'distributors/'),
-            gen_distributor(),
-        )
-        client.post(
-            urljoin(repo['_href'], 'actions/publish/'),
-            {'id': distributor['id']},
-        )
-        client.response_handler = api.safe_handler
-        url = urljoin('/pulp/repos/', distributor['config']['relative_url'])
-        url = urljoin(url, RPM)
-        pulp_rpm = client.get(url).content
+        utils.publish_repo(self.cfg, repo)
+        pulp_rpm = get_unit(self.cfg, repo, RPM).content
 
         # Does this RPM match the original RPM?
         rpm = utils.http_get(RPM_SIGNED_URL)

--- a/pulp_smash/tests/rpm/api_v2/test_export.py
+++ b/pulp_smash/tests/rpm/api_v2/test_export.py
@@ -156,7 +156,7 @@ class ExportDirMixin(DisableSELinuxMixin):
         :returns: The path to the export directory.
         """
         export_dir = self.create_export_dir()
-        api.Client(self.cfg).post(urljoin(entity_href, 'actions/publish/'), {
+        utils.publish_repo(self.cfg, repo={'_href': entity_href}, json={
             'id': distributor_id,
             'override_config': {'export_dir': export_dir},
         })
@@ -450,13 +450,11 @@ class ExportDistributorTestCase(ExportDirMixin, utils.BaseAPITestCase):
         from both locations, and assert that the fetch was successful.
         """
         # Publish the repository, and re-read the distributor.
-        client = api.Client(self.cfg, api.json_handler)
-        path = urljoin(self.repo['_href'], 'actions/publish/')
-        client.post(path, {'id': self.distributor['id']})
-        distributor = client.get(self.distributor['_href'])
+        utils.publish_repo(self.cfg, self.repo, {'id': self.distributor['id']})
+        client = api.Client(self.cfg)
+        distributor = client.get(self.distributor['_href']).json()
 
         # Fetch the ISO file via HTTP and HTTPS.
-        client.response_handler = api.safe_handler
         url = _get_iso_url(self.cfg, self.repo, 'repos', distributor)
         for scheme in ('http', 'https'):
             url = urlunparse((scheme,) + urlparse(url)[1:])

--- a/pulp_smash/tests/rpm/api_v2/test_package_paths.py
+++ b/pulp_smash/tests/rpm/api_v2/test_package_paths.py
@@ -30,7 +30,6 @@ The tests in this module verify that Pulp can correctly handle these
 situations.
 """
 import unittest
-from urllib.parse import urljoin
 
 from pulp_smash import api, config, utils
 from pulp_smash.constants import (
@@ -39,65 +38,13 @@ from pulp_smash.constants import (
     RPM_ALT_LAYOUT_FEED_URL,
     RPM_UNSIGNED_FEED_URL,
 )
-from pulp_smash.tests.rpm.api_v2.utils import gen_distributor, gen_repo
+from pulp_smash.tests.rpm.api_v2.utils import (
+    gen_distributor,
+    gen_repo,
+    get_unit,
+)
 from pulp_smash.tests.rpm.utils import check_issue_2354
 from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
-
-
-def publish_repo(cfg, repo, distributor_id=None):
-    """Publish a repository.
-
-    :param pulp_smash.config.ServerConfig cfg: Information about the Pulp host.
-    :param repo: A dict of detailed information about the repository to be
-        published.
-    :param distributor_id: The ID of the distributor to publish. If not
-        specified, the distributor described in the ``repo`` dict is used.
-    :raises: ``ValueError`` when ``distributor_id`` is not passed, and ``repo``
-        does not have exactly one distributor.
-    :returns: The decoded body of the server's reponse. (A call report.)
-    """
-    if distributor_id is None:
-        if len(repo['distributors']) != 1:
-            raise ValueError(
-                'No distributor ID was passed, and the given repository does '
-                'not have exactly one distributor. Repository distributors: {}'
-                .format(repo['distributors'])
-            )
-        distributor_id = repo['distributors'][0]['id']
-    return api.Client(cfg).post(
-        urljoin(repo['_href'], 'actions/publish/'),
-        {'id': distributor_id},
-    )
-
-
-def get_unit(cfg, unit_name, repo, distributor_id=None):
-    """Download a file from a published repository.
-
-    :param pulp_smash.config.ServerConfig cfg: Information about the Pulp host.
-    :param unit_name: The name of the content unit in the published repository.
-    :param repo: A dict of detailed information about the repository.
-    :param distributor_id: The ID of the distributor used to publish the
-        content unit. If not passed, the distributor described in the ``repo``
-        dict is used.
-    :raises: ``ValueError`` when ``distributor_id`` is not passed, and ``repo``
-        does not have exactly one distributor.
-    :returns: The raw response. The fetched unit is available as
-        ``response.content``.
-    """
-    if distributor_id is None:
-        if len(repo['distributors']) != 1:
-            raise ValueError(
-                'No distributor ID was passed, and the given repository does '
-                'not have exactly one distributor. Repository distributors: {}'
-                .format(repo['distributors'])
-            )
-        distributor_id = repo['distributors'][0]['id']
-    path = urljoin(
-        '/pulp/repos/',
-        repo['distributors'][0]['config']['relative_url'] + '/',
-    )
-    path = urljoin(path, unit_name)
-    return api.Client(cfg).get(path)
 
 
 class ReuseContentTestCase(unittest.TestCase):
@@ -126,30 +73,18 @@ class ReuseContentTestCase(unittest.TestCase):
         cfg = config.get_config()
         if check_issue_2354(cfg):
             self.skipTest('https://pulp.plan.io/issues/2354')
-        client = api.Client(cfg, api.json_handler)
-
         repos = [
             self.create_repo(cfg, feed, 'on_demand')
             for feed in (RPM_ALT_LAYOUT_FEED_URL, RPM_UNSIGNED_FEED_URL)
         ]
         for repo in repos:
             utils.sync_repo(cfg, repo['_href'])
-
-        repos = [
-            client.get(repo['_href'], params={'details': True})
-            for repo in repos
-        ]
         for repo in repos:
-            publish_repo(cfg, repo)
-
-        repos = [
-            client.get(repo['_href'], params={'details': True})
-            for repo in repos
-        ]
+            utils.publish_repo(cfg, repo)
         rpms = []
         for repo in repos:
             with self.subTest(repo=repo):
-                rpms.append(get_unit(cfg, RPM, repo).content)
+                rpms.append(get_unit(cfg, repo, RPM).content)
         self.assertEqual(len(rpms), len(repos))
         self.assertEqual(rpms[0], rpms[1], repos)
 
@@ -160,13 +95,13 @@ class ReuseContentTestCase(unittest.TestCase):
         test. Return a detailed dict of information about the just-created
         repository.
         """
-        client = api.Client(cfg)
+        client = api.Client(cfg, api.json_handler)
         body = gen_repo()
         body['importer_config']['feed'] = feed
         body['importer_config']['download_policy'] = download_policy
         distributor = gen_distributor()
         distributor['distributor_config']['relative_url'] = body['id']
         body['distributors'] = [distributor]
-        repo = client.post(REPOSITORY_PATH, body).json()
+        repo = client.post(REPOSITORY_PATH, body)
         self.addCleanup(client.delete, repo['_href'])
-        return repo
+        return client.get(repo['_href'], params={'details': True})

--- a/pulp_smash/tests/rpm/api_v2/test_upload_publish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_upload_publish.py
@@ -458,12 +458,11 @@ class UploadErratumTestCase(utils.BaseAPITestCase):
         repo = client.get(repo['_href'], params={'details': True})
 
         # Publish the repository, and fetch and parse updateinfo.xml
-        distributor = repo['distributors'][0]
-        client.post(
-            urljoin(repo['_href'], 'actions/publish/'),
-            {'id': distributor['id']},
+        utils.publish_repo(cls.cfg, repo)
+        path = urljoin(
+            '/pulp/repos/',
+            repo['distributors'][0]['config']['relative_url']
         )
-        path = urljoin('/pulp/repos/', distributor['config']['relative_url'])
         cls.updateinfo = get_repomd_xml(cls.cfg, path, 'updateinfo')
 
     def test_updateinfo_root_tag(self):

--- a/pulp_smash/tests/rpm/api_v2/utils.py
+++ b/pulp_smash/tests/rpm/api_v2/utils.py
@@ -206,3 +206,29 @@ class DisableSELinuxMixin(object):  # pylint:disable=too-few-public-methods
         client.run(cmd)
         cmd = (sudo + 'setenforce 1').split()
         self.addCleanup(client.run, cmd)
+
+
+def get_unit(cfg, repo, unit_name, distributor=None):
+    """Download a file from a published repository.
+
+    :param pulp_smash.config.ServerConfig cfg: Information about the Pulp host.
+    :param repo: A dict of detailed information about the repository.
+    :param unit_name: The name of the content unit in the published repository.
+    :param distributor: The distributor used when the content unit was
+        published. If not passed, the distributor in the ``repo`` dict is used.
+    :raises: ``ValueError`` when ``distributor`` is not passed, and ``repo``
+        does not have exactly one distributor.
+    :returns: The raw response. The fetched unit is available as
+        ``response.content``.
+    """
+    if distributor is None:
+        if len(repo['distributors']) != 1:
+            raise ValueError(
+                'No distributor was passed, and the given repository does not '
+                'have exactly one distributor. Repository distributors: {}'
+                .format(repo['distributors'])
+            )
+        distributor = repo['distributors'][0]
+    path = urljoin('/pulp/repos/', distributor['config']['relative_url'] + '/')
+    path = urljoin(path, unit_name)
+    return api.Client(cfg).get(path)

--- a/pulp_smash/utils.py
+++ b/pulp_smash/utils.py
@@ -476,3 +476,29 @@ def get_sha256_checksum(url):
         checksum = hashlib.sha256(http_get(url)).hexdigest()
         _CHECKSUM_CACHE[url] = checksum
     return _CHECKSUM_CACHE[url]
+
+
+def publish_repo(cfg, repo, json=None):
+    """Publish a repository.
+
+    :param pulp_smash.config.ServerConfig cfg: Information about the Pulp host.
+    :param repo: A dict of detailed information about the repository to be
+        published.
+    :param json: Data to be encoded as JSON and sent as the request body.
+        Defaults to ``{'id': repo['distributors'][0]['id']}``.
+    :raises: ``ValueError`` when ``json`` is not passed, and ``repo`` does not
+        have exactly one distributor.
+    :returns: The server's reponse. Call ``.json()`` on the response to get a
+        call report.
+    """
+    if json is None:
+        if 'distributors' not in repo or len(repo['distributors']) != 1:
+            raise ValueError(
+                'No request body was passed, and the given repository does '
+                'not have exactly one distributor. Repository: {}'.format(repo)
+            )
+        json = {'id': repo['distributors'][0]['id']}
+    return api.Client(cfg).post(
+        urljoin(repo['_href'], 'actions/publish/'),
+        json
+    )


### PR DESCRIPTION
Add function `pulp_smash.utils.publish_repo`. Walk through package
`pulp_smash.tests` and replace existing code as appropriate.

Add function `pulp_smash.tests.rpm.api_v2.get_unit`. Walk through
package `pulp_smash.tests.rpm.api_v2` and replace existing code as
appropriate.