### PR TITLE
Select yum or dnf at runtime

### DIFF
--- a/pulp_smash/cli.py
+++ b/pulp_smash/cli.py
@@ -15,6 +15,11 @@ from pulp_smash import exceptions
 # For example: {'old.example.com': 'sysv', 'new.example.com', 'systemd'}
 _SERVICE_MANAGERS = {}
 
+# A dict mapping hostnames to *nix package managers.
+#
+# For example: {'old.example.com': 'yum', 'new.example.com', 'yum'}
+_PACKAGE_MANAGERS = {}
+
 
 def _get_hostname(urlstring):
     """Get the hostname from a URL string.
@@ -308,3 +313,111 @@ class Service(object):
         :rtype: pulp_smash.cli.CompletedProcess
         """
         return self._client.run(self._command_builder('stop'))
+
+
+class PackageManager(object):
+    """A package manager on a system.
+
+    Each instance of this class represents the package manager on a system. An
+    example may help to clarify this idea:
+
+    >>> from pulp_smash import cli, config
+    >>> pkg_mgr = cli.PackageManager(config.get_config())
+    >>> completed_process = pkg_mgr.install('vim')
+    >>> completed_process = pkg_mgr.uninstall('vim')
+
+    In the example above, the ``pkg_mgr`` object represents the package manager
+    on the host referenced by :func:`pulp_smash.config.get_config`.
+
+    Upon instantiation, a :class:`PackageManager` object talks to its target
+    system and uses simple heuristics to determine which package manager is
+    used. As a result, it's possible to manage packages on heterogeneous
+    systems with homogeneous commands.
+
+    Upon instantiation, a :class:`PackageManager` object also talks to its
+    target system and determines whether it is running as root. If not root,
+    all commands are prefixed with "sudo". Please ensure that Pulp Smash can
+    either execute commands as root or can successfully execute ``sudo``. You
+    may need to edit your ``~/.ssh/config`` file.
+
+    :param pulp_smash.config.ServerConfig cfg: Information about the target
+        system.
+    :raises pulp_smash.exceptions.NoKnownPackageManagerError: If unable to find
+        any package manager on the target system.
+    """
+
+    def __init__(self, cfg):
+        """Initialize a new object."""
+        self._client = Client(cfg)
+        self._sudo = () if _is_root(cfg) else ('sudo',)
+        self._pkg_mgr = self._get_package_manager(cfg)
+
+    @staticmethod
+    def _get_package_manager(cfg):
+        """Talk to the target system and determine the package manager.
+
+        Return "dnf" or "yum" if the package manager appears to be one of
+        those. Raise an exception otherwise.
+        """
+        hostname = _get_hostname(cfg.base_url)
+        try:
+            return _PACKAGE_MANAGERS[hostname]
+        except KeyError:
+            pass
+
+        client = Client(cfg, echo_handler)
+        commands_managers = (
+            (('which', 'dnf'), 'dnf'),
+            (('which', 'yum'), 'yum'),
+        )
+        for cmd, pkg_mgr in commands_managers:
+            if client.run(cmd).returncode == 0:
+                _PACKAGE_MANAGERS[hostname] = pkg_mgr
+                return pkg_mgr
+        raise exceptions.NoKnownPackageManagerError(
+            'Unable to determine the package manager used by {}. It does not '
+            'appear to be any of {}.'
+            .format(hostname, {pkg_mgr for _, pkg_mgr in commands_managers})
+        )
+
+    def install(self, *args):
+        """Install the named packages.
+
+        :rtype: pulp_smash.cli.CompletedProcess
+        """
+        if self._pkg_mgr == 'dnf':
+            cmd = self._sudo + ('dnf', '-y', 'install') + tuple(args)
+        elif self._pkg_mgr == 'yum':
+            cmd = self._sudo + ('yum', '-y', 'install') + tuple(args)
+        else:
+            cmd = None
+        assert cmd is not None
+        return self._client.run(cmd)
+
+    def uninstall(self, *args):
+        """Uninstall the named packages.
+
+        :rtype: pulp_smash.cli.CompletedProcess
+        """
+        if self._pkg_mgr == 'dnf':
+            cmd = self._sudo + ('dnf', '-y', 'remove') + tuple(args)
+        elif self._pkg_mgr == 'yum':
+            cmd = self._sudo + ('yum', '-y', 'remove') + tuple(args)
+        else:
+            cmd = None
+        assert cmd is not None
+        return self._client.run(cmd)
+
+    def upgrade(self, *args):
+        """Upgrade the named packages.
+
+        :rtype: pulp_smash.cli.CompletedProcess
+        """
+        if self._pkg_mgr == 'dnf':
+            cmd = self._sudo + ('dnf', '-y', 'upgrade') + tuple(args)
+        elif self._pkg_mgr == 'yum':
+            cmd = self._sudo + ('yum', '-y', 'update') + tuple(args)
+        else:
+            cmd = None
+        assert cmd is not None
+        return self._client.run(cmd)

--- a/pulp_smash/exceptions.py
+++ b/pulp_smash/exceptions.py
@@ -53,6 +53,13 @@ class NoKnownBrokerError(Exception):
     """
 
 
+class NoKnownPackageManagerError(Exception):
+    """We cannot determine the package manager used by a system.
+
+    A "package manager" is a tool such as ``yum`` or ``dnf``.
+    """
+
+
 class NoKnownServiceManagerError(Exception):
     """We cannot determine the service manager used by a system.
 

--- a/pulp_smash/utils.py
+++ b/pulp_smash/utils.py
@@ -13,6 +13,7 @@ from urllib.parse import urljoin, urlparse
 import requests
 
 from pulp_smash import api, cli, config, exceptions
+from pulp_smash.cli import _is_root as is_root  # for backward compatibility
 from pulp_smash.constants import (
     CONTENT_UPLOAD_PATH,
     ORPHANS_PATH,
@@ -430,18 +431,6 @@ def get_unit_type_ids(server_config):
     """
     unit_types = api.Client(server_config).get(PLUGIN_TYPES_PATH).json()
     return {unit_type['id'] for unit_type in unit_types}
-
-
-def is_root(server_config):
-    """Tell if we are root on the target system.
-
-    :param pulp_smash.config.ServerConfig server_config: Information about the
-        Pulp server being targeted.
-    :returns: Either ``True`` or ``False``.
-    """
-    if cli.Client(server_config).run(('id', '-u')).stdout.strip() == '0':
-        return True
-    return False
 
 
 def sync_repo(server_config, href):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -141,7 +141,7 @@ class ServiceTestCase(unittest.TestCase):
         Give each object a different service manager (systemd, sysv, etc).
         """
         cls.services = []
-        with mock.patch.object(cli.Service, '_get_prefix', return_value=()):
+        with mock.patch.object(cli, '_is_root', return_value=True):
             with mock.patch.object(cli, 'Client'):
                 for service_manager in ('systemd', 'sysv'):
                     with mock.patch.object(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -98,7 +98,7 @@ class BaseAPITestCase(unittest.TestCase):
 
 
 class IsRootTestCase(unittest.TestCase):
-    """Test :func:`pulp_smash.utils.is_root`."""
+    """Test ``pulp_smash.utils.is_root``."""
 
     def test_true(self):
         """Assert the method returns ``True`` when root."""


### PR DESCRIPTION
The first commit deduplicates the logic behind the `pulp_smash.utils.is_root` function. It's a small refactor.

The second commit adds `pulp_smash.cli.PackageManager` and replaces hard-coded references to yum.