### PR TITLE
Add custom exception for failed CLI processes

### DIFF
--- a/pulp_smash/exceptions.py
+++ b/pulp_smash/exceptions.py
@@ -30,6 +30,28 @@ class CallReportError(Exception):
     """
 
 
+class CalledProcessError(Exception):
+    """Indicates a CLI process has a non-zero return code.
+
+    See :meth:`pulp_smash.cli.CompletedProcess` for more information.
+    """
+
+    def __init__(self, args, returncode, stdout, stderr):
+        """An exceptionally simple constructor.
+
+        Pass all arguments to ``super()``.
+        """
+        super().__init__(args, returncode, stdout, stderr)
+
+    def __str__(self):
+        """Provide a human-friendly string representation of this exception."""
+        return (
+            'Command {} returned non-zero exit status {}.\n\n'
+            'stdout: {}\n\n'
+            'stderr: {}'
+        ).format(*self.args)
+
+
 class ConfigFileNotFoundError(Exception):
     """We cannot find the requested Pulp Smash configuration file.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,13 +1,12 @@
 # coding=utf-8
 """Unit tests for :mod:`pulp_smash.cli`."""
 import socket
-import subprocess
 import unittest
 from unittest import mock
 
 from plumbum.machines.local import LocalMachine
 
-from pulp_smash import cli, config, utils
+from pulp_smash import cli, config, exceptions, utils
 
 
 class GetHostnameTestCase(unittest.TestCase):
@@ -95,7 +94,7 @@ class CompletedProcessTestCase(unittest.TestCase):
         """Call ``check_returncode`` when ``returncode`` is not zero."""
         self.kwargs['returncode'] = 1
         completed_proc = cli.CompletedProcess(**self.kwargs)
-        with self.assertRaises(subprocess.CalledProcessError):
+        with self.assertRaises(exceptions.CalledProcessError):
             completed_proc.check_returncode()
 
     def test_can_eval(self):


### PR DESCRIPTION
Add exception `pulp_smash.exceptions.CalledProcessError`. Do this for
two reasons:

* `subprocess.CalledProcessError`, which is shipped with the standard
  library, does not include stdout and stderr information in tracebacks.
  This information is hugely valuable.
* It's good practice for applications to raise expected exceptions from
  their own namespace, so as to provide a better abstraction from
  dependencies.