### PR TITLE
Prevent setup.py from installing a "tests" package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
     ],
-    packages=find_packages(),
+    packages=find_packages(include=['pulp_smash', 'pulp_smash.*']),
     install_requires=[
         'packaging',
         'plumbum',


### PR DESCRIPTION
The `setup.py` script uses function `setuptools.find_packages` to choose
which modules should be installed and which should not. By default, this
function incorrectly includes the top-level "tests" directory. Prevent
this by explicitly whitelisting the modules and packages to be included.

An even better solution is to place unit tests in a top-level "test"
directory. This is a common convention that allows unit tests to be run
on installed packages. However, the exact requirements and conventions
for doing this are unclear.