### PR TITLE
Make test case more resilient against errors

### DIFF
--- a/pulp_smash/tests/rpm/api_v2/test_orphan_remove.py
+++ b/pulp_smash/tests/rpm/api_v2/test_orphan_remove.py
@@ -10,11 +10,12 @@ describes specific tests that should be in this module.
     http://docs.pulpproject.org/en/latest/user-guide/admin-client/orphan.html
 """
 import random
+import unittest
 from urllib.parse import urljoin
 
 from packaging.version import Version
 
-from pulp_smash import api, utils
+from pulp_smash import api, config, selectors, utils
 from pulp_smash.constants import (
     ORPHANS_PATH,
     REPOSITORY_PATH,
@@ -29,55 +30,119 @@ def _count_orphans(orphans):
     return sum(content_type['count'] for content_type in orphans.values())
 
 
-class OrphansTestCase(utils.BaseAPITestCase):
+class OrphansTestCase(unittest.TestCase):
     """Establish that API calls related to orphans function correctly.
 
     At a high level, this test case does the following:
 
-    1. Create an RPM repository with a feed and sync in content. Delete the
+    1. Create an RPM repository and populate it with content. Delete the
        repository, thus leaving behind orphans.
-    2. Make an API call related to orphans, and assert that the call had the
-       desired effect. Repeat as needed.
-
-    .. NOTE:: Though the test_* methods must execute in a specific order, they
-        (should) all function correctly no matter how many other test_* methods
-        fail.
+    2. Make several orphan-related API calls, and assert that each call has the
+       desired effect.
     """
 
     @classmethod
     def setUpClass(cls):
-        """Create, sync and delete an RPM repository.
+        """Create orphans.
 
-        Doing this provides orphans that the remaining test methods can make
-        use of. If this method fails, it's possible that other repositories
-        exist with references to the same content units.
+        Create, sync and delete an RPM repository. Doing this creates orphans
+        that the test methods can make use of.
         """
-        super(OrphansTestCase, cls).setUpClass()
-
-        # Create orphans.
-        client = api.Client(cls.cfg, api.json_handler)
+        cfg = config.get_config()
+        client = api.Client(cfg, api.json_handler)
         body = gen_repo()
         body['importer_config']['feed'] = RPM_SIGNED_FEED_URL
         repo = client.post(REPOSITORY_PATH, body)
         try:
-            utils.sync_repo(cls.cfg, repo['_href'])
+            utils.sync_repo(cfg, repo['_href'])
         finally:
             client.delete(repo['_href'])
+        cls.orphans_available = False
 
-        # Verify that orphans are present. Support for langpack content units
-        # was added in Pulp 2.9.
-        orphans = client.get(ORPHANS_PATH)
-        expected_count = 39
-        if cls.cfg.version >= Version('2.9'):
-            expected_count += 1
+    def test_00_orphans_available(self):
+        """Assert that an expected number of orphans is present.
+
+        If the expected number of orphans is present, set a class variable
+        indicating such. The following test methods can conditionally run or
+        skip based on this variable. If this method fails, it may indicate that
+        other repositories exist and have references to the same content units.
+        """
+        orphans = api.Client(config.get_config()).get(ORPHANS_PATH).json()
         actual_count = _count_orphans(orphans)
-        if expected_count != actual_count:
-            # We can't use fail(), as it's an instance method.
-            raise AssertionError(
-                'Test case setup failed. We attempted to create {} orphans, '
-                'but actually created {}. Orphans: {}'
-                .format(expected_count, actual_count, orphans)
+        # Support for langpack content units was added in Pulp 2.9.
+        expected_count = 39
+        if config.get_config().version >= Version('2.9'):
+            expected_count += 1
+        self.assertEqual(actual_count, expected_count, orphans)
+        type(self).orphans_available = True
+
+    @selectors.skip_if(bool, 'orphans_available', False)
+    def test_01_get_by_href(self):
+        """Get an orphan by its href."""
+        client = api.Client(config.get_config())
+        orphans = client.get(urljoin(ORPHANS_PATH, 'erratum/')).json()
+        orphan = random.choice(orphans)
+        response = client.get(orphan['_href'])
+        with self.subTest(comment='verify status code'):
+            self.assertEqual(response.status_code, 200)
+        with self.subTest(comment='verify href'):
+            self.assertEqual(orphan['_href'], response.json()['_href'])
+
+    @selectors.skip_if(bool, 'orphans_available', False)
+    def test_01_get_by_invalid_type(self):
+        """Get orphans by content type. Specify a non-existent content type."""
+        client = api.Client(config.get_config(), api.echo_handler)
+        response = client.get(urljoin(ORPHANS_PATH, 'foo/'))
+        self.assertEqual(response.status_code, 404)
+
+    @selectors.skip_if(bool, 'orphans_available', False)
+    def test_02_delete_by_href(self):
+        """Delete an orphan by its href."""
+        client = api.Client(config.get_config(), api.json_handler)
+        orphans_pre = client.get(ORPHANS_PATH)
+        orphan = random.choice(client.get(urljoin(ORPHANS_PATH, 'erratum/')))
+        client.delete(orphan['_href'])
+        orphans_post = client.get(ORPHANS_PATH)
+        self.check_one_orphan_deleted(orphans_pre, orphans_post, orphan)
+
+    @selectors.skip_if(bool, 'orphans_available', False)
+    def test_02_delete_by_type_and_id(self):
+        """Delete an orphan by its ID and type.
+
+        This test exercises `Pulp #1923 <https://pulp.plan.io/issues/1923>`_.
+        """
+        client = api.Client(config.get_config(), api.json_handler)
+        orphans_pre = client.get(ORPHANS_PATH)
+        orphan = random.choice(client.get(urljoin(ORPHANS_PATH, 'erratum/')))
+        client.post('pulp/api/v2/content/actions/delete_orphans/', [{
+            'content_type_id': 'erratum',
+            'unit_id': orphan['_id'],
+        }])
+        orphans_post = client.get(ORPHANS_PATH)
+        self.check_one_orphan_deleted(orphans_pre, orphans_post, orphan)
+
+    @selectors.skip_if(bool, 'orphans_available', False)
+    def test_03_delete_by_content_type(self):
+        """Delete orphans by their content type."""
+        client = api.Client(config.get_config(), api.json_handler)
+        orphans_pre = client.get(ORPHANS_PATH)
+        client.delete(urljoin(ORPHANS_PATH, 'erratum/'))
+        orphans_post = client.get(ORPHANS_PATH)
+        with self.subTest(comment='verify total count'):
+            self.assertEqual(
+                _count_orphans(orphans_pre) - orphans_pre['erratum']['count'],
+                _count_orphans(orphans_post),
+                orphans_post,
             )
+        with self.subTest(comment='verify erratum count'):
+            self.assertEqual(orphans_post['erratum']['count'], 0, orphans_post)
+
+    def test_04_delete_all(self):
+        """Delete all orphans."""
+        client = api.Client(config.get_config(), api.json_handler)
+        client.delete(ORPHANS_PATH)
+        orphans = client.get(ORPHANS_PATH)
+        self.assertEqual(_count_orphans(orphans), 0, orphans)
 
     def check_one_orphan_deleted(self, orphans_pre, orphans_post, orphan):
         """Ensure that a specific orphan is well and truly deleted.
@@ -103,69 +168,9 @@ class OrphansTestCase(utils.BaseAPITestCase):
                 orphans_post['erratum']['count'],
                 orphan,
             )
-        response = api.Client(self.cfg, api.echo_handler).get(orphan['_href'])
+        response = api.Client(
+            config.get_config(),
+            api.echo_handler
+        ).get(orphan['_href'])
         with self.subTest(comment='verify erratum is unavailable'):
             self.assertEqual(response.status_code, 404)
-
-    def test_01_get_by_href(self):
-        """Get an orphan by its href."""
-        client = api.Client(self.cfg)
-        orphans = client.get(urljoin(ORPHANS_PATH, 'erratum/')).json()
-        orphan = random.choice(orphans)
-        response = client.get(orphan['_href'])
-        with self.subTest(comment='verify status code'):
-            self.assertEqual(response.status_code, 200)
-        with self.subTest(comment='verify href'):
-            self.assertEqual(orphan['_href'], response.json()['_href'])
-
-    def test_01_get_by_invalid_type(self):
-        """Get orphans by content type. Specify a non-existent content type."""
-        client = api.Client(self.cfg, api.echo_handler)
-        response = client.get(urljoin(ORPHANS_PATH, 'foo/'))
-        self.assertEqual(response.status_code, 404)
-
-    def test_02_delete_by_href(self):
-        """Delete an orphan by its href."""
-        client = api.Client(self.cfg, api.json_handler)
-        orphans_pre = client.get(ORPHANS_PATH)
-        orphan = random.choice(client.get(urljoin(ORPHANS_PATH, 'erratum/')))
-        client.delete(orphan['_href'])
-        orphans_post = client.get(ORPHANS_PATH)
-        self.check_one_orphan_deleted(orphans_pre, orphans_post, orphan)
-
-    def test_02_delete_by_type_and_id(self):
-        """Delete an orphan by its ID and type.
-
-        This test exercises `Pulp #1923 <https://pulp.plan.io/issues/1923>`_.
-        """
-        client = api.Client(self.cfg, api.json_handler)
-        orphans_pre = client.get(ORPHANS_PATH)
-        orphan = random.choice(client.get(urljoin(ORPHANS_PATH, 'erratum/')))
-        client.post('pulp/api/v2/content/actions/delete_orphans/', [{
-            'content_type_id': 'erratum',
-            'unit_id': orphan['_id'],
-        }])
-        orphans_post = client.get(ORPHANS_PATH)
-        self.check_one_orphan_deleted(orphans_pre, orphans_post, orphan)
-
-    def test_03_delete_by_content_type(self):
-        """Delete orphans by their content type."""
-        client = api.Client(self.cfg, api.json_handler)
-        orphans_pre = client.get(ORPHANS_PATH)
-        client.delete(urljoin(ORPHANS_PATH, 'erratum/'))
-        orphans_post = client.get(ORPHANS_PATH)
-        with self.subTest(comment='verify total count'):
-            self.assertEqual(
-                _count_orphans(orphans_pre) - orphans_pre['erratum']['count'],
-                _count_orphans(orphans_post),
-                orphans_post,
-            )
-        with self.subTest(comment='verify erratum count'):
-            self.assertEqual(orphans_post['erratum']['count'], 0, orphans_post)
-
-    def test_04_delete_all(self):
-        """Delete all orphans."""
-        client = api.Client(self.cfg, api.json_handler)
-        client.delete(ORPHANS_PATH)
-        orphans = client.get(ORPHANS_PATH)
-        self.assertEqual(_count_orphans(orphans), 0, orphans)


### PR DESCRIPTION
Add a new method, `pulp_smash.selectors.skip_if`. This method is similar
to `@unittest.skipIf`, but more flexible: it lets one execute skipping
logic at runtime and is capable of accessing class and instance
attributes.

Why make this method available? It exists because of the structure of
the unittest module:

1. The `setUpClass` method lacks access to certain tools like the
   `addCleanup` method. As a result, it is desirable to move
   failure-prone code to other locations, such as test methods.
2. Some failure-prone code should control whether or not the test
   methods in a test case should execute, but this is difficult to do,
   because all test methods execute regardless of how many test methods
   execute.
3. The `skip_if` decorator lets one move failure-prone code into a
   regular test method *and* control whether subsequent test methods
   execute.

This decorator may make it easier to avoid
`pulp_smash.utils.BaseAPITestCase`.