### PR TITLE
Use sudo when running getfattr

### DIFF
--- a/pulp_smash/tests/platform/cli/test_selinux.py
+++ b/pulp_smash/tests/platform/cli/test_selinux.py
@@ -125,6 +125,8 @@ class FileLabelsTestCase(unittest.TestCase):
         #     security.selinux="system_u:object_r:passwd_file_t:s0"
         #
         cmd = ['getfattr', '--name=security.selinux', file_]
+        if not utils.is_root(config.get_config()):
+            cmd.insert(0, 'sudo')
         if recursive:
             cmd.insert(1, '--recursive')
         lines = self.client.run(cmd).stdout.splitlines()


### PR DESCRIPTION
Using sudo if not root use will prevent permission denied error when
trying to getfattr on /var/log/pulp.