### PR TITLE
Replace Service with ServiceManager

### DIFF
--- a/pulp_smash/tests/rpm/cli/test_process_recycling.py
+++ b/pulp_smash/tests/rpm/cli/test_process_recycling.py
@@ -22,11 +22,9 @@ def restart_pulp(cfg):
     :param pulp_smash.config.ServerConfig cfg: Information about the Pulp
         server being targeted.
     """
-    services = tuple((cli.Service(cfg, service) for service in PULP_SERVICES))
-    for service in services:
-        service.stop()
-    for service in services:
-        service.start()
+    svc_mgr = cli.ServiceManager(cfg)
+    svc_mgr.stop(PULP_SERVICES)
+    svc_mgr.start(PULP_SERVICES)
 
 
 def get_pulp_worker_procs(cfg):

--- a/pulp_smash/utils.py
+++ b/pulp_smash/utils.py
@@ -37,12 +37,11 @@ def get_broker(server_config):
 
     Talk to the host named by ``server_config`` and use simple heuristics to
     determine which AMQP broker is installed. If Qpid or RabbitMQ appear to be
-    installed, return a :class:`pulp_smash.cli.Service` object for managing
-    those services respectively. Otherwise, raise an exception.
+    installed, return the name of that service. Otherwise, raise an exception.
 
     :param pulp_smash.config.ServerConfig server_config: Information about the
         system on which an AMQP broker exists.
-    :rtype: pulp_smash.cli.Service
+    :returns: A string such as 'qpidd' or 'rabbitmq'.
     :raises pulp_smash.exceptions.NoKnownBrokerError: If unable to find any
         AMQP brokers on the target system.
     """
@@ -55,7 +54,7 @@ def get_broker(server_config):
     for executable in executables:
         command = ('test', '-e', '/usr/sbin/' + executable)
         if client.run(command).returncode == 0:
-            return cli.Service(server_config, executable)
+            return executable
     raise exceptions.NoKnownBrokerError(
         'Unable to determine the AMQP broker used by {}. It does not appear '
         'to be any of {}.'
@@ -96,11 +95,8 @@ def reset_pulp(server_config):
         Pulp server being targeted.
     :returns: Nothing.
     """
-    services = tuple((
-        cli.Service(server_config, service) for service in PULP_SERVICES
-    ))
-    for service in services:
-        service.stop()
+    svc_mgr = cli.ServiceManager(server_config)
+    svc_mgr.stop(PULP_SERVICES)
 
     # Reset the database and nuke accumulated files.
     #
@@ -120,8 +116,7 @@ def reset_pulp(server_config):
     client.run((prefix + 'rm -rf /var/lib/pulp/content').split())
     client.run((prefix + 'rm -rf /var/lib/pulp/published').split())
 
-    for service in services:
-        service.start()
+    svc_mgr.start(PULP_SERVICES)
 
 
 def upload_import_unit(server_config, unit, unit_type_id, repo_href):
@@ -377,8 +372,8 @@ def reset_squid(server_config):
         Pulp server being targeted.
     :returns: Nothing.
     """
-    squid_service = cli.Service(server_config, 'squid')
-    squid_service.stop()
+    svc_mgr = cli.ServiceManager(server_config)
+    svc_mgr.stop(('squid',))
 
     # Clean out the cache directory and reinitialize it.
     client = cli.Client(server_config)
@@ -389,7 +384,7 @@ def reset_squid(server_config):
     client.run((prefix + 'chown squid:squid /var/spool/squid').split())
     client.run((prefix + 'squid -z').split())
 
-    squid_service.start()
+    svc_mgr.start(('squid',))
 
 
 def skip_if_type_is_unsupported(unit_type_id, server_config=None):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -128,38 +128,3 @@ class ClientTestCase(unittest.TestCase):
         cfg = config.ServerConfig(utils.uuid4(), cli_transport='local')
         handler = mock.Mock()
         self.assertIs(cli.Client(cfg, handler).response_handler, handler)
-
-
-class ServiceTestCase(unittest.TestCase):
-    """Tests for :class:`pulp_smash.cli.Service`."""
-
-    @classmethod
-    def setUpClass(cls):
-        """Instantiate and save :class:`pulp_smash.cli.Service` objects.
-
-        Give each object a different service manager (systemd, sysv, etc).
-        """
-        cls.services = []
-        with mock.patch.object(cli, '_is_root', return_value=True):
-            with mock.patch.object(cli, 'Client'):
-                for service_manager in ('systemd', 'sysv'):
-                    with mock.patch.object(
-                        cli.Service,
-                        '_get_service_manager',
-                        return_value=service_manager,
-                    ):
-                        service = cli.Service(mock.Mock(), mock.Mock())
-                        cls.services.append(service)
-
-    def test_command_builder(self):
-        """Assert the ``_command_builder`` attribute is not ``None``.
-
-        Tests of this sort aren't usually valuable. But in this case, it's
-        fairly easy for a developer to simply make a mistake when editing the
-        tightly related logic in ``__init__`` and ``_get_service_manager``.
-        This may be a sign of bad design.
-        """
-        for i, service in enumerate(self.services):
-            with self.subTest(i=i):
-                # pylint:disable=protected-access
-                self.assertIsNotNone(service._command_builder)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -24,17 +24,14 @@ class GetBrokerTestCase(unittest.TestCase):
 
         Assert that:
 
-        * ``get_broker(…)`` returns ``Service(…)``.
+        * ``get_broker(…)`` returns a string.
         * The ``server_config`` argument is passed to the service object.
         * The "qpidd" broker is the preferred broker.
         """
-        server_config = mock.Mock()
         with mock.patch.object(cli, 'Client') as client:
             client.return_value.run.return_value.returncode = 0
-            with mock.patch.object(cli, 'Service') as service:
-                broker = utils.get_broker(server_config)
-        self.assertEqual(service.return_value, broker)
-        self.assertEqual(service.call_args[0], (server_config, 'qpidd'))
+            broker = utils.get_broker(server_config=mock.Mock())
+        self.assertEqual(broker, 'qpidd')
 
     def test_failure(self):
         """Fail to generate a broker service management object.


### PR DESCRIPTION
The `Service` class represents a service (such as httpd) on a host. It
provides methods such as `start` and `stop`, and it abstracts away which
service manager is in use on the target host.

A drawback of the `Service` class is that it encourages serial code to
be written. If three services are to be restarted, it's easy to write
something like this:

    services = (Service(cfg, name) for name in ('foo', 'bar', 'biz'))
    for service in services:
        service.stop()
    for service in services:
        service.start()

The `ServiceManager` class represents the service manager (such as
systemctl) on a host. It's used like so:

    services = ('foo', 'bar', 'biz')
    svc_mgr = ServiceManager(cfg)
    svc_mgr.stop(services)
    svc_mgr.start(services)

Depending on the service manager used by the target system, `stop` and
`start` dispatch commands to the target system either in serial or in
parallel. This has the potential to improve runtime performance.