### PR TITLE
Skip some orphan tests for older versions of Pulp

### DIFF
--- a/pulp_smash/tests/rpm/api_v2/test_orphan_remove.py
+++ b/pulp_smash/tests/rpm/api_v2/test_orphan_remove.py
@@ -131,6 +131,8 @@ class OrphansTestCase(unittest.TestCase):
         call_report = client.delete(urljoin(ORPHANS_PATH, 'erratum/'))
         orphans_post = client.get(ORPHANS_PATH)
         with self.subTest(comment='verify "result" field'):
+            if selectors.bug_is_untestable(1268, cfg.version):
+                self.skipTest('https://pulp.plan.io/issues/1268')
             task = tuple(api.poll_spawned_tasks(cfg, call_report))[-1]
             self.assertIsInstance(task['result'], int)
             self.assertGreater(task['result'], 0)
@@ -147,6 +149,8 @@ class OrphansTestCase(unittest.TestCase):
         """Delete all orphans."""
         cfg = config.get_config()
         call_report = api.Client(cfg).delete(ORPHANS_PATH).json()
+        if selectors.bug_is_untestable(1268, cfg.version):
+            self.skipTest('https://pulp.plan.io/issues/1268')
         task = tuple(api.poll_spawned_tasks(cfg, call_report))[-1]
         self.assertIsInstance(task['result'], dict)
         self.assertGreater(sum(task['result'].values()), 0)


### PR DESCRIPTION
As of Pulp 2.12.0, Pulp reports how many content units were deleted when
a DELETE /pulp/api/v2/content/orphans/ API call is made. Only make
assertions about this fact when the Pulp system under test is Pulp
2.12.0 or newer.

See: https://pulp.plan.io/issues/1268

See: 0a063c063defaec4dd122974ca4f99716ab823b4