### PR TITLE
Change how package paths are calculated

### DIFF
--- a/pulp_smash/tests/rpm/api_v2/utils.py
+++ b/pulp_smash/tests/rpm/api_v2/utils.py
@@ -5,6 +5,8 @@ import io
 from urllib.parse import urljoin
 from xml.etree import ElementTree
 
+from packaging.version import Version
+
 from pulp_smash import api, cli, selectors, utils
 from pulp_smash.constants import RPM_NAMESPACES
 
@@ -229,7 +231,12 @@ def get_unit(cfg, repo, unit_name, distributor=None):
                 .format(repo['distributors'])
             )
         distributor = repo['distributors'][0]
-    path = urljoin('/pulp/repos/', distributor['config']['relative_url'] + '/')
+    path = urljoin('/pulp/repos/', distributor['config']['relative_url'])
+    if not path.endswith('/'):
+        path += '/'
+    if cfg.version >= Version('2.12'):
+        path = urljoin(path, 'Packages/')
+        path = urljoin(path, unit_name[0] + '/')  # first letter
     path = urljoin(path, unit_name)
     return api.Client(cfg).get(path)
 


### PR DESCRIPTION
The paths to packages in published repositories have changed. In Pulp
2.11 and earlier, packages ended up in the root of published
repositories, alongside the "repodata" directory. In Pulp 2.12, packages
default to being placed elsewhere, and users have the option to
customize the exact path.

The end result of this change is that clients should consult the
`repodata/...primary.xml` file when finding packages. This commit is not
so elegant, and instead implements a stop-gap solution. This stop-gap
solution should fix many broken tests, but does not yet consult with the
XML files.

See: https://github.com/PulpQE/pulp-smash/issues/472