### PR TITLE
Add tests for ISO repos from a feed URL

### DIFF
--- a/pulp_smash/api.py
+++ b/pulp_smash/api.py
@@ -71,7 +71,7 @@ def _check_tasks(tasks):
             if task[field] is not None:
                 msg = 'Task report {} contains a {}: {}\nFull task report: {}'
                 msg = msg.format(task['_href'], field, task[field], task)
-                raise exceptions.TaskReportError(msg)
+                raise exceptions.TaskReportError(msg, task)
 
 
 def _handle_202(server_config, response):

--- a/pulp_smash/constants.py
+++ b/pulp_smash/constants.py
@@ -108,6 +108,12 @@ DRPM_UNSIGNED_URL = urljoin(DRPM_UNSIGNED_FEED_URL, DRPM)
 Built from :data:`DRPM_UNSIGNED_FEED_URL` and :data:`DRPM`.
 """
 
+FILE_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'file/')
+"""The URL to a file repository."""
+
+FILE_MIXED_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'file-mixed/')
+"""The URL to a file repository containing invalid and valid entries."""
+
 ERROR_KEYS = frozenset((
     '_href',
     'error',

--- a/pulp_smash/exceptions.py
+++ b/pulp_smash/exceptions.py
@@ -101,6 +101,11 @@ class TaskReportError(Exception):
         http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/tasks.html
     """
 
+    def __init__(self, msg, task, *args, **kwargs):
+        """Require that a task object is defined."""
+        super().__init__(msg, task, *args, **kwargs)
+        self.task = task
+
 
 class TaskTimedOutError(Exception):
     """We timed out while polling a task and waiting for it to complete.


### PR DESCRIPTION
Added two commits:

1. Added `task` attr to TaskReportError to allow inspecting the failed task information
2. Added the tests to make sure Pulp will properly handle valid file feed and invalid file feed. In the latter it should fail stating all the files that were not able to find. 

Fix #482 