### PR TITLE
Fix several tests that rely on package paths

### DIFF
--- a/pulp_smash/tests/rpm/api_v2/test_packages_directory.py
+++ b/pulp_smash/tests/rpm/api_v2/test_packages_directory.py
@@ -12,6 +12,8 @@ import os
 import unittest
 from urllib.parse import urljoin
 
+from packaging.version import Version
+
 from pulp_smash import api, selectors, utils
 from pulp_smash.constants import (
     REPOSITORY_PATH,
@@ -129,7 +131,12 @@ class PackagesDirectoryTestCase(utils.BaseAPITestCase):
         self.assertGreater(len(package_hrefs), 0)
         for package_href in package_hrefs:
             with self.subTest(package_href=package_href):
-                self.assertEqual(os.path.dirname(package_href), '')
+                dirname = os.path.dirname(package_href)
+                if self.cfg.version < Version('2.12'):
+                    self.assertEqual(dirname, '')
+                else:
+                    # e.g. 'Packages/a'[:-1] == 'Packages/'
+                    self.assertEqual(dirname[:-1], 'Packages/')
 
     def test_distributor_config(self):
         """Use the ``packages_directory`` distributor option.

--- a/pulp_smash/tests/rpm/api_v2/test_republish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_republish.py
@@ -14,125 +14,61 @@ import random
 import unittest
 from urllib.parse import urljoin
 
-from pulp_smash import api, utils
+from requests.exceptions import HTTPError
+
+from pulp_smash import api, config, utils
 from pulp_smash.constants import REPOSITORY_PATH, RPM_SIGNED_FEED_URL
-from pulp_smash.tests.rpm.api_v2.utils import gen_distributor, gen_repo
+from pulp_smash.tests.rpm.api_v2.utils import (
+    find_units,
+    gen_distributor,
+    gen_repo,
+    get_unit,
+)
 from pulp_smash.tests.rpm.utils import check_issue_2277
 from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 _PUBLISH_DIR = 'pulp/repos/'
 
 
-class RepublishTestCase(utils.BaseAPITestCase):
+class RepublishTestCase(unittest.TestCase):
     """Test re-publish repository after unassociating content."""
 
-    @classmethod
-    def setUpClass(cls):
+    def test_all(self):
         """Create one repository with feed, unassociate unit and re-publish.
 
         Following steps are executed:
 
-        1. Create repository foo with feed, sync and publish it.
-        2. Get an unit X and assert it is accessible.
-        3. Remove unit X from repository foo and re-publish foo.
-        4. Get same unit X and assert it is not accessible.
+        1. Create, sync and publish a repository.
+        2. Pick a content unit from the repository and verify it can be
+           downloaded.
+        3. Remove the content unit from the repository, re-publish, and verify
+           it can't be downloaded.
         """
-        super(RepublishTestCase, cls).setUpClass()
-        if check_issue_2277(cls.cfg):
+        cfg = config.get_config()
+        if check_issue_2277(cfg):
             raise unittest.SkipTest('https://pulp.plan.io/issues/2277')
-        cls.responses = {}
 
-        # Create and sync a repository.
-        client = api.Client(cls.cfg)
+        # Create, sync and publish a repository.
+        client = api.Client(cfg, api.json_handler)
         body = gen_repo()
         body['importer_config']['feed'] = RPM_SIGNED_FEED_URL
-        repo_href = client.post(REPOSITORY_PATH, body).json()['_href']
-        cls.resources.add(repo_href)  # mark for deletion
-        cls.responses['sync'] = utils.sync_repo(cls.cfg, repo_href)
+        body['distributors'] = [gen_distributor()]
+        repo = client.post(REPOSITORY_PATH, body)
+        self.addCleanup(client.delete, repo['_href'])
+        repo = client.get(repo['_href'], params={'details': True})
+        utils.sync_repo(cfg, repo['_href'])
+        utils.publish_repo(cfg, repo)
 
-        # Add a distributor and publish it.
-        cls.responses['distribute'] = client.post(
-            urljoin(repo_href, 'distributors/'),
-            gen_distributor(),
+        # Pick a random content unit and verify it's accessible.
+        unit = random.choice(find_units(cfg, repo, {'type_ids': ('rpm',)}))
+        filename = unit['metadata']['filename']
+        get_unit(cfg, repo, filename)
+
+        # Remove the content unit and verify it's inaccessible.
+        client.post(
+            urljoin(repo['_href'], 'actions/unassociate/'),
+            {'criteria': {'filters': {'unit': {'filename': filename}}}},
         )
-        cls.responses['first publish'] = client.post(
-            urljoin(repo_href, 'actions/publish/'),
-            {'id': cls.responses['distribute'].json()['id']},
-        )
-
-        # Get contents of repository
-        cls.responses['repo units'] = client.post(
-            urljoin(repo_href, 'search/units/'),
-            {'criteria': {}},
-        )
-
-        # Get random unit from repository to remove
-        removed_unit = random.choice([
-            unit['metadata']['filename']
-            for unit in cls.responses['repo units'].json()
-            if unit['unit_type_id'] == 'rpm'
-        ])
-
-        # Download the RPM from repository.
-        url = urljoin(
-            '/pulp/repos/',
-            cls.responses['distribute'].json()['config']['relative_url']
-        )
-        url = urljoin(url, removed_unit)
-        cls.responses['first get'] = client.get(url)
-
-        # Remove unit from the repo
-        cls.responses['remove unit'] = client.post(
-            urljoin(repo_href, 'actions/unassociate/'),
-            {
-                'criteria': {
-                    'fields': {
-                        'unit': [
-                            'arch',
-                            'checksum',
-                            'checksumtype',
-                            'epoch',
-                            'name',
-                            'release',
-                            'version',
-                        ]
-                    },
-                    'type_ids': ['rpm'],
-                    'filters': {
-                        'unit': {'filename': removed_unit}
-                    }
-                }
-            },
-        )
-
-        # Publish the repo again
-        cls.responses['second publish'] = client.post(
-            urljoin(repo_href, 'actions/publish/'),
-            {'id': cls.responses['distribute'].json()['id']},
-        )
-
-        # Download the RPM from repository.
-        url = urljoin(
-            '/pulp/repos/',
-            cls.responses['distribute'].json()['config']['relative_url']
-        )
-        url = urljoin(url, removed_unit)
-        client.response_handler = api.echo_handler
-        cls.responses['second get'] = client.get(url)
-
-    def test_publishes_succeed(self):
-        """Verify the HTTP status code of each publish."""
-        for step, code in (
-                ('first publish', 202),
-                ('second publish', 202),
-        ):
-            with self.subTest(step=step):
-                self.assertEqual(self.responses[step].status_code, code)
-
-    def test_rpm_can_be_accessed(self):
-        """Test rpm can be accessed after first publish."""
-        self.assertEqual(self.responses['first get'].status_code, 200)
-
-    def test_rpm_cannot_be_accessed(self):
-        """Test rpm cannot be accessed after its removal and re-publish."""
-        self.assertEqual(self.responses['second get'].status_code, 404)
+        utils.publish_repo(cfg, repo)
+        with self.assertRaises(HTTPError):
+            get_unit(cfg, repo, filename)


### PR DESCRIPTION
As of Pulp 2.12, the layout of published RPM repositories has changed.
Fix several tests, so that they work with both earlier and later
versions of Pulp.