### PR TITLE
Login before creating a repo for CLI search test

### DIFF
--- a/pulp_smash/tests/rpm/cli/test_search.py
+++ b/pulp_smash/tests/rpm/cli/test_search.py
@@ -21,7 +21,9 @@ class SearchReposWithFiltersTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Create a repository."""
-        cls.client = cli.Client(config.get_config())
+        cfg = config.get_config()
+        utils.pulp_admin_login(cfg)
+        cls.client = cli.Client(cfg)
         cls.repo_id = utils.uuid4()
         cls.client.run(
             'pulp-admin rpm repo create --repo-id {}'


### PR DESCRIPTION
Run pulp_admin_login before creating a repository on search tests, that
will ensure the login certificates are in place and the repository can
be created.

This fixes an automation failure.