### PR TITLE
Fix documentation

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -78,9 +78,9 @@ developers, not a gospel.
     api/pulp_smash.tests.rpm.api_v2.test_no_op_publish
     api/pulp_smash.tests.rpm.api_v2.test_orphan_remove
     api/pulp_smash.tests.rpm.api_v2.test_package_paths
-    api/pulp_smash.tests.rpm.api_v2.test_packages_directory
     api/pulp_smash.tests.rpm.api_v2.test_remove_unit
     api/pulp_smash.tests.rpm.api_v2.test_repomd
+    api/pulp_smash.tests.rpm.api_v2.test_repository_layout
     api/pulp_smash.tests.rpm.api_v2.test_repoview
     api/pulp_smash.tests.rpm.api_v2.test_republish
     api/pulp_smash.tests.rpm.api_v2.test_retain_old_count

--- a/docs/api/pulp_smash.tests.rpm.api_v2.test_packages_directory.rst
+++ b/docs/api/pulp_smash.tests.rpm.api_v2.test_packages_directory.rst
@@ -1,6 +1,0 @@
-`pulp_smash.tests.rpm.api_v2.test_packages_directory`
-=====================================================
-
-Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.rpm.api_v2.test_packages_directory`
-
-.. automodule:: pulp_smash.tests.rpm.api_v2.test_packages_directory

--- a/docs/api/pulp_smash.tests.rpm.api_v2.test_repository_layout.rst
+++ b/docs/api/pulp_smash.tests.rpm.api_v2.test_repository_layout.rst
@@ -1,0 +1,6 @@
+`pulp_smash.tests.rpm.api_v2.test_repository_layout`
+====================================================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.rpm.api_v2.test_repository_layout`
+
+.. automodule:: pulp_smash.tests.rpm.api_v2.test_repository_layout


### PR DESCRIPTION
The toctree in docs/api.rst and several other supporting files were out
of date.

See: d90fe0a6ec36a6e3c0fb5bc4aaf5ffe6b82a65a7