### PR TITLE
Update export distributor package path

### DIFF
--- a/pulp_smash/tests/rpm/api_v2/test_export.py
+++ b/pulp_smash/tests/rpm/api_v2/test_export.py
@@ -474,10 +474,15 @@ class ExportDistributorTestCase(ExportDirMixin, utils.BaseAPITestCase):
             self.repo['_href'],
             self.distributor['id'],
         )
-        actual = cli.Client(self.cfg).run(('sha256sum', os.path.join(
+        path = os.path.join(
             export_dir,
             self.distributor['config']['relative_url'],
-            RPM,
-        ))).stdout.strip().split()[0]
+        )
+        if self.cfg.version >= Version('2.12'):
+            path = os.path.join(path, 'Packages', RPM[0], RPM)
+        else:
+            path = os.path.join(path, RPM)
+        actual = cli.Client(self.cfg).run(
+            ('sha256sum', path)).stdout.strip().split()[0]
         expect = utils.get_sha256_checksum(RPM_SIGNED_URL)
         self.assertEqual(actual, expect)


### PR DESCRIPTION
Make sure to use the new repository layout when asserting for RPMs
exported to a directory by the export distributor. Use the old layout
when testing Pulp < 2.12.