### PR TITLE
Make get_unit() use repodata/*.xml

### DIFF
--- a/pulp_smash/tests/rpm/api_v2/test_broker.py
+++ b/pulp_smash/tests/rpm/api_v2/test_broker.py
@@ -114,7 +114,7 @@ class BrokerTestCase(unittest.TestCase):
         repo = client.get(repo['_href'], params={'details': True})
         utils.sync_repo(self.cfg, repo['_href'])
         utils.publish_repo(self.cfg, repo)
-        pulp_rpm = get_unit(self.cfg, repo, RPM).content
+        pulp_rpm = get_unit(self.cfg, repo['distributors'][0], RPM).content
 
         # Does this RPM match the original RPM?
         rpm = utils.http_get(RPM_SIGNED_URL)

--- a/pulp_smash/tests/rpm/api_v2/test_download_policies.py
+++ b/pulp_smash/tests/rpm/api_v2/test_download_policies.py
@@ -95,7 +95,7 @@ class BackgroundTestCase(utils.BaseAPITestCase):
         cls.tasks = tuple(api.poll_spawned_tasks(cls.cfg, report))
 
         # Download an RPM.
-        cls.rpm = get_unit(cls.cfg, cls.repo, RPM)
+        cls.rpm = get_unit(cls.cfg, cls.repo['distributors'][0], RPM)
 
     def test_repo_local_units(self):
         """Assert that all content is downloaded for the repository."""
@@ -165,8 +165,8 @@ class OnDemandTestCase(utils.BaseAPITestCase):
         cls.repo = client.get(repo['_href'], params={'details': True}).json()
 
         # Download the same RPM twice.
-        cls.rpm = get_unit(cls.cfg, cls.repo, RPM)
-        cls.same_rpm = get_unit(cls.cfg, cls.repo, RPM)
+        cls.rpm = get_unit(cls.cfg, cls.repo['distributors'][0], RPM)
+        cls.same_rpm = get_unit(cls.cfg, cls.repo['distributors'][0], RPM)
 
     def test_local_units(self):
         """Assert no content units were downloaded besides metadata."""
@@ -391,7 +391,7 @@ class SwitchPoliciesTestCase(utils.BaseAPITestCase):
     def _assert_background_immediate(self, repo):
         """Common assertions for background and immediate download policies."""
         # Download an RPM.
-        rpm = get_unit(self.cfg, repo, RPM)
+        rpm = get_unit(self.cfg, repo['distributors'][0], RPM)
 
         # Assert that all content is downloaded for the repository.
         self.assertEqual(
@@ -455,8 +455,8 @@ class SwitchPoliciesTestCase(utils.BaseAPITestCase):
         self.assertEqual(repo['total_repository_units'], total_units)
 
         # Download the same RPM twice.
-        rpm = get_unit(self.cfg, repo, RPM)
-        same_rpm = get_unit(self.cfg, repo, RPM)
+        rpm = get_unit(self.cfg, repo['distributors'][0], RPM)
+        same_rpm = get_unit(self.cfg, repo['distributors'][0], RPM)
 
         # Assert the initial request received a 302 Redirect.
         self.assertTrue(rpm.history[0].is_redirect)

--- a/pulp_smash/tests/rpm/api_v2/test_mirrorlist.py
+++ b/pulp_smash/tests/rpm/api_v2/test_mirrorlist.py
@@ -132,7 +132,7 @@ class GoodMirrorlistTestCase(UtilsMixin, unittest.TestCase):
         repo = self.create_repo(cfg, RPM_MIRRORLIST_GOOD)
         utils.sync_repo(cfg, repo['_href'])
         utils.publish_repo(cfg, repo)
-        actual_rpm = get_unit(cfg, repo, RPM).content
+        actual_rpm = get_unit(cfg, repo['distributors'][0], RPM).content
         target_rpm = utils.http_get(RPM_UNSIGNED_URL)
         self.assertEqual(actual_rpm, target_rpm)
 
@@ -148,7 +148,7 @@ class GoodRelativeUrlTestCase(UtilsMixin, unittest.TestCase):
         repo = self.create_repo(cfg, RPM_MIRRORLIST_GOOD, _gen_rel_url())
         utils.sync_repo(cfg, repo['_href'])
         utils.publish_repo(cfg, repo)
-        actual_rpm = get_unit(cfg, repo, RPM).content
+        actual_rpm = get_unit(cfg, repo['distributors'][0], RPM).content
         target_rpm = utils.http_get(RPM_UNSIGNED_URL)
         self.assertEqual(actual_rpm, target_rpm)
 
@@ -170,7 +170,7 @@ class MixedMirrorlistTestCase(UtilsMixin, unittest.TestCase):
         repo = self.create_repo(cfg, RPM_MIRRORLIST_MIXED)
         utils.sync_repo(cfg, repo['_href'])
         utils.publish_repo(cfg, repo)
-        actual_rpm = get_unit(cfg, repo, RPM).content
+        actual_rpm = get_unit(cfg, repo['distributors'][0], RPM).content
         target_rpm = utils.http_get(RPM_UNSIGNED_URL)
         self.assertEqual(actual_rpm, target_rpm)
 
@@ -186,7 +186,7 @@ class MixedRelativeUrlTestCase(UtilsMixin, unittest.TestCase):
         repo = self.create_repo(cfg, RPM_MIRRORLIST_MIXED, _gen_rel_url())
         utils.sync_repo(cfg, repo['_href'])
         utils.publish_repo(cfg, repo)
-        actual_rpm = get_unit(cfg, repo, RPM).content
+        actual_rpm = get_unit(cfg, repo['distributors'][0], RPM).content
         target_rpm = utils.http_get(RPM_UNSIGNED_URL)
         self.assertEqual(actual_rpm, target_rpm)
 

--- a/pulp_smash/tests/rpm/api_v2/test_package_paths.py
+++ b/pulp_smash/tests/rpm/api_v2/test_package_paths.py
@@ -84,7 +84,9 @@ class ReuseContentTestCase(unittest.TestCase):
         rpms = []
         for repo in repos:
             with self.subTest(repo=repo):
-                rpms.append(get_unit(cfg, repo, RPM).content)
+                rpms.append(
+                    get_unit(cfg, repo['distributors'][0], RPM).content
+                )
         self.assertEqual(len(rpms), len(repos))
         self.assertEqual(rpms[0], rpms[1], repos)
 

--- a/pulp_smash/tests/rpm/api_v2/test_republish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_republish.py
@@ -14,8 +14,6 @@ import random
 import unittest
 from urllib.parse import urljoin
 
-from requests.exceptions import HTTPError
-
 from pulp_smash import api, config, utils
 from pulp_smash.constants import REPOSITORY_PATH, RPM_SIGNED_FEED_URL
 from pulp_smash.tests.rpm.api_v2.utils import (
@@ -62,7 +60,7 @@ class RepublishTestCase(unittest.TestCase):
         # Pick a random content unit and verify it's accessible.
         unit = random.choice(find_units(cfg, repo, {'type_ids': ('rpm',)}))
         filename = unit['metadata']['filename']
-        get_unit(cfg, repo, filename)
+        get_unit(cfg, repo['distributors'][0], filename)
 
         # Remove the content unit and verify it's inaccessible.
         client.post(
@@ -70,5 +68,5 @@ class RepublishTestCase(unittest.TestCase):
             {'criteria': {'filters': {'unit': {'filename': filename}}}},
         )
         utils.publish_repo(cfg, repo)
-        with self.assertRaises(HTTPError):
-            get_unit(cfg, repo, filename)
+        with self.assertRaises(KeyError):
+            get_unit(cfg, repo['distributors'][0], filename)

--- a/pulp_smash/tests/rpm/api_v2/test_upload_publish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_upload_publish.py
@@ -363,7 +363,7 @@ class UploadRpmTestCase(utils.BaseAPITestCase):
 
         Verify that it is exactly equal to the one uploaded earlier.
         """
-        repo_rpm = get_unit(self.cfg, repo, RPM).content
+        repo_rpm = get_unit(self.cfg, repo['distributors'][0], RPM).content
         self.assertEqual(self.rpm, repo_rpm)
 
 


### PR DESCRIPTION
When an RPM repository is published, several XML files are placed in a
`repodata/` directory. These XML files describe various attributes of
the repository, including the relative paths to the RPM files. Make
function `pulp_smash.tests.rpm.api_v2.utils.get_unit` use these XML
files.

Fix: https://github.com/PulpQE/pulp-smash/issues/472