### PR TITLE
Better manage pulp_manage_rsync SELinux policy

### DIFF
--- a/pulp_smash/tests/rpm/api_v2/test_rsync_distributor.py
+++ b/pulp_smash/tests/rpm/api_v2/test_rsync_distributor.py
@@ -176,16 +176,18 @@ def _set_pulp_manage_rsync(cfg, boolean):
         ``pulp_manage_rsync`` SELinux policy should be turned on or off.
     :rtype: pulp_smash.cli.CompletedProcess
     """
-    policy = 'pulp_manage_rsync'
+    sudo = () if utils.is_root(cfg) else ('sudo',)
     client = cli.Client(cfg)
     try:
-        client.run(('which', 'semanage'))
+        # semanage is installed at /sbin/semanage on some distros, and requires
+        # root privileges to discover.
+        client.run(sudo + ('which', 'semanage'))
     except exceptions.CalledProcessError:
         return
-    cmd = [] if utils.is_root(cfg) else ['sudo']
-    cmd.extend(['semanage', 'boolean', '--modify'])
-    cmd.append('--on' if boolean else '--off')
-    cmd.append(policy)
+    cmd = sudo
+    cmd += ('semanage', 'boolean', '--modify')
+    cmd += ('--on',) if boolean else ('--off',)
+    cmd += ('pulp_manage_rsync',)
     return client.run(cmd)
 
 


### PR DESCRIPTION
Module `pulp_smash.tests.rpm.api_v2.test_rsync_distributor` manages the
`pulp_manage_rsync` SELinux policy if appropriate. As part of that task,
it executes `which semanage`. On some platforms, the executable is
installed in `/sbin`, which causes the check to fail when run as a
non-root user.

Fix this check to use `sudo` if appropriate.