### PR TITLE
Rewrite Python tests

### DIFF
--- a/pulp_smash/constants.py
+++ b/pulp_smash/constants.py
@@ -238,17 +238,22 @@ to Pulp.
     http://projects.puppetlabs.com/projects/module-site/wiki/Server-api
 """
 
-PYTHON_PULP_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'python-pulp/')
-"""The URL to a Pulp Python repository."""
-
-PYTHON_EGG_URL = urljoin(
-    PYTHON_PULP_FEED_URL,
-    'packages/source/s/shelf-reader/shelf-reader-0.1.tar.gz'
-)
-"""The URL to a Python egg at :data:`PYTHON_PULP_FEED_URL`."""
-
 PYTHON_PYPI_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'python-pypi/')
 """The URL to the PyPI Python repository."""
+
+PYTHON_EGG_URL = urljoin(
+    PYTHON_PYPI_FEED_URL,
+    'packages/3a/e3/a6954c4134a899c0006515fbd40208922572947e960b35d0d19fd5a1b3'
+    'd0/shelf-reader-0.1.tar.gz'
+)
+"""The URL to a Python egg at :data:`PYTHON_PYPI_FEED_URL`."""
+
+PYTHON_WHEEL_URL = urljoin(
+    PYTHON_PYPI_FEED_URL,
+    'packages/77/e0/2156a3da94ee16466a5936394caf7e89873a9b46eed72a9912bc90e42d'
+    'bf/shelf_reader-0.1-py2-none-any.whl'
+)
+"""The URL to a Python egg at :data:`PYTHON_PYPI_FEED_URL`."""
 
 REPOSITORY_EXPORT_DISTRIBUTOR = 'export_distributor'
 """A ``distributor_type_id`` to export a repository.

--- a/pulp_smash/tests/python/api_v2/utils.py
+++ b/pulp_smash/tests/python/api_v2/utils.py
@@ -1,6 +1,9 @@
 # coding=utf-8
 """Utility functions for Python API tests."""
-from pulp_smash import utils
+import io
+from urllib.parse import urljoin
+
+from pulp_smash import api, constants, utils
 
 
 def gen_repo():
@@ -11,3 +14,72 @@ def gen_repo():
         'importer_type_id': 'python_importer',
         'notes': {'_repo-type': 'PYTHON'},
     }
+
+
+def gen_distributor():
+    """Return a semi-random dict for use in creating a Python distributor."""
+    return {
+        'distributor_id': utils.uuid4(),
+        'distributor_type_id': 'python_distributor',
+    }
+
+
+def upload_import_unit(cfg, unit, import_params, repo):
+    """Upload a content unit to a Pulp server and import it into a repository.
+
+    This procedure only works for some unit types, such as ``rpm`` or
+    ``python_package``. Others, like ``package_group``, require an alternate
+    procedure. The procedure encapsulated by this function is as follows:
+
+    1. Create an upload request.
+    2. Upload the content unit to Pulp, in small chunks.
+    3. Import the uploaded content unit into a repository.
+    4. Delete the upload request.
+
+    The default set of parameters sent to Pulp during step 3 are::
+
+        {'unit_key': {}, 'upload_id': '…'}
+
+    The actual parameters required by Pulp depending on the circumstances, and
+    the parameters sent to Pulp may be customized via the ``import_params``
+    argument. For example, if uploading a Python content unit,
+    ``import_params`` should be the following::
+
+        {'unit_key': {'filename': '…'}, 'unit_type_id': 'python_package'}
+
+    This would result in the following upload parameters being used::
+
+        {
+            'unit_key': {'filename': '…'},
+            'unit_type_id': 'python_package',
+            'upload_id': '…',
+        }
+
+    :param pulp_smash.config.ServerConfig cfg: Information about a Pulp host.
+    :param unit: The unit to be uploaded and imported, as a binary blob.
+    :param import_params: A dict of parameters to be merged into the default
+        set of import parameters during step 3.
+    :param repo: A dict of information about the target repository.
+    :returns: The call report returned when importing the unit.
+    """
+    client = api.Client(cfg, api.json_handler)
+    malloc = client.post(constants.CONTENT_UPLOAD_PATH)
+
+    # 200,000 bytes ~= 200 kB
+    chunk_size = 200000
+    offset = 0
+    with io.BytesIO(unit) as handle:
+        while True:
+            chunk = handle.read(chunk_size)
+            if not chunk:  # if chunk == b'':
+                break  # we've reached EOF
+            path = urljoin(malloc['_href'], '{}/'.format(offset))
+            client.put(path, data=chunk)
+            offset += chunk_size
+
+    path = urljoin(repo['_href'], 'actions/import_upload/')
+    body = {'unit_key': {}, 'upload_id': malloc['upload_id']}
+    body.update(import_params)
+    call_report = client.post(path, body)
+    client.delete(malloc['_href'])
+    return call_report


### PR DESCRIPTION
Rewrite module `pulp_smash.tests.python.api_v2.test_sync_publish`. Make
at least the following changes:

* Change which issues are queried when deciding whether or not to raise
  a `SkipTest` exception, and as a consequence, increase the amount of
  test code that's executed.
* Expand the tests, so that repo-to-repo syncs are performed.
* Expand the tests, so that content unit uploads are performed.

Fix: https://github.com/PulpQE/pulp-smash/issues/492

Fix: https://github.com/PulpQE/pulp-smash/issues/493

Fix: https://github.com/PulpQE/pulp-smash/issues/494