### PR TITLE
Rewrite function import_upload_unit

### DIFF
--- a/pulp_smash/tests/docker/api_v2/test_duplicate_uploads.py
+++ b/pulp_smash/tests/docker/api_v2/test_duplicate_uploads.py
@@ -30,8 +30,7 @@ class DuplicateUploadsTestCase(
         """Create a Docker repository."""
         super(DuplicateUploadsTestCase, cls).setUpClass()
         unit = utils.http_get(DOCKER_IMAGE_URL)
-        unit_type_id = 'docker_image'
-        client = api.Client(cls.cfg, api.json_handler)
-        repo_href = client.post(REPOSITORY_PATH, gen_repo())['_href']
-        cls.resources.add(repo_href)
-        cls.upload_import_unit_args = (cls.cfg, unit, unit_type_id, repo_href)
+        import_params = {'unit_type_id': 'docker_image'}
+        repo = api.Client(cls.cfg).post(REPOSITORY_PATH, gen_repo()).json()
+        cls.upload_import_unit_args = (cls.cfg, unit, import_params, repo)
+        cls.resources.add(repo['_href'])

--- a/pulp_smash/tests/puppet/api_v2/test_duplicate_uploads.py
+++ b/pulp_smash/tests/puppet/api_v2/test_duplicate_uploads.py
@@ -30,8 +30,7 @@ class DuplicateUploadsTestCase(
         """Create a Puppet repository."""
         super(DuplicateUploadsTestCase, cls).setUpClass()
         unit = utils.http_get(PUPPET_MODULE_URL)
-        unit_type_id = 'puppet_module'
-        client = api.Client(cls.cfg, api.json_handler)
-        repo_href = client.post(REPOSITORY_PATH, gen_repo())['_href']
-        cls.resources.add(repo_href)
-        cls.upload_import_unit_args = (cls.cfg, unit, unit_type_id, repo_href)
+        import_params = {'unit_type_id': 'puppet_module'}
+        repo = api.Client(cls.cfg).post(REPOSITORY_PATH, gen_repo()).json()
+        cls.upload_import_unit_args = (cls.cfg, unit, import_params, repo)
+        cls.resources.add(repo['_href'])

--- a/pulp_smash/tests/python/api_v2/test_duplicate_uploads.py
+++ b/pulp_smash/tests/python/api_v2/test_duplicate_uploads.py
@@ -37,8 +37,7 @@ class DuplicateUploadsTestCase(
                 selectors.bug_is_untestable(2334, cls.cfg.version)):
             raise unittest.SkipTest('https://pulp.plan.io/issues/2334')
         unit = utils.http_get(PYTHON_EGG_URL)
-        unit_type_id = 'python_package'
-        client = api.Client(cls.cfg, api.json_handler)
-        repo_href = client.post(REPOSITORY_PATH, gen_repo())['_href']
-        cls.resources.add(repo_href)
-        cls.upload_import_unit_args = (cls.cfg, unit, unit_type_id, repo_href)
+        import_params = {'unit_type_id': 'python_package'}
+        repo = api.Client(cls.cfg).post(REPOSITORY_PATH, gen_repo()).json()
+        cls.upload_import_unit_args = (cls.cfg, unit, import_params, repo)
+        cls.resources.add(repo['_href'])

--- a/pulp_smash/tests/python/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/python/api_v2/test_sync_publish.py
@@ -6,11 +6,7 @@ from os.path import basename
 from urllib.parse import urljoin, urlparse
 
 from pulp_smash import api, config, constants, selectors, utils
-from pulp_smash.tests.python.api_v2.utils import (
-    gen_distributor,
-    gen_repo,
-    upload_import_unit,
-)
+from pulp_smash.tests.python.api_v2.utils import gen_distributor, gen_repo
 from pulp_smash.tests.python.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 
@@ -159,7 +155,7 @@ class UploadTestCase(BaseTestCase):
                 'unit_key': {'filename': basename(urlparse(url).path)},
                 'unit_type_id': 'python_package',
             }
-            upload_import_unit(self.cfg, unit, import_params, repo)
+            utils.upload_import_unit(self.cfg, unit, import_params, repo)
         with self.subTest(comment='verify content units are present'):
             self.verify_package_types(self.cfg, repo)
         repo = get_details(self.cfg, repo)

--- a/pulp_smash/tests/python/api_v2/utils.py
+++ b/pulp_smash/tests/python/api_v2/utils.py
@@ -1,9 +1,6 @@
 # coding=utf-8
 """Utility functions for Python API tests."""
-import io
-from urllib.parse import urljoin
-
-from pulp_smash import api, constants, utils
+from pulp_smash import utils
 
 
 def gen_repo():
@@ -22,64 +19,3 @@ def gen_distributor():
         'distributor_id': utils.uuid4(),
         'distributor_type_id': 'python_distributor',
     }
-
-
-def upload_import_unit(cfg, unit, import_params, repo):
-    """Upload a content unit to a Pulp server and import it into a repository.
-
-    This procedure only works for some unit types, such as ``rpm`` or
-    ``python_package``. Others, like ``package_group``, require an alternate
-    procedure. The procedure encapsulated by this function is as follows:
-
-    1. Create an upload request.
-    2. Upload the content unit to Pulp, in small chunks.
-    3. Import the uploaded content unit into a repository.
-    4. Delete the upload request.
-
-    The default set of parameters sent to Pulp during step 3 are::
-
-        {'unit_key': {}, 'upload_id': '…'}
-
-    The actual parameters required by Pulp depending on the circumstances, and
-    the parameters sent to Pulp may be customized via the ``import_params``
-    argument. For example, if uploading a Python content unit,
-    ``import_params`` should be the following::
-
-        {'unit_key': {'filename': '…'}, 'unit_type_id': 'python_package'}
-
-    This would result in the following upload parameters being used::
-
-        {
-            'unit_key': {'filename': '…'},
-            'unit_type_id': 'python_package',
-            'upload_id': '…',
-        }
-
-    :param pulp_smash.config.ServerConfig cfg: Information about a Pulp host.
-    :param unit: The unit to be uploaded and imported, as a binary blob.
-    :param import_params: A dict of parameters to be merged into the default
-        set of import parameters during step 3.
-    :param repo: A dict of information about the target repository.
-    :returns: The call report returned when importing the unit.
-    """
-    client = api.Client(cfg, api.json_handler)
-    malloc = client.post(constants.CONTENT_UPLOAD_PATH)
-
-    # 200,000 bytes ~= 200 kB
-    chunk_size = 200000
-    offset = 0
-    with io.BytesIO(unit) as handle:
-        while True:
-            chunk = handle.read(chunk_size)
-            if not chunk:  # if chunk == b'':
-                break  # we've reached EOF
-            path = urljoin(malloc['_href'], '{}/'.format(offset))
-            client.put(path, data=chunk)
-            offset += chunk_size
-
-    path = urljoin(repo['_href'], 'actions/import_upload/')
-    body = {'unit_key': {}, 'upload_id': malloc['upload_id']}
-    body.update(import_params)
-    call_report = client.post(path, body)
-    client.delete(malloc['_href'])
-    return call_report

--- a/pulp_smash/tests/rpm/api_v2/test_duplicate_uploads.py
+++ b/pulp_smash/tests/rpm/api_v2/test_duplicate_uploads.py
@@ -31,8 +31,7 @@ class DuplicateUploadsTestCase(
         super(DuplicateUploadsTestCase, cls).setUpClass()
         utils.reset_pulp(cls.cfg)
         unit = utils.http_get(RPM_SIGNED_URL)
-        unit_type_id = 'rpm'
-        client = api.Client(cls.cfg, api.json_handler)
-        repo_href = client.post(REPOSITORY_PATH, gen_repo())['_href']
-        cls.resources.add(repo_href)
-        cls.upload_import_unit_args = (cls.cfg, unit, unit_type_id, repo_href)
+        import_params = {'unit_type_id': 'rpm'}
+        repo = api.Client(cls.cfg).post(REPOSITORY_PATH, gen_repo()).json()
+        cls.upload_import_unit_args = (cls.cfg, unit, import_params, repo)
+        cls.resources.add(repo['_href'])

--- a/pulp_smash/tests/rpm/api_v2/test_repoview.py
+++ b/pulp_smash/tests/rpm/api_v2/test_repoview.py
@@ -45,7 +45,7 @@ class RepoviewTestCase(unittest.TestCase):
         repo = client.post(constants.REPOSITORY_PATH, body).json()
         self.addCleanup(client.delete, repo['_href'])
         rpm = utils.http_get(constants.RPM_UNSIGNED_URL)
-        utils.upload_import_unit(cfg, rpm, 'rpm', repo['_href'])
+        utils.upload_import_unit(cfg, rpm, {'unit_type_id': 'rpm'}, repo)
 
         # Get info about the repo distributor
         repo = client.get(repo['_href'], params={'details': True}).json()

--- a/pulp_smash/tests/rpm/api_v2/test_signatures_checked_for_copies.py
+++ b/pulp_smash/tests/rpm/api_v2/test_signatures_checked_for_copies.py
@@ -68,12 +68,12 @@ def setUpModule():  # pylint:disable=invalid-name
         repo = client.post(REPOSITORY_PATH, gen_repo())
         _REPOS['signed'] = repo
         for type_id, pkg in _SIGNED_PACKAGES.items():
-            utils.upload_import_unit(cfg, pkg, type_id, repo['_href'])
+            utils.upload_import_unit(cfg, pkg, {'unit_type_id': type_id}, repo)
 
         repo = client.post(REPOSITORY_PATH, gen_repo())
         _REPOS['unsigned'] = repo
         for type_id, pkg in _UNSIGNED_PACKAGES.items():
-            utils.upload_import_unit(cfg, pkg, type_id, repo['_href'])
+            utils.upload_import_unit(cfg, pkg, {'unit_type_id': type_id}, repo)
     except:
         _SIGNED_PACKAGES.clear()
         _UNSIGNED_PACKAGES.clear()

--- a/pulp_smash/tests/rpm/api_v2/test_signatures_checked_for_uploads.py
+++ b/pulp_smash/tests/rpm/api_v2/test_signatures_checked_for_uploads.py
@@ -105,11 +105,11 @@ def tearDownModule():  # pylint:disable=invalid-name
 def _create_repository(cfg, importer_config):
     """Create an RPM repository with the given importer configuration.
 
-    Return the repository's href.
+    Return a dict of information about the repository.
     """
     body = gen_repo()
     body['importer_config'] = importer_config
-    return api.Client(cfg).post(REPOSITORY_PATH, body).json()['_href']
+    return api.Client(cfg).post(REPOSITORY_PATH, body).json()
 
 
 # NOTE: We could inherit from unittest.TestCase and create a separate
@@ -130,11 +130,11 @@ class RequireValidKeyTestCase(utils.BaseAPITestCase):
     def setUpClass(cls):
         """Create a repository with an importer."""
         super(RequireValidKeyTestCase, cls).setUpClass()
-        cls.repo_href = _create_repository(cls.cfg, {
+        cls.repo = _create_repository(cls.cfg, {
             'allowed_keys': [PULP_FIXTURES_KEY_ID],
             'require_signature': True,
         })
-        cls.resources.add(cls.repo_href)
+        cls.resources.add(cls.repo['_href'])
 
     def test_signed_packages(self):
         """Import signed DRPM, RPM and SRPM packages into the repository.
@@ -146,8 +146,8 @@ class RequireValidKeyTestCase(utils.BaseAPITestCase):
                 utils.upload_import_unit(
                     self.cfg,
                     package,
-                    key.split(' ')[-1],
-                    self.repo_href,
+                    {'unit_type_id': key.split(' ')[-1]},
+                    self.repo,
                 )
 
     def test_unsigned_packages(self):
@@ -161,8 +161,8 @@ class RequireValidKeyTestCase(utils.BaseAPITestCase):
                     utils.upload_import_unit(
                         self.cfg,
                         package,
-                        key.split(' ')[-1],
-                        self.repo_href,
+                        {'unit_type_id': key.split(' ')[-1]},
+                        self.repo,
                     )
 
 
@@ -180,11 +180,11 @@ class RequireInvalidKeyTestCase(utils.BaseAPITestCase):
     def setUpClass(cls):
         """Create a repository with an importer."""
         super(RequireInvalidKeyTestCase, cls).setUpClass()
-        cls.repo_href = _create_repository(cls.cfg, {
+        cls.repo = _create_repository(cls.cfg, {
             'allowed_keys': [_INVALID_KEY_ID],
             'require_signature': True,
         })
-        cls.resources.add(cls.repo_href)
+        cls.resources.add(cls.repo['_href'])
 
     def test_all_packages(self):
         """Import signed and unsigned DRPM, RPM & SRPM packages into the repo.
@@ -199,8 +199,8 @@ class RequireInvalidKeyTestCase(utils.BaseAPITestCase):
                     utils.upload_import_unit(
                         self.cfg,
                         package,
-                        key.split(' ')[-1],
-                        self.repo_href,
+                        {'unit_type_id': key.split(' ')[-1]},
+                        self.repo,
                     )
 
 
@@ -218,11 +218,11 @@ class RequireAnyKeyTestCase(utils.BaseAPITestCase):
     def setUpClass(cls):
         """Create a repository with an importer."""
         super(RequireAnyKeyTestCase, cls).setUpClass()
-        cls.repo_href = _create_repository(cls.cfg, {
+        cls.repo = _create_repository(cls.cfg, {
             'allowed_keys': [],
             'require_signature': True,
         })
-        cls.resources.add(cls.repo_href)
+        cls.resources.add(cls.repo['_href'])
 
     def test_signed_packages(self):
         """Import signed DRPM, RPM and SRPM packages into the repo.
@@ -234,8 +234,8 @@ class RequireAnyKeyTestCase(utils.BaseAPITestCase):
                 utils.upload_import_unit(
                     self.cfg,
                     package,
-                    key.split(' ')[-1],
-                    self.repo_href,
+                    {'unit_type_id': key.split(' ')[-1]},
+                    self.repo,
                 )
 
     def test_unsigned_packages(self):
@@ -249,8 +249,8 @@ class RequireAnyKeyTestCase(utils.BaseAPITestCase):
                     utils.upload_import_unit(
                         self.cfg,
                         package,
-                        key.split(' ')[-1],
-                        self.repo_href,
+                        {'unit_type_id': key.split(' ')[-1]},
+                        self.repo,
                     )
 
 
@@ -268,11 +268,11 @@ class AllowInvalidKeyTestCase(utils.BaseAPITestCase):
     def setUpClass(cls):
         """Create a repository with an importer."""
         super(AllowInvalidKeyTestCase, cls).setUpClass()
-        cls.repo_href = _create_repository(cls.cfg, {
+        cls.repo = _create_repository(cls.cfg, {
             'allowed_keys': [_INVALID_KEY_ID],
             'require_signature': False,
         })
-        cls.resources.add(cls.repo_href)
+        cls.resources.add(cls.repo['_href'])
 
     def test_signed_packages(self):
         """Import signed DRPM, RPM and SRPM packages into the repository.
@@ -285,8 +285,8 @@ class AllowInvalidKeyTestCase(utils.BaseAPITestCase):
                     utils.upload_import_unit(
                         self.cfg,
                         package,
-                        key.split(' ')[-1],
-                        self.repo_href,
+                        {'unit_type_id': key.split(' ')[-1]},
+                        self.repo,
                     )
 
     def test_unsigned_packages(self):
@@ -299,8 +299,8 @@ class AllowInvalidKeyTestCase(utils.BaseAPITestCase):
                 utils.upload_import_unit(
                     self.cfg,
                     package,
-                    key.split(' ')[-1],
-                    self.repo_href,
+                    {'unit_type_id': key.split(' ')[-1]},
+                    self.repo,
                 )
 
 
@@ -318,11 +318,11 @@ class AllowValidKeyTestCase(utils.BaseAPITestCase):
     def setUpClass(cls):
         """Create a repository with an importer."""
         super(AllowValidKeyTestCase, cls).setUpClass()
-        cls.repo_href = _create_repository(cls.cfg, {
+        cls.repo = _create_repository(cls.cfg, {
             'allowed_keys': [PULP_FIXTURES_KEY_ID],
             'require_signature': False,
         })
-        cls.resources.add(cls.repo_href)
+        cls.resources.add(cls.repo['_href'])
 
     def test_all_packages(self):
         """Import signed and unsigned DRPM, RPM & SRPM packages into the repo.
@@ -336,8 +336,8 @@ class AllowValidKeyTestCase(utils.BaseAPITestCase):
                 utils.upload_import_unit(
                     self.cfg,
                     package,
-                    key.split(' ')[-1],
-                    self.repo_href,
+                    {'unit_type_id': key.split(' ')[-1]},
+                    self.repo,
                 )
 
 
@@ -355,11 +355,11 @@ class AllowAnyKeyTestCase(utils.BaseAPITestCase):
     def setUpClass(cls):
         """Create a repository with an importer."""
         super(AllowAnyKeyTestCase, cls).setUpClass()
-        cls.repo_href = _create_repository(cls.cfg, {
+        cls.repo = _create_repository(cls.cfg, {
             'allowed_keys': [],
             'require_signature': False,
         })
-        cls.resources.add(cls.repo_href)
+        cls.resources.add(cls.repo['_href'])
 
     def test_all_packages(self):
         """Import signed and unsigned DRPM, RPM & SRPM packages into the repo.
@@ -373,8 +373,8 @@ class AllowAnyKeyTestCase(utils.BaseAPITestCase):
                 utils.upload_import_unit(
                     self.cfg,
                     package,
-                    key.split(' ')[-1],
-                    self.repo_href,
+                    {'unit_type_id': key.split(' ')[-1]},
+                    self.repo,
                 )
 
 
@@ -397,10 +397,10 @@ class KeyLengthTestCase(unittest.TestCase):
         cfg = config.get_config()
         for allowed_key in ('0123456', '012345678'):
             with self.subTest(allowed_key=allowed_key):
-                repo_href = None
+                repo = None
                 with self.assertRaises(HTTPError):
-                    repo_href = _create_repository(cfg, {
+                    repo = _create_repository(cfg, {
                         'allowed_keys': [allowed_key]
                     })
-                if repo_href is not None:
-                    api.Client(cfg).delete(repo_href)
+                if repo is not None:
+                    api.Client(cfg).delete(repo['_href'])

--- a/pulp_smash/tests/rpm/api_v2/test_signatures_saved_for_packages.py
+++ b/pulp_smash/tests/rpm/api_v2/test_signatures_saved_for_packages.py
@@ -114,15 +114,20 @@ class UploadPackageTestCase(_BaseTestCase):
         Return the repository's href.
         """
         self.addCleanup(self.client.delete, ORPHANS_PATH)
-        repo_href = self.client.post(REPOSITORY_PATH, gen_repo())['_href']
-        self.addCleanup(self.client.delete, repo_href)
+        repo = self.client.post(REPOSITORY_PATH, gen_repo())
+        self.addCleanup(self.client.delete, repo['_href'])
 
         pkg = utils.http_get(pkg_url)
         pkg_filename = _get_pkg_filename(pkg_url)
         pkg_unit_type = _get_pkg_unit_type(pkg_filename)
-        utils.upload_import_unit(self.cfg, pkg, pkg_unit_type, repo_href)
+        utils.upload_import_unit(
+            self.cfg,
+            pkg,
+            {'unit_type_id': pkg_unit_type},
+            repo,
+        )
 
-        return repo_href
+        return repo['_href']
 
     def test_signed_drpm(self):
         """Import a signed DRPM into Pulp. Verify its signature."""

--- a/pulp_smash/tests/rpm/api_v2/test_upload_publish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_upload_publish.py
@@ -13,7 +13,6 @@ import unittest
 from urllib.parse import urljoin
 
 from pulp_smash import api, config, selectors, utils
-from pulp_smash.utils import upload_import_unit
 from pulp_smash.constants import (
     DRPM,
     DRPM_UNSIGNED_URL,
@@ -181,7 +180,7 @@ class UploadDrpmTestCase(utils.BaseAPITestCase):
         repo = client.post(REPOSITORY_PATH, gen_repo()).json()
         cls.resources.add(repo['_href'])
         drpm = utils.http_get(DRPM_UNSIGNED_URL)
-        upload_import_unit(cls.cfg, drpm, 'drpm', repo['_href'])
+        utils.upload_import_unit(cls.cfg, drpm, {'unit_type_id': 'drpm'}, repo)
         cls.repo_units = client.post(
             urljoin(repo['_href'], 'search/units/'),
             {'criteria': {}},
@@ -225,7 +224,7 @@ class UploadSrpmTestCase(utils.BaseAPITestCase):
         repo = client.post(REPOSITORY_PATH, gen_repo()).json()
         cls.resources.add(repo['_href'])
         srpm = utils.http_get(SRPM_UNSIGNED_URL)
-        upload_import_unit(cls.cfg, srpm, 'srpm', repo['_href'])
+        utils.upload_import_unit(cls.cfg, srpm, {'unit_type_id': 'srpm'}, repo)
         cls.repo_units = client.post(
             urljoin(repo['_href'], 'search/units/'),
             {'criteria': {}},
@@ -291,7 +290,12 @@ class UploadRpmTestCase(utils.BaseAPITestCase):
         Execute :meth:`verify_repo_search` and :meth:`verify_repo_download`.
         """
         repo = self.repos[0]
-        utils.upload_import_unit(self.cfg, self.rpm, 'rpm', repo['_href'])
+        utils.upload_import_unit(
+            self.cfg,
+            self.rpm,
+            {'unit_type_id': 'rpm'},
+            repo,
+        )
         utils.publish_repo(self.cfg, repo)
         with self.subTest():
             self.verify_repo_search(repo)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -188,10 +188,10 @@ class UploadImportUnitTestCase(unittest.TestCase):
                 'upload_id': 'bar',
             }
             response = utils.upload_import_unit(
-                mock.Mock(),  # server_config
-                b'my unit',
-                'my unit type id',
-                'http://example.com',  # repo_href
+                mock.Mock(),  # cfg
+                b'my unit',  # unit
+                {},  # import_params
+                {'_href': 'http://example.com'},  # repo
             )
         self.assertIs(response, client.return_value.post.return_value)
 


### PR DESCRIPTION
After a content unit has been uploaded to Pulp, an HTTP POST request
must be sent to actually import it into a repository. Depending on the
type of unit being imported, the body of that HTTP POST request varies.
Unfortunately, `pulp_smash.utils.upload_import_unit` is inflexible in
this regard.

Rewrite the function so that arbitrarily complex JSON data may be sent
as the body of the HTTP POST request. This allows `import_upload_unit`
to be used when uploading and importing Python content units.

See: 9973e8911f1f1d3d8bcd030b81dd2b1059d756d3