### PR TITLE
Consolidate logic for searching for units

### DIFF
--- a/pulp_smash/tests/puppet/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/puppet/api_v2/test_sync_publish.py
@@ -350,9 +350,8 @@ class PublishTestCase(utils.BaseAPITestCase):
             cls.modules.append(client.get(path).content)
 
         # Search for all units in each of the two repositories.
-        body = {'criteria': {}}
         cls.responses['repo units'] = [
-            client.post(urljoin(repo['_href'], 'search/units/'), body)
+            utils.search_units(cls.cfg, repo, {}, api.safe_handler)
             for repo in repos
         ]
 

--- a/pulp_smash/tests/python/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/python/api_v2/test_sync_publish.py
@@ -95,10 +95,7 @@ class BaseTestCase(unittest.TestCase):
 
         This test targets `Pulp #1883 <https://pulp.plan.io/issues/1883>`_.
         """
-        units = api.Client(cfg).post(
-            urljoin(repo['_href'], 'search/units/'),
-            {'criteria': {}},
-        ).json()
+        units = utils.search_units(cfg, repo)
         unit_types = {unit['metadata']['packagetype'] for unit in units}
         self.assertEqual(unit_types, {'sdist', 'bdist_wheel'})
 

--- a/pulp_smash/tests/rpm/api_v2/test_remove_unit.py
+++ b/pulp_smash/tests/rpm/api_v2/test_remove_unit.py
@@ -14,11 +14,7 @@ from pulp_smash.constants import (
     REPOSITORY_PATH,
     RPM_SIGNED_FEED_URL,
 )
-from pulp_smash.tests.rpm.api_v2.utils import (
-    find_units,
-    gen_distributor,
-    gen_repo,
-)
+from pulp_smash.tests.rpm.api_v2.utils import gen_distributor, gen_repo
 from pulp_smash.tests.rpm.utils import check_issue_2277
 from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
@@ -150,7 +146,7 @@ class RemoveMissingTestCase(unittest.TestCase):
         utils.publish_repo(self.cfg, self.repos['root'])
 
         # Verify the removed unit cannot be found via a search.
-        units = find_units(self.cfg, self.repos['root'], criteria)
+        units = utils.search_units(self.cfg, self.repos['root'], criteria)
         self.assertEqual(len(units), 0, units)
 
     def test_04_sync_immediate_child(self):
@@ -180,10 +176,7 @@ class RemoveMissingTestCase(unittest.TestCase):
 
 def _get_rpms(cfg, repo):
     """Return RPM content units in the given repository."""
-    return api.Client(cfg).post(
-        urljoin(repo['_href'], 'search/units/'),
-        {'criteria': {'type_ids': ('rpm',)}},
-    ).json()
+    return utils.search_units(cfg, repo, {'type_ids': ('rpm',)})
 
 
 def _get_rpm_ids(search_body):

--- a/pulp_smash/tests/rpm/api_v2/test_republish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_republish.py
@@ -17,7 +17,6 @@ from urllib.parse import urljoin
 from pulp_smash import api, config, utils
 from pulp_smash.constants import REPOSITORY_PATH, RPM_SIGNED_FEED_URL
 from pulp_smash.tests.rpm.api_v2.utils import (
-    find_units,
     gen_distributor,
     gen_repo,
     get_unit,
@@ -58,7 +57,9 @@ class RepublishTestCase(unittest.TestCase):
         utils.publish_repo(cfg, repo)
 
         # Pick a random content unit and verify it's accessible.
-        unit = random.choice(find_units(cfg, repo, {'type_ids': ('rpm',)}))
+        unit = random.choice(
+            utils.search_units(cfg, repo, {'type_ids': ('rpm',)})
+        )
         filename = unit['metadata']['filename']
         get_unit(cfg, repo['distributors'][0], filename)
 

--- a/pulp_smash/tests/rpm/api_v2/test_signatures_saved_for_packages.py
+++ b/pulp_smash/tests/rpm/api_v2/test_signatures_saved_for_packages.py
@@ -17,7 +17,7 @@ For more information, see:
 """
 import inspect
 import unittest
-from urllib.parse import urljoin, urlparse
+from urllib.parse import urlparse
 
 from pulp_smash import api, config, selectors, utils
 from pulp_smash.constants import (
@@ -83,11 +83,9 @@ class _BaseTestCase(unittest.TestCase):
         if pkg_unit_type == 'drpm':
             # This is the location of the package relative to the repo root.
             pkg_filename = 'drpms/' + pkg_filename
-        units = self.client.post(urljoin(repo_href, 'search/units/'), {
-            'criteria': {
-                'filters': {'unit': {'filename': {'$in': [pkg_filename]}}},
-                'type_ids': [pkg_unit_type],
-            }
+        units = utils.search_units(self.cfg, {'_href': repo_href}, {
+            'filters': {'unit': {'filename': {'$in': [pkg_filename]}}},
+            'type_ids': [pkg_unit_type],
         })
         self.assertEqual(len(units), 1)
         return units[0]

--- a/pulp_smash/tests/rpm/api_v2/test_updateinfo.py
+++ b/pulp_smash/tests/rpm/api_v2/test_updateinfo.py
@@ -20,7 +20,6 @@ from pulp_smash.constants import (
     RPM_UNSIGNED_FEED_URL,
 )
 from pulp_smash.tests.rpm.api_v2.utils import (
-    find_units,
     gen_distributor,
     gen_repo,
     get_repodata,
@@ -438,7 +437,9 @@ class CleanUpTestCase(unittest.TestCase):
         self.updateinfo_xml_hrefs.append(self.get_updateinfo_xml_href())
 
         with self.subTest(comment='check number of RPMs in repo'):
-            units = find_units(self.cfg, self.repo, {'type_ids': ('rpm',)})
+            units = (
+                utils.search_units(self.cfg, self.repo, {'type_ids': ('rpm',)})
+            )
             self.assertEqual(len(units), 31)
         with self.subTest(comment='check updateinfo.xml is available'):
             client.get(self.updateinfo_xml_hrefs[0])
@@ -451,7 +452,9 @@ class CleanUpTestCase(unittest.TestCase):
 
         client = api.Client(self.cfg)
         with self.subTest(comment='check number of RPMs in repo'):
-            units = find_units(self.cfg, self.repo, {'type_ids': ('rpm',)})
+            units = (
+                utils.search_units(self.cfg, self.repo, {'type_ids': ('rpm',)})
+            )
             self.assertEqual(len(units), 32)
         with self.subTest(comment='check updateinfo.xml has a new path'):
             # pylint:disable=no-value-for-parameter

--- a/pulp_smash/tests/rpm/api_v2/test_upload_publish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_upload_publish.py
@@ -25,7 +25,6 @@ from pulp_smash.constants import (
     SRPM_UNSIGNED_URL,
 )
 from pulp_smash.tests.rpm.api_v2.utils import (
-    find_units,
     gen_distributor,
     gen_repo,
     get_repodata,
@@ -181,23 +180,20 @@ class UploadDrpmTestCase(utils.BaseAPITestCase):
         cls.resources.add(repo['_href'])
         drpm = utils.http_get(DRPM_UNSIGNED_URL)
         utils.upload_import_unit(cls.cfg, drpm, {'unit_type_id': 'drpm'}, repo)
-        cls.repo_units = client.post(
-            urljoin(repo['_href'], 'search/units/'),
-            {'criteria': {}},
-        )
+        cls.units = utils.search_units(cls.cfg, repo, {}, api.safe_handler)
 
-    def test_status_code_repo_units(self):
+    def test_status_code_units(self):
         """Verify the HTTP status code for repo units response."""
-        self.assertEqual(self.repo_units.status_code, 200)
+        self.assertEqual(self.units.status_code, 200)
 
     def test_drpm_uploaded_successfully(self):
         """Test if DRPM has been uploaded successfully."""
-        self.assertEqual(len(self.repo_units.json()), 1)
+        self.assertEqual(len(self.units.json()), 1)
 
     def test_drpm_file_name_is_correct(self):
         """Test if DRPM extracted correct metadata for creating filename."""
         self.assertEqual(
-            self.repo_units.json()[0]['metadata']['filename'],
+            self.units.json()[0]['metadata']['filename'],
             DRPM,
         )
 
@@ -225,23 +221,20 @@ class UploadSrpmTestCase(utils.BaseAPITestCase):
         cls.resources.add(repo['_href'])
         srpm = utils.http_get(SRPM_UNSIGNED_URL)
         utils.upload_import_unit(cls.cfg, srpm, {'unit_type_id': 'srpm'}, repo)
-        cls.repo_units = client.post(
-            urljoin(repo['_href'], 'search/units/'),
-            {'criteria': {}},
-        )
+        cls.units = utils.search_units(cls.cfg, repo, {}, api.safe_handler)
 
-    def test_status_code_repo_units(self):
+    def test_status_code_units(self):
         """Verify the HTTP status code for repo units response."""
-        self.assertEqual(self.repo_units.status_code, 200)
+        self.assertEqual(self.units.status_code, 200)
 
     def test_srpm_uploaded_successfully(self):
         """Test if SRPM has been uploaded successfully."""
-        self.assertEqual(len(self.repo_units.json()), 1)
+        self.assertEqual(len(self.units.json()), 1)
 
     def test_srpm_file_name_is_correct(self):
         """Test if SRPM extracted correct metadata for creating filename."""
         self.assertEqual(
-            self.repo_units.json()[0]['metadata']['filename'],
+            self.units.json()[0]['metadata']['filename'],
             SRPM,
         )
 
@@ -319,8 +312,8 @@ class UploadRpmTestCase(utils.BaseAPITestCase):
 
     def test_03_compare_repos(self):
         """Verify the two repositories contain the same content unit."""
-        repo_0_units = find_units(self.cfg, self.repos[0])
-        repo_1_units = find_units(self.cfg, self.repos[1])
+        repo_0_units = utils.search_units(self.cfg, self.repos[0])
+        repo_1_units = utils.search_units(self.cfg, self.repos[1])
         self.assertEqual(
             repo_0_units[0]['unit_id'],
             repo_1_units[0]['unit_id'],
@@ -333,7 +326,7 @@ class UploadRpmTestCase(utils.BaseAPITestCase):
         its metadata attributes are correct. This test targets `Pulp #2365
         <https://pulp.plan.io/issues/2365>`_.
         """
-        units = find_units(self.cfg, repo)
+        units = utils.search_units(self.cfg, repo)
         self.assertEqual(len(units), 1)
 
         # filename and derived attributes

--- a/pulp_smash/tests/rpm/api_v2/utils.py
+++ b/pulp_smash/tests/rpm/api_v2/utils.py
@@ -225,20 +225,3 @@ def get_unit(cfg, distributor, unit_name, primary_xml=None):
         path += '/'
     path = urljoin(path, href)
     return api.Client(cfg).get(path)
-
-
-def find_units(cfg, repo, criteria=None):
-    """Find units in repository ``repo_href``.
-
-    :param pulp_smash.config.ServerConfig cfg: Information about the Pulp host.
-    :param repo: A dict of detailed information about the repository.
-    :param criteria: A dict of criteria to pass in the search body. Defaults to
-        an empty dict.
-    :return: The JSON-decoded response body.
-    """
-    if criteria is None:
-        criteria = {}
-    return api.Client(cfg).post(
-        urljoin(repo['_href'], 'search/units/'),
-        {'criteria': criteria},
-    ).json()

--- a/pulp_smash/utils.py
+++ b/pulp_smash/utils.py
@@ -520,3 +520,25 @@ def publish_repo(cfg, repo, json=None):
         urljoin(repo['_href'], 'actions/publish/'),
         json
     )
+
+
+def search_units(cfg, repo, criteria=None, response_handler=None):
+    """Find content units in a ``repo``.
+
+    :param pulp_smash.config.ServerConfig cfg: Information about the Pulp host.
+    :param repo: A dict of detailed information about the repository.
+    :param criteria: A dict of criteria to pass in the search body. Defaults to
+        an empty dict.
+    :param response_handler: The callback function used by
+        :class:`pulp_smash.api.Client` after searching. Defaults to
+        :func:`pulp_smash.api.json_handler`.
+    :returns: Whatever is dictated by ``response_handler``.
+    """
+    if criteria is None:
+        criteria = {}
+    if response_handler is None:
+        response_handler = api.json_handler
+    return api.Client(cfg, response_handler).post(
+        urljoin(repo['_href'], 'search/units/'),
+        {'criteria': criteria},
+    )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -255,3 +255,17 @@ class GetSha256ChecksumTestCase(unittest.TestCase):
         self.assertEqual(http_get.call_count, 2)
         self.assertNotEqual(checksums[0], checksums[1])
         self.assertEqual(checksums[0], checksums[2])
+
+
+class SearchUnitsTestCase(unittest.TestCase):
+    """Test :func:`pulp_smash.utils.search_units`."""
+
+    def test_defaults(self):
+        """Verify that default parameters are correctly set."""
+        with mock.patch.object(api, 'Client') as client:
+            utils.search_units(mock.Mock(), {'_href': 'foo/bar/'})
+        self.assertEqual(client.call_args[0][1], api.json_handler)
+        self.assertEqual(
+            client.return_value.post.call_args[0][1],
+            {'criteria': {}},
+        )


### PR DESCRIPTION
Create function `pulp_smash.utils.search_units`. Use it in place of all
similar functions and all direct API calls to path
`{repo_href}/search/units/`.