### PR TITLE
Skip some Python tests unless testing Pulp 2.12+

### DIFF
--- a/pulp_smash/tests/python/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/python/api_v2/test_sync_publish.py
@@ -5,6 +5,8 @@ import unittest
 from os.path import basename
 from urllib.parse import urljoin, urlparse
 
+from packaging.version import Version
+
 from pulp_smash import api, config, constants, selectors, utils
 from pulp_smash.tests.python.api_v2.utils import gen_distributor, gen_repo
 from pulp_smash.tests.python.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
@@ -29,6 +31,8 @@ class BaseTestCase(unittest.TestCase):
         cls.repos = []
         if inspect.getmro(cls)[0] == BaseTestCase:
             raise unittest.SkipTest('Abstract base class.')
+        if cls.cfg.version < Version('2.12'):
+            raise unittest.SkipTest('This test requires Pulp 2.12 or newer.')
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
Tests in module `pulp_smash.tests.python.api_v2.test_sync_publish` will
already skip if the relevant Pulp issues are open. However, the
"Platform Release" field is not set on the relevant issues, meaning that
the tests will run even for very old versions of Pulp, and thus causing
unnecessary test failures. Fix this.