### PR TITLE
Add rsync distributor test: AddUnitsTestCase

### DIFF
--- a/pulp_smash/constants.py
+++ b/pulp_smash/constants.py
@@ -286,6 +286,9 @@ REPOSITORY_PATH = '/pulp/api/v2/repositories/'
 RPM = 'bear-4.1-1.noarch.rpm'
 """The name of an RPM file. See :data:`pulp_smash.constants.RPM_SIGNED_URL`."""
 
+RPM2 = 'camel-0.1-1.noarch.rpm'
+"""The name of an RPM. See :data:`pulp_smash.constants.RPM2_UNSIGNED_URL`."""
+
 RPM_ALT_LAYOUT_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'rpm-alt-layout/')
 """The URL to a signed RPM repository. See :data:`RPM_SIGNED_URL`."""
 
@@ -396,6 +399,12 @@ RPM_UNSIGNED_URL = urljoin(RPM_UNSIGNED_FEED_URL, RPM)
 """The URL to an unsigned RPM file.
 
 Built from :data:`RPM_UNSIGNED_FEED_URL` and :data:`RPM`.
+"""
+
+RPM2_UNSIGNED_URL = urljoin(RPM_UNSIGNED_FEED_URL, RPM2)
+"""The URL to an unsigned RPM file.
+
+Built from :data:`RPM_UNSIGNED_FEED_URL` and :data:`RPM2`.
 """
 
 RPM_WITH_PULP_DISTRIBUTION_FEED_URL = urljoin(


### PR DESCRIPTION
Add `AddUnitsTestCase` to module
`pulp_smash.tests.rpm.api_v2.test_rsync_distributor`. From its
docstring:

> When executed, this test case does the following:
>
> 1. Create a yum repository with a yum and rsync distributor.
> 2. Add some content to the repository.
> 3. Publish the repository with its yum distributor.
> 4. Add additional content to the repository.
> 5. Publish the repository with its rsync distributor. This publish
>    shouldn't distribute the new content unit, as the new content unit
>    wasn't included in the most recent publish with the yum
>    distributor.
> 6. Publish the repository with its yum distributor.
> 7. Publish the repository with its rsync distributor. This publish
>    should distribute the new content unit, as the new content unit was
>    included in the most recent publish with the yum distributor.

Fix: https://github.com/PulpQE/pulp-smash/issues/526