### PR TITLE
Improve assertion for download policies test

### DIFF
--- a/pulp_smash/tests/rpm/api_v2/test_download_policies.py
+++ b/pulp_smash/tests/rpm/api_v2/test_download_policies.py
@@ -207,7 +207,7 @@ class OnDemandTestCase(utils.BaseAPITestCase):
         headers = self.rpm.headers
         self.assertIn(key, headers)
         self.assertEqual(
-            headers[key].split(', '),
+            set(headers[key].split(', ')),
             {'s-maxage=86400', 'public', 'max-age=86400'},
             headers,
         )


### PR DESCRIPTION
Make sure the assertion checks for the content not for the order of the
values.