### PR TITLE
Use Puppet fixtures from Pulp Fixtures

### DIFF
--- a/pulp_smash/constants.py
+++ b/pulp_smash/constants.py
@@ -197,26 +197,62 @@ Pulp's functioning. However, if resetting Pulp (such as in
 be restarted.
 """
 
-PUPPET_FEED = 'http://forge.puppetlabs.com'
+PUPPET_MODULE_1 = {
+    'author': 'pulpqe',
+    'name': 'dummypuppet',
+    'version': '0.1.0'
+}
+"""Information about a Puppet module available via Pulp Fixtures."""
+
+PUPPET_MODULE_URL_1 = urljoin(
+    urljoin(PULP_FIXTURES_BASE_URL, 'puppet/'),
+    '{}-{}.tar.gz'.format(PUPPET_MODULE_1['author'], PUPPET_MODULE_1['name'])
+)
+"""The URL to a Puppet module module available via Pulp Fixtures.
+
+Test cases that require a single module should use this URL, and test cases
+that require a feed should use :data:`PUPPET_MODULE_URL_2`. Doing so shifts
+load away from the Puppet Forge.
+
+Why do both URLs exist? Because simulating the Puppet Forge's behaviour is
+unreasonably hard.
+
+Pulp Fixtures is designed to create data that can be hosted by a simple HTTP
+server, such as ``python3 -m http.server``. A dynamic API, such as the `Puppet
+Forge API`_, cannot be simulated. We could create a static tree of files, where
+that tree of files is the same as what the Puppet Forge would provide in
+response to a certain HTTP GET request. However:
+
+* The `Puppet Forge API`_ will inevitably change over time as bugs are fixed
+  and features are added. This will make a static facsimile of the Puppet Forge
+  API outdated. This is more than a mere inconvenience: outdated information is
+  also confusing!
+* Without an in-depth understanding of each and every file the Puppet Forge
+  yields, it is probable that static fixtures will be wrong from the get-go.
+
+.. _Puppet Forge API: https://forgeapi.puppetlabs.com/
+"""
+
+PUPPET_FEED_2 = 'http://forge.puppetlabs.com'
 """The URL to a repository of Puppet modules."""
 
-PUPPET_MODULE = {'author': 'pulp', 'name': 'pulp', 'version': '1.0.0'}
-"""Information about a Puppet module available at :data:`PUPPET_FEED`."""
+PUPPET_MODULE_2 = {'author': 'pulp', 'name': 'pulp', 'version': '1.0.0'}
+"""Information about a Puppet module available at :data:`PUPPET_FEED_2`."""
 
-PUPPET_MODULE_URL = ('{}/v3/files/{}-{}-{}.tar.gz'.format(
-    PUPPET_FEED,
-    PUPPET_MODULE['author'],
-    PUPPET_MODULE['name'],
-    PUPPET_MODULE['version'],
+PUPPET_MODULE_URL_2 = ('{}/v3/files/{}-{}-{}.tar.gz'.format(
+    PUPPET_FEED_2,
+    PUPPET_MODULE_2['author'],
+    PUPPET_MODULE_2['name'],
+    PUPPET_MODULE_2['version'],
 ))
-"""The URL to a Puppet module available at :data:`PUPPET_FEED`."""
+"""The URL to a Puppet module available at :data:`PUPPET_FEED_2`."""
 
-PUPPET_QUERY = quote_plus('-'.join(
-    PUPPET_MODULE[key] for key in ('author', 'name', 'version')
+PUPPET_QUERY_2 = quote_plus('-'.join(
+    PUPPET_MODULE_2[key] for key in ('author', 'name', 'version')
 ))
 """A query that can be used to search for Puppet modules.
 
-Built from :data:`PUPPET_MODULE`.
+Built from :data:`PUPPET_MODULE_2`.
 
 Though the `Puppet Forge API`_ supports a variety of search types, Pulp
 only supports the ability to search for modules. As a result, it is
@@ -234,8 +270,7 @@ following URL is constructed:
 In an attempt to avoid this error, this query is encoded before being submitted
 to Pulp.
 
-.. _Puppet Forge API:
-    http://projects.puppetlabs.com/projects/module-site/wiki/Server-api
+.. _Puppet Forge API: https://forgeapi.puppetlabs.com/
 """
 
 PYTHON_PYPI_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'python-pypi/')

--- a/pulp_smash/tests/puppet/api_v2/test_duplicate_uploads.py
+++ b/pulp_smash/tests/puppet/api_v2/test_duplicate_uploads.py
@@ -15,7 +15,7 @@ The second upload should silently fail for all Pulp releases in the 2.x series.
 .. _Pulp Smash #81: https://github.com/PulpQE/pulp-smash/issues/81
 """
 from pulp_smash import api, utils
-from pulp_smash.constants import PUPPET_MODULE_URL, REPOSITORY_PATH
+from pulp_smash.constants import PUPPET_MODULE_URL_1, REPOSITORY_PATH
 from pulp_smash.tests.puppet.api_v2.utils import gen_repo
 from pulp_smash.tests.puppet.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
@@ -29,7 +29,7 @@ class DuplicateUploadsTestCase(
     def setUpClass(cls):
         """Create a Puppet repository."""
         super(DuplicateUploadsTestCase, cls).setUpClass()
-        unit = utils.http_get(PUPPET_MODULE_URL)
+        unit = utils.http_get(PUPPET_MODULE_URL_1)
         import_params = {'unit_type_id': 'puppet_module'}
         repo = api.Client(cls.cfg).post(REPOSITORY_PATH, gen_repo()).json()
         cls.upload_import_unit_args = (cls.cfg, unit, import_params, repo)

--- a/pulp_smash/tests/puppet/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/puppet/api_v2/test_sync_publish.py
@@ -41,10 +41,10 @@ from pulp_smash import api, selectors, utils
 from pulp_smash.constants import (
     CALL_REPORT_KEYS,
     CONTENT_UPLOAD_PATH,
-    PUPPET_FEED,
-    PUPPET_MODULE,
-    PUPPET_MODULE_URL,
-    PUPPET_QUERY,
+    PUPPET_FEED_2,
+    PUPPET_MODULE_1,
+    PUPPET_MODULE_URL_1,
+    PUPPET_QUERY_2,
     REPOSITORY_PATH,
 )
 from pulp_smash.tests.puppet.api_v2.utils import gen_repo
@@ -61,7 +61,7 @@ class CreateTestCase(utils.BaseAPITestCase):
         cls.bodies = tuple((gen_repo() for _ in range(2)))
         cls.bodies[1]['importer_config'] = {
             'feed': 'http://' + utils.uuid4(),  # Pulp checks for a URI scheme
-            'queries': [PUPPET_QUERY],
+            'queries': [PUPPET_QUERY_2],
         }
 
         client = api.Client(cls.cfg, api.json_handler)
@@ -118,9 +118,9 @@ class SyncValidFeedTestCase(utils.BaseAPITestCase):
         utils.reset_pulp(cls.cfg)  # See: https://pulp.plan.io/issues/1406
         bodies = tuple((gen_repo() for _ in range(2)))
         for i, query in enumerate((
-                PUPPET_QUERY, PUPPET_QUERY.replace('-', '_'))):
+                PUPPET_QUERY_2, PUPPET_QUERY_2.replace('-', '_'))):
             bodies[i]['importer_config'] = {
-                'feed': PUPPET_FEED,
+                'feed': PUPPET_FEED_2,
                 'queries': [query],
             }
         client = api.Client(cls.cfg, api.json_handler)
@@ -267,7 +267,7 @@ class PublishTestCase(utils.BaseAPITestCase):
         for repo in repos:
             cls.resources.add(repo['_href'])
         client.response_handler = api.safe_handler
-        cls.modules.append(utils.http_get(PUPPET_MODULE_URL))
+        cls.modules.append(utils.http_get(PUPPET_MODULE_URL_1))
 
         # Begin an upload request, upload a puppet module, move the puppet
         # module into a repository, and end the upload request.
@@ -318,7 +318,7 @@ class PublishTestCase(utils.BaseAPITestCase):
 
         # Query both distributors using all three query forms.
         cls.responses['puppet releases'] = []
-        author_name = PUPPET_MODULE['author'] + '/' + PUPPET_MODULE['name']
+        author_name = PUPPET_MODULE_1['author'] + '/' + PUPPET_MODULE_1['name']
         for repo in repos:
             if selectors.bug_is_untestable(1440, cls.cfg.version):
                 continue

--- a/pulp_smash/tests/puppet/cli/test_sync.py
+++ b/pulp_smash/tests/puppet/cli/test_sync.py
@@ -3,7 +3,7 @@
 import unittest
 
 from pulp_smash import cli, config, selectors, utils
-from pulp_smash.constants import PUPPET_FEED, PUPPET_QUERY
+from pulp_smash.constants import PUPPET_FEED_2, PUPPET_QUERY_2
 from pulp_smash.tests.puppet.utils import set_up_module
 
 
@@ -83,7 +83,7 @@ class SyncDownloadedContentTestCase(unittest.TestCase):
             client.run((
                 'pulp-admin puppet repo create '
                 '--repo-id {} --feed {} --queries {}'
-            ).format(repo_id, PUPPET_FEED, PUPPET_QUERY).split())
+            ).format(repo_id, PUPPET_FEED_2, PUPPET_QUERY_2).split())
             self.addCleanup(client.run, (
                 'pulp-admin puppet repo delete --repo-id {}'
             ).format(repo_id).split())
@@ -138,7 +138,7 @@ class SyncFromPuppetForgeTestCase(unittest.TestCase):
         client = cli.Client(cfg)
         cmd = (
             'pulp-admin puppet repo create --repo-id {} --feed {} --queries {}'
-        ).format(repo_id, PUPPET_FEED, PUPPET_QUERY)
+        ).format(repo_id, PUPPET_FEED_2, PUPPET_QUERY_2)
         client.run(cmd.split())
         cmd = 'pulp-admin puppet repo delete --repo-id {}'.format(repo_id)
         self.addCleanup(client.run, cmd.split())


### PR DESCRIPTION
Pulp Fixtures has grown the ability to generate a Puppet module. Make
use of this module, where possible.

The new fixtures provided by Pulp Fixtures are not comprehensive, so
there are still references to the Puppet Forge. To make this distinction
clear, and to ensure that users default to using the fixtures provided
by Puppet Fixtures when possible:

* Append ``_1`` to fixtures provided by Pulp Fixtures.
* Append ``_2`` to fixtures provided by the Puppet Forge.