### PR TITLE
Skip tests affected by Pulp issue 2620

### DIFF
--- a/pulp_smash/tests/rpm/api_v2/test_remove_unit.py
+++ b/pulp_smash/tests/rpm/api_v2/test_remove_unit.py
@@ -15,7 +15,7 @@ from pulp_smash.constants import (
     RPM_SIGNED_FEED_URL,
 )
 from pulp_smash.tests.rpm.api_v2.utils import gen_distributor, gen_repo
-from pulp_smash.tests.rpm.utils import check_issue_2277
+from pulp_smash.tests.rpm.utils import check_issue_2277, check_issue_2620
 from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 _PUBLISH_DIR = 'pulp/repos/'
@@ -49,6 +49,8 @@ class RemoveMissingTestCase(unittest.TestCase):
         cls.repos = {}  # Each inner dict has info about a repository.
         if check_issue_2277(cls.cfg):
             raise unittest.SkipTest('https://pulp.plan.io/issues/2277')
+        if check_issue_2620(cls.cfg):
+            raise unittest.SkipTest('https://pulp.plan.io/issues/2620')
 
     @classmethod
     def tearDownClass(cls):

--- a/pulp_smash/tests/rpm/api_v2/test_republish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_republish.py
@@ -21,7 +21,7 @@ from pulp_smash.tests.rpm.api_v2.utils import (
     gen_repo,
     get_unit,
 )
-from pulp_smash.tests.rpm.utils import check_issue_2277
+from pulp_smash.tests.rpm.utils import check_issue_2277, check_issue_2620
 from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 _PUBLISH_DIR = 'pulp/repos/'
@@ -44,6 +44,8 @@ class RepublishTestCase(unittest.TestCase):
         cfg = config.get_config()
         if check_issue_2277(cfg):
             raise unittest.SkipTest('https://pulp.plan.io/issues/2277')
+        if check_issue_2620(cfg):
+            raise unittest.SkipTest('https://pulp.plan.io/issues/2620')
 
         # Create, sync and publish a repository.
         client = api.Client(cfg, api.json_handler)

--- a/pulp_smash/tests/rpm/api_v2/test_search.py
+++ b/pulp_smash/tests/rpm/api_v2/test_search.py
@@ -27,6 +27,7 @@ from pulp_smash.constants import (
     SRPM_SIGNED_FEED_URL,
 )
 from pulp_smash.tests.rpm.api_v2.utils import gen_repo
+from pulp_smash.tests.rpm.utils import check_issue_2620
 from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 
@@ -39,6 +40,8 @@ class BaseSearchTestCase(utils.BaseAPITestCase):
         if inspect.getmro(cls)[0] == BaseSearchTestCase:
             raise unittest.SkipTest('Abstract base class.')
         super(BaseSearchTestCase, cls).setUpClass()
+        if check_issue_2620(cls.cfg):
+            raise unittest.SkipTest('https://pulp.plan.io/issues/2620')
         body = gen_repo()
         body['importer_config']['feed'] = cls.get_feed_url()
         cls.repo = api.Client(cls.cfg).post(REPOSITORY_PATH, body).json()

--- a/pulp_smash/tests/rpm/api_v2/test_signatures_saved_for_packages.py
+++ b/pulp_smash/tests/rpm/api_v2/test_signatures_saved_for_packages.py
@@ -38,6 +38,7 @@ from pulp_smash.constants import (
     SRPM_UNSIGNED_URL,
 )
 from pulp_smash.tests.rpm.api_v2.utils import gen_repo
+from pulp_smash.tests.rpm.utils import check_issue_2620
 from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 
@@ -137,12 +138,16 @@ class UploadPackageTestCase(_BaseTestCase):
 
     def test_signed_rpm(self):
         """Import a signed RPM into Pulp. Verify its signature."""
+        if check_issue_2620(self.cfg):
+            self.skipTest('https://pulp.plan.io/issues/2620')
         repo_href = self._create_repo_import_unit(RPM_SIGNED_URL)
         unit = self._find_unit(repo_href, RPM_SIGNED_URL)
         self._verify_pkg_key(unit, PULP_FIXTURES_KEY_ID)
 
     def test_signed_srpm(self):
         """Import a signed SRPM into Pulp. Verify its signature."""
+        if check_issue_2620(self.cfg):
+            self.skipTest('https://pulp.plan.io/issues/2620')
         repo_href = self._create_repo_import_unit(SRPM_SIGNED_URL)
         unit = self._find_unit(repo_href, SRPM_SIGNED_URL)
         self._verify_pkg_key(unit, PULP_FIXTURES_KEY_ID)
@@ -157,12 +162,16 @@ class UploadPackageTestCase(_BaseTestCase):
 
     def test_unsigned_rpm(self):
         """Import an unsigned RPM into Pulp. Veriy it has no signature."""
+        if check_issue_2620(self.cfg):
+            self.skipTest('https://pulp.plan.io/issues/2620')
         repo_href = self._create_repo_import_unit(RPM_UNSIGNED_URL)
         unit = self._find_unit(repo_href, RPM_UNSIGNED_URL)
         self.assertNotIn('signing_key', unit['metadata'])
 
     def test_unsigned_srpm(self):
         """Import an unsigned SRPM into Pulp. Verify it has no signature."""
+        if check_issue_2620(self.cfg):
+            self.skipTest('https://pulp.plan.io/issues/2620')
         repo_href = self._create_repo_import_unit(SRPM_UNSIGNED_URL)
         unit = self._find_unit(repo_href, SRPM_UNSIGNED_URL)
         self.assertNotIn('signing_key', unit['metadata'])
@@ -192,12 +201,16 @@ class SyncPackageTestCase(_BaseTestCase):
 
     def test_signed_rpm(self):
         """Assert signature is stored for signed rpm during sync."""
+        if check_issue_2620(self.cfg):
+            self.skipTest('https://pulp.plan.io/issues/2620')
         repo_href = self._create_sync_repo(RPM_SIGNED_FEED_URL)
         unit = self._find_unit(repo_href, RPM_SIGNED_URL)
         self._verify_pkg_key(unit, PULP_FIXTURES_KEY_ID)
 
     def test_signed_srpm(self):
         """Assert signature is stored for signed srpm during sync."""
+        if check_issue_2620(self.cfg):
+            self.skipTest('https://pulp.plan.io/issues/2620')
         repo_href = self._create_sync_repo(SRPM_SIGNED_FEED_URL)
         unit = self._find_unit(repo_href, SRPM_SIGNED_URL)
         self._verify_pkg_key(unit, PULP_FIXTURES_KEY_ID)
@@ -210,12 +223,16 @@ class SyncPackageTestCase(_BaseTestCase):
 
     def test_unsigned_rpm(self):
         """Assert no signature is stored for unsigned rpm during sync."""
+        if check_issue_2620(self.cfg):
+            self.skipTest('https://pulp.plan.io/issues/2620')
         repo_href = self._create_sync_repo(RPM_UNSIGNED_FEED_URL)
         unit = self._find_unit(repo_href, RPM_UNSIGNED_URL)
         self.assertNotIn('signing_key', unit['metadata'])
 
     def test_unsigned_srpm(self):
         """Assert no signature is stored for unsigned srpm during sync."""
+        if check_issue_2620(self.cfg):
+            self.skipTest('https://pulp.plan.io/issues/2620')
         repo_href = self._create_sync_repo(SRPM_UNSIGNED_FEED_URL)
         unit = self._find_unit(repo_href, SRPM_UNSIGNED_URL)
         self.assertNotIn('signing_key', unit['metadata'])

--- a/pulp_smash/tests/rpm/api_v2/test_unassociate.py
+++ b/pulp_smash/tests/rpm/api_v2/test_unassociate.py
@@ -26,7 +26,15 @@ from pulp_smash.constants import (
     RPM_UNSIGNED_URL,
 )
 from pulp_smash.tests.rpm.api_v2.utils import gen_distributor, gen_repo
-from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.rpm.utils import check_issue_2620
+from pulp_smash.tests.rpm.utils import set_up_module
+
+
+def setUpModule():  # pylint:disable=invalid-name
+    """Maybe skip this module of tests."""
+    set_up_module()
+    if check_issue_2620(config.get_config()):
+        raise unittest.SkipTest('https://pulp.plan.io/issues/2620')
 
 
 class RemoveUnitsTestCase(unittest.TestCase):

--- a/pulp_smash/tests/rpm/api_v2/test_updateinfo.py
+++ b/pulp_smash/tests/rpm/api_v2/test_updateinfo.py
@@ -25,7 +25,11 @@ from pulp_smash.tests.rpm.api_v2.utils import (
     get_repodata,
     get_repodata_repomd_xml,
 )
-from pulp_smash.tests.rpm.utils import check_issue_2277, set_up_module
+from pulp_smash.tests.rpm.utils import (
+    check_issue_2277,
+    check_issue_2620,
+    set_up_module,
+)
 
 
 def setUpModule():  # pylint:disable=invalid-name
@@ -404,6 +408,8 @@ class CleanUpTestCase(unittest.TestCase):
     def setUpClass(cls):
         """Create and sync a repository."""
         cls.cfg = config.get_config()
+        if check_issue_2620(cls.cfg):
+            raise unittest.SkipTest('https://pulp.plan.io/issues/2620')
         client = api.Client(cls.cfg, api.json_handler)
         body = gen_repo()
         body['distributors'] = [gen_distributor()]

--- a/pulp_smash/tests/rpm/api_v2/test_upload_publish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_upload_publish.py
@@ -33,6 +33,7 @@ from pulp_smash.tests.rpm.api_v2.utils import (
 from pulp_smash.tests.rpm.utils import (
     check_issue_2277,
     check_issue_2387,
+    check_issue_2620,
     gen_erratum,
 )
 from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
@@ -216,6 +217,8 @@ class UploadSrpmTestCase(utils.BaseAPITestCase):
         3. Search for all content units in the repository.
         """
         super(UploadSrpmTestCase, cls).setUpClass()
+        if check_issue_2620(cls.cfg):
+            raise unittest.SkipTest('https://pulp.plan.io/issues/2620')
         client = api.Client(cls.cfg)
         repo = client.post(REPOSITORY_PATH, gen_repo()).json()
         cls.resources.add(repo['_href'])
@@ -252,8 +255,10 @@ class UploadRpmTestCase(utils.BaseAPITestCase):
     @classmethod
     def setUpClass(cls):
         """Create a pair of RPM repositories."""
-        cls.rpm = utils.http_get(RPM_UNSIGNED_URL)
         cls.cfg = config.get_config()
+        if check_issue_2620(cls.cfg):
+            raise unittest.SkipTest('https://pulp.plan.io/issues/2620')
+        cls.rpm = utils.http_get(RPM_UNSIGNED_URL)
         client = api.Client(cls.cfg, api.json_handler)
         cls.repos = []
         try:

--- a/pulp_smash/tests/rpm/cli/test_copy_units.py
+++ b/pulp_smash/tests/rpm/cli/test_copy_units.py
@@ -10,7 +10,11 @@ from packaging.version import Version
 
 from pulp_smash import cli, config, constants, selectors, utils
 from pulp_smash.tests.rpm.cli.utils import count_langpacks
-from pulp_smash.tests.rpm.utils import check_issue_2277, set_up_module
+from pulp_smash.tests.rpm.utils import (
+    check_issue_2277,
+    check_issue_2620,
+    set_up_module,
+)
 from pulp_smash.utils import is_root
 
 _REPO_ID = utils.uuid4()
@@ -151,6 +155,8 @@ class CopyTestCase(UtilsMixin, unittest.TestCase):
         Verify that only the "chimpanzee" unit is in the target repository.
         """
         cfg = config.get_config()
+        if check_issue_2620(cfg):
+            self.skipTest('https://pulp.plan.io/issues/2620')
         repo_id = self.create_repo(cfg)
         cli.Client(cfg).run(
             'pulp-admin rpm repo copy rpm --from-repo-id {} --to-repo-id {} '
@@ -180,6 +186,8 @@ class CopyRecursiveTestCase(UtilsMixin, unittest.TestCase):
         copied.
         """
         cfg = config.get_config()
+        if check_issue_2620(cfg):
+            self.skipTest('https://pulp.plan.io/issues/2620')
         repo_id = self.create_repo(cfg)
         cli.Client(cfg).run(
             'pulp-admin rpm repo copy rpm --from-repo-id {} --to-repo-id {} '
@@ -255,6 +263,8 @@ class UpdateRpmTestCase(UtilsMixin, unittest.TestCase):
         cfg = config.get_config()
         if check_issue_2277(cfg):
             raise unittest.SkipTest('https://pulp.plan.io/issues/2277')
+        if check_issue_2620(cfg):
+            raise unittest.SkipTest('https://pulp.plan.io/issues/2620')
         client = cli.Client(cfg)
         pkg_mgr = cli.PackageManager(cfg)
         sudo = '' if is_root(cfg) else 'sudo '

--- a/pulp_smash/tests/rpm/cli/test_sync.py
+++ b/pulp_smash/tests/rpm/cli/test_sync.py
@@ -5,7 +5,7 @@ import unittest
 
 from pulp_smash import cli, config, selectors, utils
 from pulp_smash.constants import RPM_UNSIGNED_FEED_URL
-from pulp_smash.tests.rpm.utils import set_up_module
+from pulp_smash.tests.rpm.utils import check_issue_2620, set_up_module
 from pulp_smash.utils import is_root
 
 
@@ -56,6 +56,8 @@ class RemovedContentTestCase(_BaseTestCase):
     def test_all(self):
         """Test whether Pulp can re-sync content into a repository."""
         cfg = config.get_config()
+        if check_issue_2620(cfg):
+            self.skipTest('https://pulp.plan.io/issues/2620')
         repo_id = utils.uuid4()
         client = cli.Client(cfg)
         client.run((

--- a/pulp_smash/tests/rpm/utils.py
+++ b/pulp_smash/tests/rpm/utils.py
@@ -75,6 +75,19 @@ def check_issue_2354(cfg):
     return False
 
 
+def check_issue_2620(cfg):
+    """Return true if `Pulp #2620`_ affects the targeted Pulp system.
+
+    :param pulp_smash.config.ServerConfig cfg: The Pulp system under test.
+
+    .. _Pulp #2620: https://pulp.plan.io/issues/2620
+    """
+    if (cfg.version >= Version('2.12') and
+            selectors.bug_is_untestable(2620, cfg.version)):
+        return True
+    return False
+
+
 def os_is_rhel6(cfg):
     """Return ``True`` if the server runs RHEL 6, or ``False`` otherwise.
 


### PR DESCRIPTION
The title of Pulp issue 2620 is:

> All RPM repo searches are broken

See: https://pulp.plan.io/issues/2620