### PR TITLE
Add tests for RPM metadata character encodings

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -68,6 +68,7 @@ developers, not a gospel.
     api/pulp_smash.tests.rpm
     api/pulp_smash.tests.rpm.api_v2
     api/pulp_smash.tests.rpm.api_v2.test_broker
+    api/pulp_smash.tests.rpm.api_v2.test_character_encoding
     api/pulp_smash.tests.rpm.api_v2.test_comps_xml
     api/pulp_smash.tests.rpm.api_v2.test_crud
     api/pulp_smash.tests.rpm.api_v2.test_download_policies
@@ -99,6 +100,7 @@ developers, not a gospel.
     api/pulp_smash.tests.rpm.api_v2.test_upload_publish
     api/pulp_smash.tests.rpm.api_v2.utils
     api/pulp_smash.tests.rpm.cli
+    api/pulp_smash.tests.rpm.cli.test_character_encoding
     api/pulp_smash.tests.rpm.cli.test_copy_units
     api/pulp_smash.tests.rpm.cli.test_environments
     api/pulp_smash.tests.rpm.cli.test_langpacks

--- a/docs/api/pulp_smash.tests.rpm.api_v2.test_character_encoding.rst
+++ b/docs/api/pulp_smash.tests.rpm.api_v2.test_character_encoding.rst
@@ -1,0 +1,6 @@
+`pulp_smash.tests.rpm.api_v2.test_character_encoding`
+=====================================================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.rpm.api_v2.test_character_encoding`
+
+.. automodule:: pulp_smash.tests.rpm.api_v2.test_character_encoding

--- a/docs/api/pulp_smash.tests.rpm.cli.test_character_encoding.rst
+++ b/docs/api/pulp_smash.tests.rpm.cli.test_character_encoding.rst
@@ -1,0 +1,6 @@
+`pulp_smash.tests.rpm.cli.test_character_encoding`
+==================================================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.rpm.cli.test_character_encoding`
+
+.. automodule:: pulp_smash.tests.rpm.cli.test_character_encoding

--- a/pulp_smash/constants.py
+++ b/pulp_smash/constants.py
@@ -446,6 +446,18 @@ RPM_WITH_PULP_DISTRIBUTION_FEED_URL = urljoin(
     PULP_FIXTURES_BASE_URL, 'rpm-with-pulp-distribution/')
 """The URL to a RPM repository with a PULP_DISTRIBUTION.xml file."""
 
+RPM_WITH_NON_ASCII_URL = urljoin(
+    PULP_FIXTURES_BASE_URL,
+    'rpm-with-non-ascii/rpm-with-non-ascii-1-1.fc24.noarch.rpm'
+)
+"""The URL to an RPM with non-ascii metadata in its header."""
+
+RPM_WITH_NON_UTF_8_URL = urljoin(
+    PULP_FIXTURES_BASE_URL,
+    'rpm-with-non-utf-8/rpm-with-non-utf-8-1-1.fc24.noarch.rpm'
+)
+"""The URL to an RPM with non-UTF-8 metadata in its header."""
+
 SRPM = 'test-srpm02-1.0-1.src.rpm'
 """An SRPM file at :data:`pulp_smash.constants.SRPM_SIGNED_FEED_URL`."""
 

--- a/pulp_smash/tests/rpm/api_v2/test_character_encoding.py
+++ b/pulp_smash/tests/rpm/api_v2/test_character_encoding.py
@@ -1,0 +1,61 @@
+# coding=utf-8
+"""Tests for Pulp's character encoding handling.
+
+RPM files have metadata embedded in their headers. This metadata should be
+encoded as utf-8, and Pulp should gracefully handle cases where invalid byte
+sequences are encountered.
+"""
+import unittest
+
+from pulp_smash import api, config, selectors, utils
+from pulp_smash.constants import (
+    REPOSITORY_PATH,
+    RPM_WITH_NON_ASCII_URL,
+    RPM_WITH_NON_UTF_8_URL,
+)
+from pulp_smash.tests.rpm.api_v2.utils import gen_repo
+from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+
+
+class UploadNonAsciiTestCase(unittest.TestCase):
+    """Test whether one can upload an RPM with non-ascii metadata.
+
+    Specifically, do the following:
+
+    1. Create an RPM repository.
+    2. Upload and import :data:`pulp_smash.constants.RPM_WITH_NON_ASCII_URL`
+       into the repository.
+    """
+
+    def test_all(self):
+        """Test whether one can upload an RPM with non-ascii metadata."""
+        cfg = config.get_config()
+        client = api.Client(cfg, api.json_handler)
+        repo = client.post(REPOSITORY_PATH, gen_repo())
+        self.addCleanup(client.delete, repo['_href'])
+        rpm = utils.http_get(RPM_WITH_NON_ASCII_URL)
+        utils.upload_import_unit(cfg, rpm, {'unit_type_id': 'rpm'}, repo)
+
+
+class UploadNonUtf8TestCase(unittest.TestCase):
+    """Test whether one can upload an RPM with non-utf-8 metadata.
+
+    Specifically, do the following:
+
+    1. Create an RPM repository.
+    2. Upload and import :data:`pulp_smash.constants.RPM_WITH_NON_UTF_8_URL`
+       into the repository.
+
+    This test case targets `Pulp #1903 <https://pulp.plan.io/issues/1903>`_.
+    """
+
+    def test_all(self):
+        """Test whether one can upload an RPM with non-ascii metadata."""
+        cfg = config.get_config()
+        if selectors.bug_is_untestable(1903, cfg.version):
+            self.skipTest('https://pulp.plan.io/issues/1903')
+        client = api.Client(cfg, api.json_handler)
+        repo = client.post(REPOSITORY_PATH, gen_repo())
+        self.addCleanup(client.delete, repo['_href'])
+        rpm = utils.http_get(RPM_WITH_NON_UTF_8_URL)
+        utils.upload_import_unit(cfg, rpm, {'unit_type_id': 'rpm'}, repo)

--- a/pulp_smash/tests/rpm/cli/test_character_encoding.py
+++ b/pulp_smash/tests/rpm/cli/test_character_encoding.py
@@ -1,0 +1,100 @@
+# coding=utf-8
+"""Tests for Pulp's character encoding handling.
+
+RPM files have metadata embedded in their headers. This metadata should be
+encoded as utf-8, and Pulp should gracefully handle cases where invalid byte
+sequences are encountered.
+"""
+import unittest
+
+from pulp_smash import cli, config, selectors, utils
+from pulp_smash.constants import RPM_WITH_NON_ASCII_URL, RPM_WITH_NON_UTF_8_URL
+from pulp_smash.tests.rpm.utils import set_up_module
+
+
+def setUpModule():  # pylint:disable=invalid-name
+    """Execute ``pulp-admin login``."""
+    set_up_module()
+    utils.pulp_admin_login(config.get_config())
+
+
+class UploadNonAsciiTestCase(unittest.TestCase):
+    """Test whether one can upload an RPM with non-ascii metadata.
+
+    Specifically, do the following:
+
+    1. Create an RPM repository.
+    2. Upload and import :data:`pulp_smash.constants.RPM_WITH_NON_ASCII_URL`
+       into the repository.
+    """
+
+    def test_all(self):
+        """Test whether one can upload an RPM with non-ascii metadata."""
+        cfg = config.get_config()
+        client = cli.Client(cfg)
+
+        # Get the RPM
+        rpm = client.run(('mktemp',)).stdout.strip()
+        self.addCleanup(client.run, ('rm', rpm))
+        client.run(('curl', '--output', rpm, RPM_WITH_NON_ASCII_URL))
+
+        # Create a repo.
+        repo_id = utils.uuid4()
+        client.run((
+            'pulp-admin', 'rpm', 'repo', 'create', '--repo-id', repo_id
+        ))
+        self.addCleanup(
+            client.run,
+            ('pulp-admin', 'rpm', 'repo', 'delete', '--repo-id', repo_id)
+        )
+
+        # Upload an RPM.
+        response = client.run((
+            'pulp-admin', 'rpm', 'repo', 'uploads', 'rpm', '--repo-id',
+            repo_id, '--file', rpm
+        ))
+        for stream in (response.stdout, response.stderr):
+            self.assertNotIn('Task Failed', stream)
+
+
+class UploadNonUtf8TestCase(unittest.TestCase):
+    """Test whether one can upload an RPM with non-utf-8 metadata.
+
+    Specifically, do the following:
+
+    1. Create an RPM repository.
+    2. Upload and import :data:`pulp_smash.constants.RPM_WITH_NON_UTF_8_URL`
+       into the repository.
+
+    This test case targets `Pulp #1903 <https://pulp.plan.io/issues/1903>`_.
+    """
+
+    def test_all(self):
+        """Test whether one can upload an RPM with non-utf-8 metadata."""
+        cfg = config.get_config()
+        if selectors.bug_is_untestable(1903, cfg.version):
+            self.skipTest('https://pulp.plan.io/issues/1903')
+        client = cli.Client(cfg)
+
+        # Get the RPM
+        rpm = client.run(('mktemp',)).stdout.strip()
+        self.addCleanup(client.run, ('rm', rpm))
+        client.run(('curl', '--output', rpm, RPM_WITH_NON_UTF_8_URL))
+
+        # Create a repo.
+        repo_id = utils.uuid4()
+        client.run((
+            'pulp-admin', 'rpm', 'repo', 'create', '--repo-id', repo_id
+        ))
+        self.addCleanup(
+            client.run,
+            ('pulp-admin', 'rpm', 'repo', 'delete', '--repo-id', repo_id)
+        )
+
+        # Upload an RPM.
+        response = client.run((
+            'pulp-admin', 'rpm', 'repo', 'uploads', 'rpm', '--repo-id',
+            repo_id, '--file', rpm
+        ))
+        for stream in (response.stdout, response.stderr):
+            self.assertNotIn('Task Failed', stream)


### PR DESCRIPTION
According to Pulp issue 1903, it should be possible to upload an RPM to
Pulp even when that RPM has non-utf8 metadata in its header. Add API and
CLI tests to check whether this is true.

See: https://pulp.plan.io/issues/1903

Fix: https://github.com/PulpQE/pulp-smash/issues/524