### PR TITLE
Only run certain Python tests when appropriate

### DIFF
--- a/pulp_smash/tests/python/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/python/api_v2/test_sync_publish.py
@@ -58,7 +58,8 @@ class BaseTestCase(unittest.TestCase):
         * `Pulp #140 <https://pulp.plan.io/issues/140>`_
         * `Pulp Smash #493 <https://github.com/PulpQE/pulp-smash/issues/493>`_
         """
-        if selectors.bug_is_untestable(140, self.cfg.version):
+        if (self.cfg.version <= Version('2.13') or
+                selectors.bug_is_untestable(140, self.cfg.version)):
             self.skipTest('https://pulp.plan.io/issues/140')
         client = api.Client(self.cfg, api.json_handler)
         body = gen_repo()
@@ -112,7 +113,7 @@ class SyncTestCase(BaseTestCase):
         * `Pulp #135 <https://pulp.plan.io/issues/135>`_
         * `Pulp Smash #494 <https://github.com/PulpQE/pulp-smash/issues/494>`_
         """
-        if (self.cfg.version <= Version('2.12.1') or
+        if (self.cfg.version <= Version('2.13') or
                 selectors.bug_is_untestable(135, self.cfg.version)):
             self.skipTest('https://pulp.plan.io/issues/135')
         client = api.Client(self.cfg, api.json_handler)
@@ -145,9 +146,9 @@ class UploadTestCase(BaseTestCase):
         * `Pulp #2334 <https://pulp.plan.io/issues/2334>`_
         * `Pulp Smash #492 <https://github.com/PulpQE/pulp-smash/issues/492>`_
         """
-        if (self.cfg.version <= Version('2.12.1') or
+        if (self.cfg.version <= Version('2.13') or
                 selectors.bug_is_untestable(136, self.cfg.version)):
-            self.skipTest('https://pulp.plan.io/issues/135')
+            self.skipTest('https://pulp.plan.io/issues/136')
         client = api.Client(self.cfg, api.json_handler)
         body = gen_repo()
         body['distributors'] = [gen_distributor()]


### PR DESCRIPTION
The tests in module `pulp_smash.tests.python.api_v2.test_sync_publish`
make use of features that are introduced in Python plugin version 2.
This plugin will be added in Pulp 2.13.

Ensure that the tests in this module don't run unless Pulp 2.13 or later
is being tested.

Fix: https://github.com/PulpQE/pulp-smash/issues/588