### PR TITLE
Update RPM_WITH_NON_{ASCII,UTF_8}_URL constants

### DIFF
--- a/pulp_smash/constants.py
+++ b/pulp_smash/constants.py
@@ -448,13 +448,13 @@ RPM_WITH_PULP_DISTRIBUTION_FEED_URL = urljoin(
 
 RPM_WITH_NON_ASCII_URL = urljoin(
     PULP_FIXTURES_BASE_URL,
-    'rpm-with-non-ascii/rpm-with-non-ascii-1-1.fc24.noarch.rpm'
+    'rpm-with-non-ascii/rpm-with-non-ascii-1-1.fc25.noarch.rpm'
 )
 """The URL to an RPM with non-ascii metadata in its header."""
 
 RPM_WITH_NON_UTF_8_URL = urljoin(
     PULP_FIXTURES_BASE_URL,
-    'rpm-with-non-utf-8/rpm-with-non-utf-8-1-1.fc24.noarch.rpm'
+    'rpm-with-non-utf-8/rpm-with-non-utf-8-1-1.fc25.noarch.rpm'
 )
 """The URL to an RPM with non-UTF-8 metadata in its header."""
 


### PR DESCRIPTION
The fixtures were published by a Fedora 25 which produces RPM for fc25
instead of fc24. Update RPM_WITH_NON_ASCII_URL and
RPM_WITH_NON_UTF_8_URL constants.