### PR TITLE
Test Puppet download HTTP headers

### DIFF
--- a/pulp_smash/tests/puppet/api_v2/utils.py
+++ b/pulp_smash/tests/puppet/api_v2/utils.py
@@ -11,3 +11,13 @@ def gen_repo():
         'importer_type_id': 'puppet_importer',
         'notes': {'_repo-type': 'puppet-repo'},
     }
+
+
+def gen_distributor():
+    """Return a semi-random dict for use in creating a Puppet distributor."""
+    return {
+        'auto_publish': False,
+        'distributor_config': {'serve_http': True, 'serve_https': True},
+        'distributor_id': utils.uuid4(),
+        'distributor_type_id': 'puppet_distributor',
+    }


### PR DESCRIPTION
Rewrite test case `SyncValidFeedTestCase` in module
`pulp_smash.tests.puppet.api-v2.test_sync_publish`. Make at least the
following changes:

* Drop the call to function `reset_pulp`. This call worked around an
  issue fixed in Pulp 2.8. We're now developing Pulp 2.13, and keeping
  it in simply lengthens the test suite execution time.
* Make the test case more robust in the case of failures, by ensuring
  that repositories are deleted even when unexpected failures occur.
* Drop several assertions relating to the tasks spawned during a
  repository sync. These checks are already done by
  `pulp_smash.api.safe_handler` and `pulp_smash.api.json_handler`.
* Add assertions to verify that the content units synced into a
  repository can be downloaded. This is the most important addition.

Fix: https://github.com/PulpQE/pulp-smash/issues/521

See: https://pulp.plan.io/issues/1781