### PR TITLE
Add API tests for puppet install distributor

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -53,6 +53,7 @@ developers, not a gospel.
     api/pulp_smash.tests.puppet.api_v2
     api/pulp_smash.tests.puppet.api_v2.test_crud
     api/pulp_smash.tests.puppet.api_v2.test_duplicate_uploads
+    api/pulp_smash.tests.puppet.api_v2.test_install_distributor
     api/pulp_smash.tests.puppet.api_v2.test_sync_publish
     api/pulp_smash.tests.puppet.api_v2.utils
     api/pulp_smash.tests.puppet.cli

--- a/docs/api/pulp_smash.tests.puppet.api_v2.test_install_distributor.rst
+++ b/docs/api/pulp_smash.tests.puppet.api_v2.test_install_distributor.rst
@@ -1,0 +1,6 @@
+`pulp_smash.tests.puppet.api_v2.test_install_distributor`
+=========================================================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.puppet.api_v2.test_install_distributor`
+
+.. automodule:: pulp_smash.tests.puppet.api_v2.test_install_distributor

--- a/pulp_smash/tests/puppet/api_v2/test_install_distributor.py
+++ b/pulp_smash/tests/puppet/api_v2/test_install_distributor.py
@@ -1,0 +1,73 @@
+# coding=utf-8
+"""Tests for puppet_install_distributor.
+
+For more information check `puppet_install_distributor`_
+
+.. _puppet_install_distributor:
+    http://docs.pulpproject.org/plugins/pulp_puppet/tech-reference/plugin_conf.html?#install-distributor
+"""
+from pulp_smash import api, cli, utils
+from pulp_smash.constants import (
+    PUPPET_MODULE_1,
+    PUPPET_MODULE_URL_1,
+    REPOSITORY_PATH,
+)
+from pulp_smash.tests.puppet.api_v2.utils import (
+    gen_install_distributor,
+    gen_repo,
+)
+from pulp_smash.tests.puppet.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+
+
+class InstallDistributorTestCase(utils.BaseAPITestCase):
+    """Test Puppet install distributor."""
+
+    def test_all(self):
+        """Test puppet_install_distributor.
+
+        Do the following:
+
+        1. Create a puppet repository with a puppet_install_distributor
+        2. Upload a puppet module
+        3. Publish the repository
+        4. Check if the puppet_install_distributor config was properly used
+        """
+        cli_client = cli.Client(self.cfg)
+        sudo = '' if utils.is_root(self.cfg) else 'sudo '
+        install_path = cli_client.run(
+            'mktemp --directory'.split()).stdout.strip()
+        self.addCleanup(
+            cli_client.run, (sudo + 'rm -rf {} ' + install_path).split())
+
+        # Make sure Pulp can write to the install_path directory
+        cli_client.run((sudo + 'chown apache:apache ' + install_path).split())
+        cli_client.run(
+            (sudo + 'chcon -t puppet_etc_t ' + install_path).split())
+
+        # Make sure the pulp_manage_puppet boolean is enabled
+        cli_client.run((
+            sudo + 'semanage boolean --modify --on pulp_manage_puppet'
+        ).split())
+        self.addCleanup(
+            cli_client.run,
+            (sudo + 'semanage boolean --modify --off pulp_manage_puppet')
+            .split()
+        )
+
+        install_distributor = gen_install_distributor()
+        install_distributor['distributor_config']['install_path'] = (
+            install_path)
+        body = gen_repo()
+        body['distributors'] = [install_distributor]
+        client = api.Client(self.cfg, api.json_handler)
+        repo = client.post(REPOSITORY_PATH, body)
+        self.addCleanup(client.delete, repo['_href'])
+        repo = client.get(repo['_href'], params={'details': True})
+        unit = utils.http_get(PUPPET_MODULE_URL_1)
+        utils.upload_import_unit(
+            self.cfg, unit, {'unit_type_id': 'puppet_module'}, repo)
+        utils.publish_repo(self.cfg, repo)
+        self.assertIn(
+            PUPPET_MODULE_1['name'],
+            cli_client.run(('ls ' + install_path).split()).stdout
+        )

--- a/pulp_smash/tests/puppet/api_v2/utils.py
+++ b/pulp_smash/tests/puppet/api_v2/utils.py
@@ -21,3 +21,17 @@ def gen_distributor():
         'distributor_id': utils.uuid4(),
         'distributor_type_id': 'puppet_distributor',
     }
+
+
+def gen_install_distributor():
+    """Return a semi-random dict used for creating a Puppet install distributor.
+
+    The caller must fill the install_path distributor_config option otherwise
+    Pulp will throw an error when creating the distributor.
+    """
+    return {
+        'auto_publish': False,
+        'distributor_config': {},
+        'distributor_id': utils.uuid4(),
+        'distributor_type_id': 'puppet_install_distributor',
+    }


### PR DESCRIPTION
Make sure the puppet_install_distributor publishes Puppet modules as
expected.