### PR TITLE
Un-break Puppet test case

### DIFF
--- a/pulp_smash/tests/puppet/api_v2/test_install_distributor.py
+++ b/pulp_smash/tests/puppet/api_v2/test_install_distributor.py
@@ -61,8 +61,9 @@ class InstallDistributorTestCase(utils.BaseAPITestCase):
             self.cfg, unit, {'unit_type_id': 'puppet_module'}, repo)
 
         # Publish, and verify the module is present. (Dir has 700 permissions.)
+        utils.publish_repo(self.cfg, repo)
         proc = cli_client.run(sudo + (
-            'runuser', '--shell', '/bin/sh', 'apache', '--command', 'ls', '-1',
-            install_path
+            'runuser', '--shell', '/bin/sh', '--command',
+            'ls -1 {}'.format(install_path), '-', 'apache'
         ))
-        self.assertIn(PUPPET_MODULE_1['name'], proc.stdout.split('\n'))
+        self.assertIn(PUPPET_MODULE_1['name'], proc.stdout.split('\n'), proc)


### PR DESCRIPTION
Commit 9e435390eb467741ba16ba632b8b7b9a61b51471 updated
`InstallDistributorTestCase` by ensuring that the correct permissions
are in use when inspecting the files created by Pulp. However, that
commit removes a necessary repository publish step, and uses the
`runuser` executable incorrectly. Fix these *glaring* errors. Mea culpa.