### PR TITLE
Skip test affected by Pulp issue 2613

### DIFF
--- a/pulp_smash/tests/rpm/api_v2/test_broker.py
+++ b/pulp_smash/tests/rpm/api_v2/test_broker.py
@@ -26,6 +26,8 @@ Both scenarios are executed by
 import time
 import unittest
 
+from packaging.version import Version
+
 from pulp_smash import api, cli, config, selectors, utils
 from pulp_smash.constants import (
     PULP_SERVICES,
@@ -93,9 +95,17 @@ class BrokerTestCase(unittest.TestCase):
         2. Stop the broker, wait, and start it again.
         3. Test Pulp's health. Create an RPM repository, sync it, add a
            distributor, publish it, and download an RPM.
+
+        This test targets:
+
+        * `Pulp #1635 <https://pulp.plan.io/issues/1635>`_
+        * `Pulp #2613 <https://pulp.plan.io/issues/2613>`_
         """
         if selectors.bug_is_untestable(1635, self.cfg.version):
             self.skipTest('https://pulp.plan.io/issues/1635')
+        if (self.cfg.version >= Version('2.13') and
+                selectors.bug_is_untestable(2613, self.cfg.version)):
+            self.skipTest('https://pulp.plan.io/issues/2613')
         # We assume that the broker and other services are already running. As
         # a result, we skip step 1 and go straight to step 2.
         self.svc_mgr.stop(self.broker)


### PR DESCRIPTION
The title of Pulp issue 2613 is:

> Broker reconnect support broken

See: https://pulp.plan.io/issues/2613