### PR TITLE
Run Python sync tests for Pulp 2.13+

### DIFF
--- a/pulp_smash/tests/python/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/python/api_v2/test_sync_publish.py
@@ -58,7 +58,7 @@ class BaseTestCase(unittest.TestCase):
         * `Pulp #140 <https://pulp.plan.io/issues/140>`_
         * `Pulp Smash #493 <https://github.com/PulpQE/pulp-smash/issues/493>`_
         """
-        if (self.cfg.version <= Version('2.13') or
+        if (self.cfg.version < Version('2.13') or
                 selectors.bug_is_untestable(140, self.cfg.version)):
             self.skipTest('https://pulp.plan.io/issues/140')
         client = api.Client(self.cfg, api.json_handler)
@@ -113,7 +113,7 @@ class SyncTestCase(BaseTestCase):
         * `Pulp #135 <https://pulp.plan.io/issues/135>`_
         * `Pulp Smash #494 <https://github.com/PulpQE/pulp-smash/issues/494>`_
         """
-        if (self.cfg.version <= Version('2.13') or
+        if (self.cfg.version < Version('2.13') or
                 selectors.bug_is_untestable(135, self.cfg.version)):
             self.skipTest('https://pulp.plan.io/issues/135')
         client = api.Client(self.cfg, api.json_handler)
@@ -146,7 +146,7 @@ class UploadTestCase(BaseTestCase):
         * `Pulp #2334 <https://pulp.plan.io/issues/2334>`_
         * `Pulp Smash #492 <https://github.com/PulpQE/pulp-smash/issues/492>`_
         """
-        if (self.cfg.version <= Version('2.13') or
+        if (self.cfg.version < Version('2.13') or
                 selectors.bug_is_untestable(136, self.cfg.version)):
             self.skipTest('https://pulp.plan.io/issues/136')
         client = api.Client(self.cfg, api.json_handler)


### PR DESCRIPTION
The tests in module `pulp_smash.tests.python.api_v2.test_sync_publish`
should run when Pulp 2.13 or newer is under test.