### PR TITLE
Skip Docker v2 tests on Pulp 2.13 (for now!)

### DIFF
--- a/pulp_smash/tests/docker/cli/test_sync_publish.py
+++ b/pulp_smash/tests/docker/cli/test_sync_publish.py
@@ -105,6 +105,11 @@ class SyncPublishV2TestCase(unittest.TestCase):
         some information for use by the test methods.
         """
         cls.cfg = config.get_config()
+        if cls.cfg.version >= Version('2.13'):
+            raise unittest.SkipTest(
+                'These tests are not yet compatible with Pulp 2.13+. Please '
+                'update the CI jobs to install Crane.'
+            )
         if cls.cfg.version < Version('2.8'):
             raise unittest.SkipTest('These tests require Pulp 2.8 or above.')
         if (cls.cfg.version >= Version('2.9') and


### PR DESCRIPTION
`SyncPublishV2TestCase` in module
`pulp_smash/tests/docker/cli/test_sync_publish.py` syncs and publishes a
v2 Docker repository. Unfortunately, this test case also interacts with
the pulp_docker plugin directly, instead of talking to the Crane
plug-in. As a result, the changes to pulp_docker in Pulp 2.13 break this
test case.

Updating the test case to work well with either version of Pulp is
infeasible. The changes to pulp_docker are extensive, and they're
internal anyway: clients should talk to Crane.

Skip this test case if Pulp 2.13 or newer is under test. This "fix" is a
band-aid. The test should be re-written to use Crane — and the CI jobs
should be updated to install and configure Crane!