### PR TITLE
Implement new configuration file format

### DIFF
--- a/pulp_smash/tests/docker/api_v2/test_tags.py
+++ b/pulp_smash/tests/docker/api_v2/test_tags.py
@@ -31,7 +31,8 @@ def setUpModule():  # pylint:disable=invalid-name
 def create_docker_repo(cfg, upstream_name, use_v1=False):
     """Create a docker repository.
 
-    :param pulp_smash.config.ServerConfig cfg: Information about a Pulp host.
+    :param pulp_smash.config.PulpSmashConfig cfg: Information about a Pulp
+        host.
     :param upstream_name: The Docker container upstream name.
     :param use_v1: If ``True`` use Docker V1 feed URL else use Docker V2 feed
         URL.
@@ -55,7 +56,8 @@ def create_docker_repo(cfg, upstream_name, use_v1=False):
 def import_upload(cfg, repo, params):
     """Create or update a docker repository.
 
-    :param pulp_smash.config.ServerConfig cfg: Information about a Pulp host.
+    :param pulp_smash.config.PulpSmashConfig cfg: Information about a Pulp
+        host.
     :param repo: A dict of information about the targed repository.
     :param params: A dict of information to pass as import_upload body.
     :return: A dict of information about the creation/update report.

--- a/pulp_smash/tests/docker/cli/test_copy.py
+++ b/pulp_smash/tests/docker/cli/test_copy.py
@@ -22,8 +22,8 @@ def _get_unit_ids(server_config, repo_id, unit_type, regex):
     This method is highly specific to the tests in this module, and the best
     way to understand it is to read its source code.
 
-    :param pulp_smash.config.ServerConfig server_config: Information about the
-        Pulp server being targeted.
+    :param pulp_smash.config.PulpSmashConfig server_config: Information about
+        the Pulp server being targeted.
     :param repo_id: A docker repository ID.
     :param unit_type: A type of docker content unit, like "image" or "tag."
     :param regex: A regex for searching stdout for unit IDs.

--- a/pulp_smash/tests/docker/cli/utils.py
+++ b/pulp_smash/tests/docker/cli/utils.py
@@ -2,9 +2,10 @@
 """Utility functions for docker CLI tests.
 
 All of the functions in this module share a common structure. The first
-argument is a :class:`pulp_smash.config.ServerConfig`, and all other arguments
-correspond to command-line options. Most arguments are named after a flag. For
-example, an argument ``to_repo_id`` corresponds to the flag ``--to-repo-id``.
+argument is a :class:`pulp_smash.config.PulpSmashConfig`, and all other
+arguments correspond to command-line options. Most arguments are named after a
+flag. For example, an argument ``to_repo_id`` corresponds to the flag
+``--to-repo-id``.
 
 For the meaning of each argument, see pulp-admin.
 """

--- a/pulp_smash/tests/platform/cli/test_content_sources.py
+++ b/pulp_smash/tests/platform/cli/test_content_sources.py
@@ -18,7 +18,7 @@ def generate_content_source(server_config, name, **kwargs):
     .. _Defining a Content Source:
         http://docs.pulpproject.org/user-guide/content-sources.html#defining-a-content-source
 
-    :param server_config: A :class:`pulp_smash.config.ServerConfig` object.
+    :param server_config: A :class:`pulp_smash.config.PulpSmashConfig` object.
     :param name: file name and content source id (string inside []).
     :param kwargs: each item will be converted to content source properties
         where the key is the property name and the value its value.
@@ -48,7 +48,7 @@ def generate_content_source(server_config, name, **kwargs):
 def _get_content_source_ids(server_config):
     """Get the id list of all content sources, or empty list.
 
-    :param server_config: A :class:`pulp_smash.config.ServerConfig` object.
+    :param server_config: A :class:`pulp_smash.config.PulpSmashConfig` object.
     :returns: A list of content source IDs, where each ID is a string.
     """
     keyword = 'Source Id:'

--- a/pulp_smash/tests/platform/cli/test_pulp_manage_db.py
+++ b/pulp_smash/tests/platform/cli/test_pulp_manage_db.py
@@ -52,7 +52,7 @@ class BaseTestCase(unittest.TestCase):
 
     def tearDown(self):
         """Start all of Pulp's services."""
-        cli.ServiceManager(config.get_config()).start(
+        cli.GlobalServiceManager(config.get_config()).start(
             CONFLICTING_SERVICES.union(REQUIRED_SERVICES)
         )
 
@@ -62,7 +62,7 @@ class PositiveTestCase(BaseTestCase):
 
     def test_conflicting_stopped(self):
         """Test with :data:`CONFLICTING_SERVICES` stopped."""
-        cli.ServiceManager(self.cfg).stop((
+        cli.GlobalServiceManager(self.cfg).stop((
             'pulp_celerybeat',
             'pulp_resource_manager',
             'pulp_workers',
@@ -75,7 +75,7 @@ class NegativeTestCase(BaseTestCase):
 
     def test_required_stopped(self):
         """Test with :data:`REQUIRED_SERVICES` stopped."""
-        cli.ServiceManager(self.cfg).stop(REQUIRED_SERVICES)
+        cli.GlobalServiceManager(self.cfg).stop(REQUIRED_SERVICES)
         self._do_test()
 
     def test_conflicting_running(self):
@@ -84,7 +84,7 @@ class NegativeTestCase(BaseTestCase):
 
     def test_celerybeat_running(self):
         """Test with ``pulp_celerybeat`` running."""
-        cli.ServiceManager(config.get_config()).stop((
+        cli.GlobalServiceManager(config.get_config()).stop((
             CONFLICTING_SERVICES.difference(('pulp_celerybeat',))
         ))
         self._do_test()
@@ -96,7 +96,7 @@ class NegativeTestCase(BaseTestCase):
         """
         if selectors.bug_is_untestable(2684, self.cfg.version):
             self.skipTest('https://pulp.plan.io/issues/2684')
-        cli.ServiceManager(config.get_config()).stop((
+        cli.GlobalServiceManager(config.get_config()).stop((
             CONFLICTING_SERVICES.difference(('pulp_resource_manager',))
         ))
         self._do_test()
@@ -108,7 +108,7 @@ class NegativeTestCase(BaseTestCase):
         """
         if selectors.bug_is_untestable(2684, self.cfg.version):
             self.skipTest('https://pulp.plan.io/issues/2684')
-        cli.ServiceManager(config.get_config()).stop((
+        cli.GlobalServiceManager(config.get_config()).stop((
             CONFLICTING_SERVICES.difference(('pulp_workers',))
         ))
         self._do_test()

--- a/pulp_smash/tests/puppet/cli/test_sync.py
+++ b/pulp_smash/tests/puppet/cli/test_sync.py
@@ -20,8 +20,8 @@ def setUpModule():  # pylint:disable=invalid-name
 def get_num_units_in_repo(server_config, repo_id):
     """Tell how many puppet modules are in a repository.
 
-    :param pulp_smash.config.ServerConfig server_config: Information about the
-        Pulp server being targeted.
+    :param pulp_smash.config.PulpSmashConfig server_config: Information about
+        the Pulp server being targeted.
     :param repo_id: A Puppet repository ID.
     :returns: The number of puppet modules in a repository, as an ``int``.
     """

--- a/pulp_smash/tests/rpm/api_v2/test_broker.py
+++ b/pulp_smash/tests/rpm/api_v2/test_broker.py
@@ -56,7 +56,7 @@ class BrokerTestCase(unittest.TestCase):
         if check_issue_2387(self.cfg):
             self.skipTest('https://pulp.plan.io/issues/2387')
         self.broker = (utils.get_broker(self.cfg),)
-        self.svc_mgr = cli.ServiceManager(self.cfg)
+        self.svc_mgr = cli.GlobalServiceManager(self.cfg)
 
     def tearDown(self):
         """Ensure Pulp services and AMQP broker are running.

--- a/pulp_smash/tests/rpm/api_v2/test_export.py
+++ b/pulp_smash/tests/rpm/api_v2/test_export.py
@@ -89,7 +89,7 @@ class ExportDirMixin(DisableSELinuxMixin):
     other methods only if more granularity is needed.
 
     A class attribute named ``cfg`` must be present. It should be a
-    :class:`pulp_smash.config.ServerConfig`.
+    :class:`pulp_smash.config.PulpSmashConfig`.
     """
 
     def __init__(self, *args, **kwargs):

--- a/pulp_smash/tests/rpm/api_v2/test_mirrorlist.py
+++ b/pulp_smash/tests/rpm/api_v2/test_mirrorlist.py
@@ -59,8 +59,8 @@ class UtilsMixin(object):
 
         In addition, schedule the repository for deletion with ``addCleanup``.
 
-        :param pulp_smash.config.ServerConfig cfg: The Pulp server on which to
-            create a repository.
+        :param pulp_smash.config.PulpSmashConfig cfg: The Pulp deployment on
+            which to create a repository.
         :param feed: A value for the yum importer's ``feed`` option.
         :param relative_url: A value for the yum distributor's ``relative_url``
             option. If ``None``, this option is not passed to Pulp.

--- a/pulp_smash/tests/rpm/api_v2/test_repository_layout.py
+++ b/pulp_smash/tests/rpm/api_v2/test_repository_layout.py
@@ -37,8 +37,8 @@ from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pyli
 def get_parse_repodata_xml(server_config, distributor, file_path):
     """Fetch, parse and return an XML file from a ``repodata`` directory.
 
-    :param pulp_smash.config.ServerConfig server_config: Information about the
-        Pulp server being targeted.
+    :param pulp_smash.config.PulpSmashConfig server_config: Information about
+        the Pulp deployment being targeted.
     :param distributor: Information about a distributor. It should be a dict
         containing at least ``{'config': {'relative_url': …}}``.
     :param file_path: The path to an XML file, relative to the distributor's
@@ -53,8 +53,8 @@ def get_parse_repodata_xml(server_config, distributor, file_path):
 def get_parse_repodata_primary_xml(cfg, distributor):
     """Fetch, decompress, parse and return a ``repodata/…primary.xml.gz`` file.
 
-    :param pulp_smash.config.ServerConfig cfg: Information about the Pulp
-        server being targeted.
+    :param pulp_smash.config.PulpSmashConfig cfg: Information about the Pulp
+        deployment being targeted.
     :param distributor: Information about a distributor. It should be a dict
         containing at least ``{'config': {'relative_url': …}}``.
     :returns: An ``xml.etree.ElementTree`` object.

--- a/pulp_smash/tests/rpm/api_v2/test_rsync_distributor.py
+++ b/pulp_smash/tests/rpm/api_v2/test_rsync_distributor.py
@@ -127,8 +127,8 @@ class _RsyncDistUtilsMixin(object):  # pylint:disable=too-few-public-methods
 
         In addition, schedule the repository for deletion.
 
-        :param pulp_smash.config.ServerConfig cfg: Information about the Pulp
-            server being targeted.
+        :param pulp_smash.config.PulpSmashConfig cfg: Information about the
+            Pulp deployment being targeted.
         :param dist_cfg_updates: A dict to be merged into the RPM rsync
             distributor's ``distributor_config`` dict. At a minimum, this
             argument should have a value of ``{'remote': {…}}``.
@@ -158,8 +158,8 @@ class _RsyncDistUtilsMixin(object):  # pylint:disable=too-few-public-methods
         Assert that only one task has this type, and that this task has a
         result of ``skipped``.
 
-        :param pulp_smash.config.ServerConfig cfg: Information about the Pulp
-            server being targeted.
+        :param pulp_smash.config.PulpSmashConfig cfg: Information about the
+            Pulp deployment being targeted.
         :param call_report: A call report returned from Pulp after requesting a
             publish; a dict.
         :returns: Nothing.
@@ -178,8 +178,8 @@ class _RsyncDistUtilsMixin(object):  # pylint:disable=too-few-public-methods
         target system's filesystem, and that the correct number of RPMs are
         present in that directory.
 
-        :param pulp_smash.config.ServerConfig cfg: Information about the system
-            onto which files have been published.
+        :param pulp_smash.config.PulpSmashConfig cfg: Information about the
+            system onto which files have been published.
         :param distributor_cfg: A dict of information about an RPM rsync
             distributor.
         :param num_units: The number of units that should be on the target

--- a/pulp_smash/tests/rpm/api_v2/utils.py
+++ b/pulp_smash/tests/rpm/api_v2/utils.py
@@ -46,7 +46,8 @@ def gen_distributor():
 def get_repodata_repomd_xml(cfg, distributor, response_handler=None):
     """Download the given repository's ``repodata/repomd.xml`` file.
 
-    :param pulp_smash.config.ServerConfig cfg: Information about a Pulp host.
+    :param pulp_smash.config.PulpSmashConfig cfg: Information about a Pulp
+        host.
     :param distributor: A dict of information about a repository distributor.
     :param response_handler: The callback function used by
         :class:`pulp_smash.api.Client` after downloading the ``repomd.xml``
@@ -71,7 +72,8 @@ def get_repodata(
         repomd_xml=None):
     """Download a file of the given ``type_`` from a ``repodata/`` directory.
 
-    :param pulp_smash.config.ServerConfig cfg: Information about a Pulp host.
+    :param pulp_smash.config.PulpSmashConfig cfg: Information about a Pulp
+        host.
     :param distributor: A dict of information about a repository distributor.
     :param type_: The type of file to fetch from a repository's ``repodata/``
         directory. Valid values might be "updateinfo" or "group".
@@ -149,8 +151,8 @@ class DisableSELinuxMixin(object):  # pylint:disable=too-few-public-methods
         enforcing on the target Pulp system, then disable SELinux and schedule
         it to be re-enabled. (Method ``addCleanup`` is used for the schedule.)
 
-        :param pulp_smash.config.ServerConfig cfg: Information about the Pulp
-            server being targeted.
+        :param pulp_smash.config.PulpSmashConfig cfg: Information about the
+            Pulp deployment being targeted.
         :param pulp_issue_id: The (integer) ID of a `Pulp issue`_. If the
             referenced issue is fixed in the Pulp system under test, this
             method immediately returns.
@@ -208,8 +210,8 @@ class TemporaryUserMixin(object):
 
         In addition, schedule the user for deletion with ``self.addCleanup``.
 
-        :param pulp_smash.config.ServerConfig cfg: Information about the host
-            being targeted.
+        :param pulp_smash.config.PulpSmashConfig cfg: Information about the
+            host being targeted.
         :returns: A ``(username, private_key)`` tuple.
         """
         creator = self._make_user(cfg)
@@ -308,8 +310,8 @@ class TemporaryUserMixin(object):
         ``600``. In addition, schedule the key for deletion with
         ``self.addCleanup``.
 
-        :param pulp_smash.config.ServerConfig cfg: Information about the host
-            being targeted.
+        :param pulp_smash.config.PulpSmashConfig cfg: Information about the
+            host being targeted.
         :returns: The path to the private key on disk, as a string.
         """
         sudo = '' if utils.is_root(cfg) else 'sudo '
@@ -347,7 +349,8 @@ def get_unit(cfg, distributor, unit_name, primary_xml=None):
         >>> foo_rpm = get_unit(cfg, distributor, 'foo.rpm', primary_xml)
         >>> bar_rpm = get_unit(cfg, distributor, 'bar.rpm', primary_xml)
 
-    :param pulp_smash.config.ServerConfig cfg: Information about a Pulp host.
+    :param pulp_smash.config.PulpSmashConfig cfg: Information about a Pulp
+        host.
     :param distributor: A dict of information about a repository distributor.
     :param unit_name: The name of a content unit to be fetched. For example:
         "bear-4.1-1.noarch.rpm".
@@ -377,7 +380,8 @@ def get_unit(cfg, distributor, unit_name, primary_xml=None):
 def get_dists_by_type_id(cfg, repo):
     """Return the named repository's distributors, keyed by their type IDs.
 
-    :param pulp_smash.config.ServerConfig cfg: Information about a Pulp host.
+    :param pulp_smash.config.PulpSmashConfig cfg: Information about a Pulp
+        host.
     :param repo_href: A dict of information about a repository.
     :returns: A dict in the form ``{'type_id': {distributor_info}}``.
     """
@@ -397,7 +401,8 @@ def set_pulp_manage_rsync(cfg, boolean):
     rsync Distributor → Configuration
     <http://docs.pulpproject.org/plugins/pulp_rpm/tech-reference/iso-rsync-distributor.html#configuration>`_.
 
-    :param pulp_smash.config.ServerConfig cfg: Information about a Pulp host.
+    :param pulp_smash.config.PulpSmashConfig cfg: Information about a Pulp
+        host.
     :param boolean: Either ``True`` or ``False``.
     :returns: Information about the executed command, or ``None`` if no command
         was executed.

--- a/pulp_smash/tests/rpm/cli/test_copy_units.py
+++ b/pulp_smash/tests/rpm/cli/test_copy_units.py
@@ -71,8 +71,8 @@ class UtilsMixin(object):  # pylint:disable=too-few-public-methods
     def create_repo(self, cfg):
         """Create a repository and schedule it for deletion.
 
-        :param pulp_smash.config.ServerConfig cfg: The Pulp system on which to
-            create a repository.
+        :param pulp_smash.config.PulpSmashConfig cfg: The Pulp system on which
+            to create a repository.
         :return: The repository's ID.
         """
         repo_id = utils.uuid4()
@@ -93,8 +93,8 @@ def gen_yum_config_file(cfg, repositoryid, **kwargs):
     Generate a yum configuration file containing a single repository section,
     and write it to ``/etc/yum.repos.d/{repositoryid}.repo``.
 
-    :param pulp_smash.config.ServerConfig cfg: The system on which to create a
-        yum configuration file.
+    :param pulp_smash.config.PulpSmashConfig cfg: The system on which to create
+        a yum configuration file.
     :param repositoryid: The section's ``repositoryid``. Used when naming the
         configuration file and populating the brackets at the head of the file.
         For details, see yum.conf(5).
@@ -117,8 +117,8 @@ def gen_yum_config_file(cfg, repositoryid, **kwargs):
 def _get_rpm_names_versions(server_config, repo_id):
     """Get a dict of repo's RPMs with names as keys, mapping to version lists.
 
-    :param pulp_smash.config.ServerConfig server_config: Information about the
-        Pulp server being targeted.
+    :param pulp_smash.config.PulpSmashConfig server_config: Information about
+        the Pulp deployment being targeted.
     :param repo_id: A RPM repository ID.
     :returns: The name and versions of each package in the repository, with the
         versions sorted in ascending order. For example: ``{'walrus': ['0.71',

--- a/pulp_smash/tests/rpm/cli/test_process_recycling.py
+++ b/pulp_smash/tests/rpm/cli/test_process_recycling.py
@@ -19,10 +19,10 @@ def restart_pulp(cfg):
     Unlike :func:`pulp_smash.utils.reset_pulp`, do not reset the state of any
     of Pulp's services.
 
-    :param pulp_smash.config.ServerConfig cfg: Information about the Pulp
-        server being targeted.
+    :param pulp_smash.config.PulpSmashConfig cfg: Information about the Pulp
+        deployment being targeted.
     """
-    svc_mgr = cli.ServiceManager(cfg)
+    svc_mgr = cli.GlobalServiceManager(cfg)
     svc_mgr.stop(PULP_SERVICES)
     svc_mgr.start(PULP_SERVICES)
 
@@ -30,8 +30,8 @@ def restart_pulp(cfg):
 def get_pulp_worker_procs(cfg):
     """Use ``ps aux`` to get information about each Pulp worker process.
 
-    :param pulp_smash.config.ServerConfig cfg: Information about the Pulp
-        server being targeted.
+    :param pulp_smash.config.PulpSmashConfig cfg: Information about the Pulp
+        deployment being targeted.
     :return: An iterable of strings, one per line of matching output.
     """
     cmd = ['ps', 'aux']

--- a/pulp_smash/tests/rpm/cli/test_sync.py
+++ b/pulp_smash/tests/rpm/cli/test_sync.py
@@ -154,7 +154,8 @@ class ForceSyncTestCase(_BaseTestCase):
 def get_rpm_names(cfg, repo_id):
     """Get a list of names of all packages in a repository.
 
-    :param pulp_smash.config.ServerConfig cfg: Information about a Pulp server.
+    :param pulp_smash.config.PulpSmashConfig cfg: Information about a Pulp
+        deployment.
     :param repo_id: A RPM repository ID.
     :returns: The names of all modules in a repository, as an ``list``.
     """
@@ -171,7 +172,8 @@ def get_rpm_names(cfg, repo_id):
 def sync_repo(cfg, repo_id, force_sync=False):
     """Sync an RPM repository.
 
-    :param pulp_smash.config.ServerConfig cfg: Information about a Pulp server.
+    :param pulp_smash.config.PulpSmashConfig cfg: Information about a Pulp
+        deployment.
     :param repo_id: A RPM repository ID.
     :param repo_id: A boolean flag to denote if is a force-full sync.
     :returns: A :class:`pulp_smash.cli.CompletedProcess`.

--- a/pulp_smash/tests/rpm/cli/utils.py
+++ b/pulp_smash/tests/rpm/cli/utils.py
@@ -6,8 +6,8 @@ from pulp_smash import cli
 def count_langpacks(server_config, repo_id):
     """Tell how many langpack content units are in the given repository.
 
-    :param pulp_smash.config.ServerConfig server_config: Information about the
-        Pulp server being targeted.
+    :param pulp_smash.config.PulpSmashConfig server_config: Information about
+        the Pulp deployment being targeted.
     :param repo_id: A repository ID.
     :returns: The number of langpacks in the named repository, as an integer.
     """

--- a/pulp_smash/tests/rpm/utils.py
+++ b/pulp_smash/tests/rpm/utils.py
@@ -16,7 +16,7 @@ def set_up_module():
 def check_issue_2277(cfg):
     """Return true if `Pulp #2277`_ affects the targeted Pulp system.
 
-    :param pulp_smash.config.ServerConfig cfg: The Pulp system under test.
+    :param pulp_smash.config.PulpSmashConfig cfg: The Pulp system under test.
 
     .. _Pulp #2277: https://pulp.plan.io/issues/2277
     """
@@ -29,7 +29,7 @@ def check_issue_2277(cfg):
 def check_issue_2387(cfg):
     """Return true if `Pulp #2387`_ affects the targeted Pulp system.
 
-    :param pulp_smash.config.ServerConfig cfg: The Pulp system under test.
+    :param pulp_smash.config.PulpSmashConfig cfg: The Pulp system under test.
 
     .. _Pulp #2387: https://pulp.plan.io/issues/2387
     """
@@ -42,7 +42,7 @@ def check_issue_2387(cfg):
 def check_issue_2354(cfg):
     """Return true if `Pulp #2354`_ affects the targeted Pulp system.
 
-    :param pulp_smash.config.ServerConfig cfg: The Pulp system under test.
+    :param pulp_smash.config.PulpSmashConfig cfg: The Pulp system under test.
 
     .. _Pulp #2354: https://pulp.plan.io/issues/2354
     """
@@ -55,7 +55,7 @@ def check_issue_2354(cfg):
 def check_issue_2620(cfg):
     """Return true if `Pulp #2620`_ affects the targeted Pulp system.
 
-    :param pulp_smash.config.ServerConfig cfg: The Pulp system under test.
+    :param pulp_smash.config.PulpSmashConfig cfg: The Pulp system under test.
 
     .. _Pulp #2620: https://pulp.plan.io/issues/2620
     """
@@ -68,7 +68,7 @@ def check_issue_2620(cfg):
 def os_is_rhel6(cfg):
     """Return ``True`` if the server runs RHEL 6, or ``False`` otherwise.
 
-    :param pulp_smash.config.ServerConfig cfg: Information about the system
+    :param pulp_smash.config.PulpSmashConfig cfg: Information about the system
         being targeted.
     :returns: True or false.
     """

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,22 +12,88 @@ import xdg
 
 from pulp_smash import config, exceptions, utils
 
+PULP_SMASH_CONFIG = """
+{
+    "pulp": {
+        "auth": ["username", "password"],
+        "version": "2.12.1"
+    },
+    "systems": [
+        {
+            "hostname": "first.example.com",
+            "roles": {
+                "amqp broker": {"service": "qpidd"},
+                "api": {"scheme": "https", "verify": true},
+                "mongod": {},
+                "pulp cli": {},
+                "pulp celerybeat": {},
+                "pulp resource manager": {},
+                "pulp workers": {},
+                "shell": {"transport": "local"},
+                "squid": {}
+            }
+        },
+        {
+            "hostname": "second.example.com",
+            "roles": {
+                "api": {"scheme": "https", "verify": false},
+                "pulp celerybeat": {},
+                "pulp resource manager": {},
+                "pulp workers": {},
+                "shell": {"transport": "ssh"},
+                "squid": {}
+            }
+        }
+    ]
+}
+"""
+
+
+OLD_CONFIG = """
+{
+    "pulp": {
+        "base_url": "https://pulp.example.com",
+        "auth": ["username", "password"],
+        "verify": false,
+        "version": "2.12",
+        "cli_transport": "ssh"
+    }
+}
+"""
+
 
 def _gen_attrs():
-    """Generate attributes for populating a ``ServerConfig``.
+    """Generate attributes for populating a ``PulpSmashConfig``.
 
-    Example usage: ``ServerConfig(**_gen_attrs())``.
+    Example usage: ``PulpSmashConfig(**_gen_attrs())``.
 
-    :returns: A dict. It populates all attributes in a ``ServerConfig``.
+    :returns: A dict. It populates all attributes in a ``PulpSmashConfig``.
     """
-    attrs = {
-        key: utils.uuid4() for key in ('base_url', 'cli_transport', 'verify')
+    return {
+        'pulp_auth': [utils.uuid4() for _ in range(2)],
+        'pulp_version': '.'.join(
+            type('')(random.randint(1, 150)) for _ in range(4)
+        ),
+        'systems': [
+            config.PulpSystem(
+                hostname='pulp.example.com',
+                roles={
+                    'amqp broker': {'service': 'qpidd'},
+                    'api': {
+                        'scheme': 'https',
+                        'verify': True
+                    },
+                    'mongod': {},
+                    'pulp cli': {},
+                    'pulp celerybeat': {},
+                    'pulp resource manager': {},
+                    'pulp workers': {},
+                    'shell': {'transport': 'local'},
+                    'squid': {}
+                }
+            )
+        ],
     }
-    attrs['auth'] = [utils.uuid4() for _ in range(2)]
-    attrs['version'] = '.'.join(
-        type('')(random.randint(1, 150)) for _ in range(4)
-    )
-    return attrs
 
 
 class GetConfigTestCase(unittest.TestCase):
@@ -36,36 +102,36 @@ class GetConfigTestCase(unittest.TestCase):
     def test_cache_full(self):
         """No config is read from disk if the cache is populated."""
         with mock.patch.object(config, '_CONFIG'):
-            with mock.patch.object(config.ServerConfig, 'read') as read:
+            with mock.patch.object(config.PulpSmashConfig, 'read') as read:
                 config.get_config()
         self.assertEqual(read.call_count, 0)
 
     def test_cache_empty(self):
         """A config is read from disk if the cache is empty."""
         with mock.patch.object(config, '_CONFIG', None):
-            with mock.patch.object(config.ServerConfig, 'read') as read:
+            with mock.patch.object(config.PulpSmashConfig, 'read') as read:
                 config.get_config()
         self.assertEqual(read.call_count, 1)
 
 
 class InitTestCase(unittest.TestCase):
-    """Test :class:`pulp_smash.config.ServerConfig` instantiation."""
+    """Test :class:`pulp_smash.config.PulpSmashConfig` instantiation."""
 
     @classmethod
     def setUpClass(cls):
         """Generate some attributes and use them to instantiate a config."""
         cls.kwargs = _gen_attrs()
-        cls.cfg = config.ServerConfig(**cls.kwargs)
+        cls.cfg = config.PulpSmashConfig(**cls.kwargs)
 
     def test_public_attrs(self):
         """Assert that public attributes have correct values."""
         attrs = config._public_attrs(self.cfg)  # pylint:disable=W0212
-        attrs['version'] = type('')(attrs['version'])
+        attrs['pulp_version'] = type('')(attrs['pulp_version'])
         self.assertEqual(self.kwargs, attrs)
 
     def test_private_attrs(self):
         """Assert that private attributes have been set."""
-        for attr in ('_section', '_xdg_config_file', '_xdg_config_dir'):
+        for attr in ('_xdg_config_file', '_xdg_config_dir'):
             with self.subTest(attr):
                 self.assertIsNotNone(getattr(self.cfg, attr))
 
@@ -77,7 +143,7 @@ class PulpSmashConfigFileTestCase(unittest.TestCase):
         """Set the environment variable."""
         os_environ = {'PULP_SMASH_CONFIG_FILE': utils.uuid4()}
         with mock.patch.dict(os.environ, os_environ, clear=True):
-            cfg = config.ServerConfig()
+            cfg = config.PulpSmashConfig()
         self.assertEqual(
             cfg._xdg_config_file,  # pylint:disable=protected-access
             os_environ['PULP_SMASH_CONFIG_FILE']
@@ -86,102 +152,180 @@ class PulpSmashConfigFileTestCase(unittest.TestCase):
     def test_var_unset(self):
         """Do not set the environment variable."""
         with mock.patch.dict(os.environ, {}, clear=True):
-            cfg = config.ServerConfig()
+            cfg = config.PulpSmashConfig()
         # pylint:disable=protected-access
         self.assertEqual(cfg._xdg_config_file, 'settings.json')
 
 
 class ReadTestCase(unittest.TestCase):
-    """Test :meth:`pulp_smash.config.ServerConfig.read`."""
+    """Test :meth:`pulp_smash.config.PulpSmashConfig.read`."""
 
-    def setUp(self):
-        """Generate contents for a configuration file."""
-        self.config_file = {'pulp': _gen_attrs()}
-
-    def test_read_section(self):
-        """Read a section from the configuration file.
-
-        Assert that values from the configuration file are present on the
-        resultant :class:`pulp_smash.config.ServerConfig` object.
-        """
-        open_ = mock.mock_open(read_data=json.dumps(self.config_file))
+    def test_read_config_file(self):
+        """Ensure Pulp Smash can read the config file."""
+        open_ = mock.mock_open(read_data=PULP_SMASH_CONFIG)
         with mock.patch.object(builtins, 'open', open_):
             with mock.patch.object(config, '_get_config_file_path'):
-                cfg = config.ServerConfig().read()
-        self.assertEqual(self.config_file['pulp']['base_url'], cfg.base_url)
+                cfg = config.PulpSmashConfig().read()
+        with self.subTest('check pulp_auth'):
+            self.assertEqual(cfg.pulp_auth, ['username', 'password'])
+        with self.subTest('check pulp_version'):
+            self.assertEqual(cfg.pulp_version, config.Version('2.12.1'))
+        with self.subTest('check systems'):
+            self.assertEqual(
+                sorted(cfg.systems),
+                sorted([
+                    config.PulpSystem(
+                        hostname='first.example.com',
+                        roles={
+                            'amqp broker': {'service': 'qpidd'},
+                            'api': {
+                                'scheme': 'https',
+                                'verify': True,
+                            },
+                            'mongod': {},
+                            'pulp cli': {},
+                            'pulp celerybeat': {},
+                            'pulp resource manager': {},
+                            'pulp workers': {},
+                            'shell': {'transport': 'local'},
+                            'squid': {},
+                        }
+                    ),
+                    config.PulpSystem(
+                        hostname='second.example.com',
+                        roles={
+                            'api': {
+                                'scheme': 'https',
+                                'verify': False,
+                            },
+                            'pulp celerybeat': {},
+                            'pulp resource manager': {},
+                            'pulp workers': {},
+                            'shell': {'transport': 'ssh'},
+                            'squid': {}
+                        }
+                    ),
+                ])
+            )
 
-    def test_read_nonexistent_section(self):
-        """Read a non-existent section from the configuration file.
-
-        Assert a :class:`pulp_smash.exceptions.ConfigFileSectionNotFoundError`
-        is raised.
-        """
-        open_ = mock.mock_open(read_data=json.dumps(self.config_file))
-        with mock.patch.object(builtins, 'open', open_):
-            with mock.patch.object(config, '_get_config_file_path'):
-                with self.assertRaises(
-                    exceptions.ConfigFileSectionNotFoundError
-                ):
-                    config.ServerConfig().read('foo')
-
-    def test_read_default_section(self):
-        """Read from a configuration file with a section named 'default'."""
-        self.config_file['default'] = self.config_file.pop('pulp')
-        open_ = mock.mock_open(read_data=json.dumps(self.config_file))
+    def test_read_old_config_file(self):
+        """Ensure Pulp Smash can read old config file format."""
+        open_ = mock.mock_open(read_data=OLD_CONFIG)
         with mock.patch.object(builtins, 'open', open_):
             with mock.patch.object(config, '_get_config_file_path'):
                 with self.assertWarns(DeprecationWarning):
-                    cfg = config.ServerConfig().read()
-        self.assertEqual(self.config_file['default']['base_url'], cfg.base_url)
+                    cfg = config.PulpSmashConfig().read()
+        with self.subTest('check pulp_auth'):
+            self.assertEqual(cfg.pulp_auth, ['username', 'password'])
+        with self.subTest('check pulp_version'):
+            self.assertEqual(cfg.pulp_version, config.Version('2.12'))
+        with self.subTest('check systems'):
+            self.assertEqual(
+                cfg.systems,
+                [
+                    config.PulpSystem(
+                        hostname='pulp.example.com',
+                        roles={
+                            'amqp broker': {'service': 'qpidd'},
+                            'api': {
+                                'scheme': 'https',
+                                'verify': False,
+                            },
+                            'mongod': {},
+                            'pulp cli': {},
+                            'pulp celerybeat': {},
+                            'pulp resource manager': {},
+                            'pulp workers': {},
+                            'shell': {'transport': 'ssh'},
+                            'squid': {},
+                        }
+                    )
+                ])
 
 
-class SectionsTestCase(unittest.TestCase):
-    """Test :meth:`pulp_smash.config.ServerConfig.sections`."""
+class HelperMethodsTestCase(unittest.TestCase):
+    """Test :meth:`pulp_smash.config.PulpSmashConfig` helper methods."""
 
-    @classmethod
-    def setUpClass(cls):
-        """Read a mock configuration file's sections. Save relevant objects."""
-        cls.config = random.choice((
-            {},
-            {'foo': None},
-            {'foo': None, 'bar': None, 'biz': None},
-        ))
-        cls.open_ = mock.mock_open(read_data=json.dumps(cls.config))
-        with mock.patch.object(builtins, 'open', cls.open_):
+    def setUp(self):
+        """Generate contents for a configuration file."""
+        open_ = mock.mock_open(read_data=PULP_SMASH_CONFIG)
+        with mock.patch.object(builtins, 'open', open_):
             with mock.patch.object(config, '_get_config_file_path'):
-                cls.sections = config.ServerConfig().sections()
+                self.cfg = config.PulpSmashConfig().read()
 
-    def test_sections(self):
-        """Assert that the correct section names are returned."""
-        self.assertEqual(set(self.config.keys()), self.sections)
+    def test_get_systems(self):
+        """``get_systems`` returns proper result."""
+        with self.subTest('role with multiplie matching systems'):
+            result = [
+                system.hostname for system in self.cfg.get_systems('api')]
+            self.assertEqual(len(result), 2)
+            self.assertEqual(
+                sorted(result),
+                sorted(['first.example.com', 'second.example.com'])
+            )
+        with self.subTest('role with single match system'):
+            result = [
+                system.hostname for system in self.cfg.get_systems('mongod')]
+            self.assertEqual(len(result), 1)
+            self.assertEqual(
+                sorted(result),
+                sorted(['first.example.com'])
+            )
 
-    def test_open(self):
-        """Assert that ``open`` was called once."""
-        self.assertEqual(self.open_.call_count, 1)
+    def test_services_for_roles(self):
+        """``services_for_roles`` returns proper result."""
+        roles = {role: {} for role in config.ROLES}
+        expected_roles = {
+            'httpd',
+            'mongod',
+            'pulp_celerybeat',
+            'pulp_resource_manager',
+            'pulp_workers',
+            'squid',
+        }
+        with self.subTest('no amqp broker service'):
+            self.assertEqual(
+                self.cfg.services_for_roles(roles),
+                expected_roles
+            )
+        with self.subTest('qpidd amqp broker service'):
+            roles['amqp broker']['service'] = 'qpidd'
+            self.assertEqual(
+                self.cfg.services_for_roles(roles),
+                expected_roles.union({'qpidd'})
+            )
+        with self.subTest('rabbitmq amqp broker service'):
+            roles['amqp broker']['service'] = 'rabbitmq'
+            self.assertEqual(
+                self.cfg.services_for_roles(roles),
+                expected_roles.union({'rabbitmq'})
+            )
 
 
 class GetRequestsKwargsTestCase(unittest.TestCase):
-    """Test :meth:`pulp_smash.config.ServerConfig.get_requests_kwargs`."""
+    """Test :meth:`pulp_smash.config.PulpSmashConfig.get_requests_kwargs`."""
 
     @classmethod
     def setUpClass(cls):
         """Create a mock server config and call the method under test."""
         cls.attrs = _gen_attrs()
-        cls.cfg = config.ServerConfig(**cls.attrs)
+        cls.cfg = config.PulpSmashConfig(**cls.attrs)
         cls.kwargs = cls.cfg.get_requests_kwargs()
 
     def test_kwargs(self):
         """Assert that the method returns correct values."""
-        attrs = self.attrs.copy()
-        for key in ('base_url', 'cli_transport', 'version'):
-            del attrs[key]
-        attrs['auth'] = tuple(attrs['auth'])
-        self.assertEqual(attrs, self.kwargs)
+        self.assertEqual(
+            self.kwargs,
+            {
+                'auth': tuple(self.attrs['pulp_auth']),
+                'verify': True,
+            }
+        )
 
     def test_cfg_auth(self):
         """Assert that the method does not alter the config's ``auth``."""
         # _gen_attrs() returns ``auth`` as a list.
-        self.assertIsInstance(self.cfg.auth, list)
+        self.assertIsInstance(self.cfg.pulp_auth, list)
 
     def test_kwargs_auth(self):
         """Assert that the method converts ``auth`` to a tuple."""
@@ -189,13 +333,14 @@ class GetRequestsKwargsTestCase(unittest.TestCase):
 
 
 class ReprTestCase(unittest.TestCase):
-    """Test calling ``repr`` on a :class:`pulp_smash.config.ServerConfig`."""
+    """Test calling ``repr`` on a `pulp_smash.config.PulpSmashConfig`."""
 
     @classmethod
     def setUpClass(cls):
         """Generate attributes and call the method under test."""
         cls.attrs = _gen_attrs()
-        cls.result = repr(config.ServerConfig(**cls.attrs))
+        cls.cfg = config.PulpSmashConfig(**cls.attrs)
+        cls.result = repr(cls.cfg)
 
     def test_is_sane(self):
         """Assert that the result is in an expected set of results."""
@@ -206,65 +351,21 @@ class ReprTestCase(unittest.TestCase):
             for two_tuples in itertools.permutations(self.attrs.items())
         )
         targets = tuple(
-            'ServerConfig({})'.format(arglist) for arglist in kwargs_iter
+            'PulpSmashConfig({})'.format(arglist) for arglist in kwargs_iter
         )
         self.assertIn(self.result, targets)
 
     def test_can_eval(self):
         """Assert that the result can be parsed by ``eval``."""
-        from pulp_smash.config import ServerConfig  # noqa pylint:disable=unused-variable
+        from pulp_smash.config import PulpSmashConfig, PulpSystem  # noqa pylint:disable=unused-variable
         # pylint:disable=eval-used
-        self.assertEqual(self.result, repr(eval(self.result)))
-
-
-class DeleteTestCase(unittest.TestCase):
-    """Test :meth:`pulp_smash.config.ServerConfig.delete`."""
-
-    def test_delete_default(self):
-        """Assert that the method can delete the default section."""
-        open_ = mock.mock_open(read_data=json.dumps({'pulp': {}}))
-        with mock.patch.object(builtins, 'open', open_):
-            with mock.patch.object(config, '_get_config_file_path'):
-                config.ServerConfig().delete()
-        self.assertEqual(_get_written_json(open_), {})
-
-    def test_delete_section(self):
-        """Assert that the method can delete a specified section."""
-        attrs = {'foo': {}, 'bar': {}}
-        section = random.choice(tuple(attrs.keys()))
-        open_ = mock.mock_open(read_data=json.dumps(attrs))
-        with mock.patch.object(builtins, 'open', open_):
-            with mock.patch.object(config, '_get_config_file_path'):
-                config.ServerConfig().delete(section)
-        del attrs[section]
-        self.assertEqual(_get_written_json(open_), attrs)
-
-
-class SaveTestCase(unittest.TestCase):
-    """Test :meth:`pulp_smash.config.ServerConfig.save`."""
-
-    def test_save_default(self):
-        """Assert that the method can save the default section."""
-        attrs = _gen_attrs()
-        open_ = mock.mock_open(read_data=json.dumps({}))
-        with mock.patch.object(builtins, 'open', open_):
-            with mock.patch.object(config, '_get_config_file_path'):
-                config.ServerConfig(**attrs).save()
-        self.assertEqual(_get_written_json(open_), {'pulp': attrs})
-
-    def test_save_section(self):
-        """Assert that the method can save a specified section."""
-        # `cfg` is the existing config file. We generate a new config as
-        # `attrs` and save it into section `section`.
-        cfg = {'existing': {}}
-        section = utils.uuid4()
-        attrs = _gen_attrs()
-        open_ = mock.mock_open(read_data=json.dumps(cfg))
-        with mock.patch.object(builtins, 'open', open_):
-            with mock.patch.object(config, '_get_config_file_path'):
-                config.ServerConfig(**attrs).save(section)
-        cfg[section] = attrs
-        self.assertEqual(_get_written_json(open_), cfg)
+        cfg = eval(self.result)
+        with self.subTest('check pulp_version'):
+            self.assertEqual(cfg.pulp_version, self.cfg.pulp_version)
+        with self.subTest('check pulp_version'):
+            self.assertEqual(cfg.pulp_version, self.cfg.pulp_version)
+        with self.subTest('check systems'):
+            self.assertEqual(cfg.systems, self.cfg.systems)
 
 
 class GetConfigFilePathTestCase(unittest.TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -121,14 +121,14 @@ class SkipIfTypeIsUnsupportedTestCase(unittest.TestCase):
         """Assert nothing happens if the given unit type is supported.
 
         Also assert :func:`pulp_smash.config.get_config` is not called, as we
-        provide a :class:`pulp_smash.config.ServerConfig` argument.
+        provide a :class:`pulp_smash.config.PulpSmashConfig` argument.
         """
         with mock.patch.object(config, 'get_config') as get_config:
             with mock.patch.object(utils, 'get_unit_type_ids') as get_u_t_ids:
                 get_u_t_ids.return_value = {self.unit_type_id}
                 self.assertIsNone(utils.skip_if_type_is_unsupported(
                     self.unit_type_id,
-                    mock.Mock(),  # a ServerConfig object
+                    mock.Mock(),  # a PulpSmashConfig object
                 ))
         self.assertEqual(get_config.call_count, 0)
 
@@ -136,7 +136,7 @@ class SkipIfTypeIsUnsupportedTestCase(unittest.TestCase):
         """Assert ``SkipTest`` is raised if the given unit type is unsupported.
 
         Also assert :func:`pulp_smash.config.get_config` is called, as we do
-        not provide a :class:`pulp_smash.config.ServerConfig` argument.
+        not provide a :class:`pulp_smash.config.PulpSmashConfig` argument.
         """
         with mock.patch.object(config, 'get_config') as get_config:
             with mock.patch.object(utils, 'get_unit_type_ids') as get_u_t_ids:
@@ -224,7 +224,15 @@ class PulpAdminLoginTestCase(unittest.TestCase):
     def test_run(self):
         """Assert the function executes ``cli.Client.run``."""
         with mock.patch.object(cli, 'Client') as client:
-            cfg = config.ServerConfig('http://example.com', auth=['u', 'p'])
+            cfg = config.PulpSmashConfig(
+                pulp_auth=['u', 'p'],
+                systems=[
+                    config.PulpSystem(
+                        hostname='example.com',
+                        roles={'pulp cli': {}}
+                    )
+                ]
+            )
             response = utils.pulp_admin_login(cfg)
             self.assertIs(response, client.return_value.run.return_value)
 


### PR DESCRIPTION
Improve the configuration in order to support clustered Pulp deployment
where multiple machines compose a Pulp system. But it still supporting
deployments where all services are running within the same machine.

The new format adopt the system with roles format where each system
(machine) have one or more roles. Each role provide information about a
given fact, for example, the api role tells Pulp Smash that the API can
be accessed on a given system. Also it helps Pulp Smash check which
systems have a Pulp service running, then Pulp Smash can access that
system and manage the service if that is needed.