### PR TITLE
Pin version of pydocstyle in requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,8 @@
 flake8
 flake8-docstrings
 flake8-quotes
+# See: https://gitlab.com/pycqa/flake8-docstrings/issues/19
+pydocstyle<2
 pylint
 astroid
 


### PR DESCRIPTION
flake8-docstrings is incompatible with pydocstyle version 2. Pin
pydocstyle to an older version until flake8-docstrings is updated.

See: https://gitlab.com/pycqa/flake8-docstrings/issues/19