### PR TITLE
Rewrite CLI Docker sync & publish tests

### DIFF
--- a/pulp_smash/api.py
+++ b/pulp_smash/api.py
@@ -312,16 +312,16 @@ class Client(object):
         request_kwargs = self.request_kwargs.copy()
         request_kwargs['url'] = urljoin(request_kwargs['url'], url)
         request_kwargs.update(kwargs)
-        config_host = urlparse(self._cfg.get_base_url(self.pulp_system)).netloc
-        request_host = urlparse(request_kwargs['url']).netloc
-        if request_host != config_host:
+        cfg_host = urlparse(self._cfg.get_base_url(self.pulp_system)).hostname
+        request_host = urlparse(request_kwargs['url']).hostname
+        if request_host != cfg_host:
             warnings.warn(
-                'This client is configured to make HTTP requests to {0}, but '
-                'a request is being made to {1}. The request will be made, '
-                'but some options may be incorrect. For example, an incorrect '
-                'SSL certificate may be specified with the `verify` option. '
-                'Request options: {2}'
-                .format(config_host, request_host, request_kwargs),
+                'This client was originally created for communicating with '
+                '{0}, but a request is being made to {1}. The request will be '
+                'made, but beware that information intended for {0} (such as '
+                "authentication tokens) may now be sent to {1}. Here's the "
+                'full list of options being sent with this request: {2}'
+                .format(cfg_host, request_host, request_kwargs),
                 RuntimeWarning
             )
         return self.response_handler(

--- a/pulp_smash/tests/docker/cli/utils.py
+++ b/pulp_smash/tests/docker/cli/utils.py
@@ -100,3 +100,15 @@ def repo_update(  # pylint:disable=too-many-arguments
     if repo_registry_id is not None:
         cmd.extend(('--repo-registry-id', repo_registry_id))
     return cli.Client(server_config).run(cmd)
+
+
+def repo_publish(server_config, repo_id, bg=None, force_full=None):  # noqa pylint:disable=invalid-name
+    """Execute ``pulp-admin docker repo publish run``."""
+    cmd = (
+        'pulp-admin', 'docker', 'repo', 'publish', 'run', '--repo-id', repo_id
+    )
+    if bg:
+        cmd += '--bg'
+    if force_full:
+        cmd += '--force-full'
+    return cli.Client(server_config).run(cmd)


### PR DESCRIPTION
The tests in `pulp_smash/tests/docker/` talk directly to the pulp_docker
plugin. This isn't a good idea. It is assumed that clients such as
Docker will talk to the API exposed by Crane, and as a result,
pulp_docker changes more frequently and in more significant ways than is
typical for other plugins. In addition, testing pulp_docker directly
means that Pulp Smash isn't verifying the behaviour that real clients
see.

Re-write the module, so that its tests communicate with the interface
exposed by Crane, not the interface exposed by pulp_docker.

See: b470bfb59554d31aa7eb74725d1118c7ea485378