### PR TITLE
Add an ISO upload test case

### DIFF
--- a/pulp_smash/constants.py
+++ b/pulp_smash/constants.py
@@ -117,6 +117,9 @@ FILE_FEED_COUNT = 3
 FILE_MIXED_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'file-mixed/')
 """The URL to a file repository containing invalid and valid entries."""
 
+FILE_URL = urljoin(FILE_FEED_URL, '1.iso')
+"""The URL to an ISO file at :data:`FILE_FEED_URL`."""
+
 ERROR_KEYS = frozenset((
     '_href',
     'error',


### PR DESCRIPTION
Add `UploadIsoTestCase`. This new test case uploads an ISO file to an
ISO repository.

The test case is simple and can (should!) be expanded, but even in its
current state, it adds some much-needed coverage for a very basic use
case.