### PR TITLE
Test pulp_docker's repo_repository_id option

### DIFF
--- a/pulp_smash/tests/docker/cli/utils.py
+++ b/pulp_smash/tests/docker/cli/utils.py
@@ -28,6 +28,7 @@ def repo_create(  # pylint:disable=too-many-arguments
         enable_v2=None,
         feed=None,
         repo_id=None,
+        repo_registry_id=None,
         upstream_name=None):
     """Execute ``pulp-admin docker repo create``."""
     cmd = 'pulp-admin docker repo create'.split()
@@ -39,6 +40,8 @@ def repo_create(  # pylint:disable=too-many-arguments
         cmd.extend(('--feed', feed))
     if repo_id is not None:
         cmd.extend(('--repo-id', repo_id))
+    if repo_registry_id is not None:
+        cmd.extend(('--repo-registry-id', repo_registry_id))
     if upstream_name is not None:
         cmd.extend(('--upstream-name', upstream_name))
     return cli.Client(server_config).run(cmd)


### PR DESCRIPTION
The `repo_registry_id` setting defines a repository's name as seen by
clients such as the Docker CLI. It's traditionally a two-part name such
as `docker/busybox`, but according to `Pulp #2368`, it can contain an
arbitrary number of slashes. This test case verifies that the
`repo_registry_id` can be set to values containing varying numbers of
slashes.

Fix: https://github.com/PulpQE/pulp-smash/issues/625

See: https://pulp.plan.io/issues/2368