### PR TITLE
Add jsonschema dependency, test docker manifests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
     ],
     packages=find_packages(include=['pulp_smash', 'pulp_smash.*']),
     install_requires=[
+        'jsonschema',
         'packaging',
         'plumbum',
         'python-dateutil',


### PR DESCRIPTION
Add a new dependency to `setup.py`: jsonschema. This library lets one
define schemas for JSON documents, and validate that arbitrary JSON
documents abide by those schemas.

Expand `SyncPublishV2TestCase`. Let the test case make HTTP GET requests
to `/v2/{repo_id}/manifests/latest` with varying headers, and use
jsonschema to assert that the response is as described by one of the
following:

* https://docs.docker.com/registry/spec/manifest-v2-1/
* https://docs.docker.com/registry/spec/manifest-v2-2/

Fiddle with `SyncPublishV1TestCase` so that it's structured like
`SyncPublishV2TestCase`.

See: https://python-jsonschema.readthedocs.io/en/latest/

See: https://github.com/PulpQE/pulp-smash/issues/555