### PR TITLE
Pin flake8-quotes to an older version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,8 @@
 # For `make lint`
 flake8
 flake8-docstrings
-flake8-quotes
+# See: https://github.com/zheller/flake8-quotes/issues/55
+flake8-quotes<0.10
 pydocstyle
 pylint
 astroid


### PR DESCRIPTION
flake8-quotes version 0.10 incorrectly flags valid docstrings as being
invalid.

See: https://github.com/zheller/flake8-quotes/issues/55