### PR TITLE
Add test case for parallel errata synchronization

### DIFF
--- a/pulp_smash/constants.py
+++ b/pulp_smash/constants.py
@@ -354,16 +354,20 @@ repository which feed is :data:`pulp_smash.constants.RPM_SIGNED_FEED_URL`.
 """
 
 RPM_ERRATUM_RPM_NAME = 'gorilla'
-"""The name of the RPM present on an erratum.
-
-The erratum ID is defined by :data:`pulp_smash.constants.RPM_ERRATUM_ID`.
-"""
+"""The name of the RPM named by :data:`pulp_smash.constants.RPM_ERRATUM_ID`."""
 
 RPM_ERRATUM_URL = (
     'https://repos.fedorapeople.org'
     '/repos/pulp/pulp/fixtures/rpm-erratum/erratum.json'
 )
-"""The URL to an JSON erratum file for an RPM repository."""
+"""The URL to an JSON erratum file for an RPM repository.
+
+.. NOTE:: This erratum is also used by several of the RPM repositories
+    referenced in this module.
+"""
+
+RPM_ERRATUM_COUNT = 4
+"""The number of errata listed in :data:`RPM_ERRATUM_URL`."""
 
 RPM_MIRRORLIST_BAD = urljoin(PULP_FIXTURES_BASE_URL, 'rpm-mirrorlist-bad')
 """The URL to a mirrorlist file containing only invalid entries."""


### PR DESCRIPTION
Pulp issue 2721 describes how a race condition can arise when multiple
repositories with identical errata are synchronized at the same time.
This issue should be fixed in Pulp 2.13.1. Add a test case for this
issue.

See: https://pulp.plan.io/issues/2721

Fix: https://github.com/PulpQE/pulp-smash/issues/638