### PR TITLE
Improve pulp_smash.config._get_config_file_path

### DIFF
--- a/pulp_smash/config.py
+++ b/pulp_smash/config.py
@@ -482,14 +482,13 @@ def _get_config_file_path(xdg_config_dir, xdg_config_file):
     :raises pulp_smash.exceptions.ConfigFileNotFoundError: If the requested
         configuration file cannot be found.
     """
-    paths = [
-        os.path.join(config_dir, xdg_config_file)
-        for config_dir in BaseDirectory.load_config_paths(xdg_config_dir)
-    ]
-    for path in paths:
-        if os.path.isfile(path):
-            return path
+    path = BaseDirectory.load_first_config(xdg_config_dir, xdg_config_file)
+    if path and os.path.isfile(path):
+        return path
     raise exceptions.ConfigFileNotFoundError(
         'Pulp Smash is unable to find a configuration file. The following '
-        '(XDG compliant) paths have been searched: ' + ', '.join(paths)
+        '(XDG compliant) paths have been searched: ' + ', '.join([
+            os.path.join(config_dir, xdg_config_dir, xdg_config_file)
+            for config_dir in BaseDirectory.xdg_config_dirs
+        ])
     )


### PR DESCRIPTION
Make sure to proper list all the searched XDG compliant paths searched,
also take advantage of `BaseDirectory.load_first_config` function to get
the configuration file.

What these changes are improving:

* `load_config_paths` only returns paths that exists on the filesystem (see http://pyxdg.readthedocs.io/en/latest/_modules/xdg/BaseDirectory.html#load_config_paths). This information will not be useful when raising the exception because if no config file and config dir is present on any of the searched paths then it will print a blank list of searched path, which is not true.
* Proper list all searched paths by joining each dir in `BaseDirectory.xdg_config_dirs` with 'pulp_smash/settings.json', this will provide the full list of searched paths.
* The previous logic was doing the same that the `BaseDirecotry.load_first_config` provides, let's reuse that instead of duplicating it. It still need to be checked if the path is a file because it only check if the path exists on the file system and we are looking for a config file.
