### PR TITLE
Update warning ignore filter for urllib3

### DIFF
--- a/pulp_smash/tests/__init__.py
+++ b/pulp_smash/tests/__init__.py
@@ -75,9 +75,9 @@ use a different test runner.
 """
 from warnings import simplefilter
 
-import requests
+import urllib3
 
 simplefilter(
     'ignore',
-    requests.packages.urllib3.exceptions.InsecureRequestWarning,
+    urllib3.exceptions.InsecureRequestWarning,
 )


### PR DESCRIPTION
Requests recently dropped vendor packages so urllib3 is now being
installed as a dependency. Update the
`urllib3.exceptions.InsecureRequestWarning` filter to import from the
`urllib3` instead of `requests.packages.urllib3`.