### PR TITLE
Fiddle with `pulp-smash settings create` wording

### DIFF
--- a/pulp_smash/pulp_smash_cli.py
+++ b/pulp_smash/pulp_smash_cli.py
@@ -67,7 +67,8 @@ def settings_create(ctx):
     else:
         system_api_verify = False
 
-    if click.confirm('Is Pulp\'s message broker Qpid?', default=True):
+    if click.confirm(
+            'Is Pulp\'s message broker Qpid (no for RabbitMQ)?', default=True):
         amqp_broker = 'qpidd'
     else:
         amqp_broker = 'rabbitmq'


### PR DESCRIPTION
Tell the user which message broker will be configured if the default of
Qpid is not chosen. (It's RabbitMQ.)