### PR TITLE
Update release script

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -35,7 +35,7 @@ source "${venv}/bin/activate"
 set -u
 for dist in dist/*; do
     pip install --quiet "${dist}"
-    python -m pulp_smash 1>/dev/null
+    pulp-smash settings --help 1>/dev/null
     pip uninstall --quiet --yes pulp_smash
 done
 set +u


### PR DESCRIPTION
The release script performs some sanity checks. One of those sanity
checks ensures the CLI interface works in a basic sense by executing:

    python -m pulp_smash

Due to updates to the CLI, this is now broken. Do the following instead:

    pulp-smash settings --help