### PR TITLE
Expand API test case for `retain_old_count`

### DIFF
--- a/pulp_smash/tests/rpm/api_v2/test_retain_old_count.py
+++ b/pulp_smash/tests/rpm/api_v2/test_retain_old_count.py
@@ -9,64 +9,80 @@ one sync a limited number of outdated RPMs.
 .. _retain_old_count:
     https://docs.pulpproject.org/plugins/pulp_rpm/tech-reference/yum-plugins.html
 """
-import unittest
 from urllib.parse import urljoin
 
-from pulp_smash import api, config, utils
+from pulp_smash import api, utils
 from pulp_smash.constants import REPOSITORY_PATH, RPM_UNSIGNED_FEED_URL
 from pulp_smash.tests.rpm.api_v2.utils import gen_distributor, gen_repo
-from pulp_smash.tests.rpm.utils import check_issue_2277
 from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 
-class RetainOldCountTestCase(unittest.TestCase):
+class RetainOldCountTestCase(utils.BaseAPITestCase):
     """Test the ``retain_old_count`` feature."""
 
-    def test_all(self):
-        """Test the ``retain_old_count`` feature.
+    @classmethod
+    def setUpClass(cls):
+        """Create, populate and publish a repository.
 
-        Specifically, do the following:
-
-        1. Create, populate and publish repository. Ensure at least two
-           versions of some RPM are present.
-        2. Create and sync a second repository whose feed references the first
-           repository and where ``retain_old_count`` is zero.
-        3. Inspect the two repositories. Assert that only the newest version of
-           any duplicate RPMs has been copied to the second repository.
+        Ensure at least two versions of an RPM are present in the repository.
         """
-        cfg = config.get_config()
-        if check_issue_2277(cfg):
-            raise unittest.SkipTest('https://pulp.plan.io/issues/2277')
-        client = api.Client(cfg, api.json_handler)
-
-        # Create, populate and publish a repo.
+        super().setUpClass()
+        client = api.Client(cls.cfg, api.json_handler)
         body = gen_repo()
         body['importer_config']['feed'] = RPM_UNSIGNED_FEED_URL
         body['distributors'] = [gen_distributor()]
-        repo = client.post(REPOSITORY_PATH, body)
-        self.addCleanup(client.delete, repo['_href'])
-        repo = client.get(repo['_href'], params={'details': True})
-        utils.sync_repo(cfg, repo['_href'])
-        utils.publish_repo(cfg, repo)
+        cls.repo = client.post(REPOSITORY_PATH, body)
+        cls.resources.add(cls.repo['_href'])
+        try:
+            cls.repo = client.get(cls.repo['_href'], params={'details': True})
+            utils.sync_repo(cls.cfg, cls.repo['_href'])
+            utils.publish_repo(cls.cfg, cls.repo)
+            cls.repo = client.get(cls.repo['_href'], params={'details': True})
+        except:
+            cls.tearDownClass()
+            raise
 
-        # Create second repository. We disable SSL validation for a practical
-        # reason: each HTTPS feed must have a certificate to work, which is
-        # burdensome to do here.
+    def test_retain_zero(self):
+        """Give ``retain_old_count`` a value of zero.
+
+        Create a repository whose feed references the repository created by
+        :meth:`setUpClass`, and whose ``retain_old_count`` option is zero.
+        Sync the repository, and assert that zero old versions of any duplicate
+        RPMs were copied over.
+        """
+        repo = self.create_sync_repo(0)
+        counts = [_['content_unit_counts']['rpm'] for _ in (self.repo, repo)]
+        self.assertEqual(counts[0] - 1, counts[1])
+
+    def test_retain_one(self):
+        """Give ``retain_old_count`` a value of one.
+
+        Create a repository whose feed references the repository created in
+        :meth:`setUpClass`, and whose ``retain_old_count`` option is one. Sync
+        the repository, and assert that one old version of any duplicate RPMs
+        were copied over.
+        """
+        repo = self.create_sync_repo(1)
+        counts = [_['content_unit_counts']['rpm'] for _ in (self.repo, repo)]
+        self.assertEqual(counts[0], counts[1])
+
+    def create_sync_repo(self, retain_old_count):
+        """Create and sync a repository. Return detailed information about it.
+
+        Implement the logic described by the ``test_retain_*`` methods.
+        """
+        # We disable SSL validation for a practical reason: each HTTPS feed
+        # must have a certificate to work, which is burdensome to do here.
+        client = api.Client(self.cfg, api.json_handler)
         body = gen_repo()
         body['importer_config']['feed'] = urljoin(
-            cfg.base_url,
-            'pulp/repos/' + repo['distributors'][0]['config']['relative_url'],
+            self.cfg.base_url,
+            'pulp/repos/' +
+            self.repo['distributors'][0]['config']['relative_url'],
         )
-        body['importer_config']['retain_old_count'] = 0
+        body['importer_config']['retain_old_count'] = retain_old_count
         body['importer_config']['ssl_validation'] = False
-        repo2 = client.post(REPOSITORY_PATH, body)
-        self.addCleanup(client.delete, repo2['_href'])
-        utils.sync_repo(cfg, repo2['_href'])
-
-        # Inspect the repos. Most of the RPMs in the first repo are unique.
-        # However, there are two versions of the "walrus" RPM, and when
-        # ``retain_old_count=0``, zero old versions should be copied over.
-        repo = client.get(repo['_href'], params={'details': True})
-        repo2 = client.get(repo2['_href'], params={'details': True})
-        counts = [repo['content_unit_counts']['rpm'] for repo in (repo, repo2)]
-        self.assertEqual(counts[0] - 1, counts[1])
+        repo = client.post(REPOSITORY_PATH, body)
+        self.addCleanup(client.delete, repo['_href'])
+        utils.sync_repo(self.cfg, repo['_href'])
+        return client.get(repo['_href'], params={'details': True})


### PR DESCRIPTION
The API test case for the `retain_old_count` feature already ensures
that the flag works correctly when set to zero. However, it doesn't
ensure that the flag works for values greater than zero. Fix this
omission.

See: https://github.com/PulpQE/pulp-smash/issues/662

See: https://pulp.plan.io/issues/2785