### PR TITLE
Skip tests affected by Pulp issue 2798

### DIFF
--- a/pulp_smash/tests/rpm/api_v2/test_download_policies.py
+++ b/pulp_smash/tests/rpm/api_v2/test_download_policies.py
@@ -25,6 +25,7 @@ from pulp_smash.tests.rpm.api_v2.utils import (
 )
 from pulp_smash.tests.rpm.utils import (
     check_issue_2387,
+    check_issue_2798,
     os_is_rhel6,
     set_up_module,
 )
@@ -36,6 +37,8 @@ def setUpModule():  # pylint:disable=invalid-name
     cfg = config.get_config()
     if cfg.version < Version('2.8'):
         raise unittest.SkipTest('This module requires Pulp 2.8 or greater.')
+    if check_issue_2798(cfg):
+        raise unittest.SkipTest('https://pulp.plan.io/issues/2798')
     if check_issue_2387(cfg):
         raise unittest.SkipTest('https://pulp.plan.io/issues/2387')
     if selectors.bug_is_untestable(2272, cfg.version):

--- a/pulp_smash/tests/rpm/api_v2/test_package_paths.py
+++ b/pulp_smash/tests/rpm/api_v2/test_package_paths.py
@@ -43,7 +43,7 @@ from pulp_smash.tests.rpm.api_v2.utils import (
     gen_repo,
     get_unit,
 )
-from pulp_smash.tests.rpm.utils import check_issue_2354
+from pulp_smash.tests.rpm.utils import check_issue_2354, check_issue_2798
 from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 
@@ -71,6 +71,8 @@ class ReuseContentTestCase(unittest.TestCase):
     def test_all(self):
         """Sync two repositories w/identical content but differing layouts."""
         cfg = config.get_config()
+        if check_issue_2798(cfg):
+            self.skipTest('https://pulp.plan.io/issues/2798')
         if check_issue_2354(cfg):
             self.skipTest('https://pulp.plan.io/issues/2354')
         repos = [

--- a/pulp_smash/tests/rpm/utils.py
+++ b/pulp_smash/tests/rpm/utils.py
@@ -65,6 +65,17 @@ def check_issue_2620(cfg):
     return False
 
 
+def check_issue_2798(cfg):
+    """Return true if `Pulp #2798`_ affects the targeted Pulp system.
+
+    :param pulp_smash.config.PulpSmashConfig cfg: The Pulp system under test.
+
+    .. _Pulp #2798: https://pulp.plan.io/issues/2798
+    """
+    return (cfg.version >= Version('2.14') and
+            selectors.bug_is_untestable(2798, cfg.version))
+
+
 def os_is_rhel6(cfg):
     """Return ``True`` if the server runs RHEL 6, or ``False`` otherwise.
 


### PR DESCRIPTION
Pulp issue 2798 describes how background and on demand downloads are
broken. See: https://pulp.plan.io/issues/2798