### PR TITLE
Update method `utils.sync_repo`

### DIFF
--- a/pulp_smash/tests/docker/api_v2/test_tags.py
+++ b/pulp_smash/tests/docker/api_v2/test_tags.py
@@ -80,7 +80,7 @@ class DockerTagTestCase(utils.BaseAPITestCase):
         super().setUp()
         self.repo = create_docker_repo(self.cfg, DOCKER_UPSTREAM_NAME)
         self.addCleanup(api.Client(self.cfg).delete, self.repo['_href'])
-        utils.sync_repo(self.cfg, self.repo['_href'])
+        utils.sync_repo(self.cfg, self.repo)
         self.repo = api.Client(self.cfg, api.json_handler).get(
             self.repo['_href'], params={'details': True})
         self.tags = self._get_tags()
@@ -210,7 +210,7 @@ class DockerTagTestCase(utils.BaseAPITestCase):
         """Check if tagging fail for a manifest from another repo."""
         other = create_docker_repo(self.cfg, 'library/swarm')
         self.addCleanup(api.Client(self.cfg).delete, other['_href'])
-        utils.sync_repo(self.cfg, other['_href'])
+        utils.sync_repo(self.cfg, other)
         other = api.Client(self.cfg, api.json_handler).get(
             other['_href'], params={'details': True})
         other_manifest = random.choice(utils.search_units(

--- a/pulp_smash/tests/ostree/api_v2/test_publish.py
+++ b/pulp_smash/tests/ostree/api_v2/test_publish.py
@@ -34,7 +34,7 @@ class PublishTestCase(unittest.TestCase):
         self.addCleanup(client.delete, repo['_href'])
 
         # Sync the repository.
-        utils.sync_repo(cfg, repo['_href'])
+        utils.sync_repo(cfg, repo)
         repo = client.get(repo['_href'], params={'details': True})
         with self.subTest(comment='verify last_publish after sync'):
             self.assertIsNone(repo['distributors'][0]['last_publish'])

--- a/pulp_smash/tests/ostree/api_v2/test_sync.py
+++ b/pulp_smash/tests/ostree/api_v2/test_sync.py
@@ -117,7 +117,7 @@ class SyncTestCase(_SyncMixin, utils.BaseAPITestCase):
         body['importer_config']['branches'] = [OSTREE_BRANCH]
         repo = api.Client(cls.cfg).post(REPOSITORY_PATH, body).json()
         cls.resources.add(repo['_href'])
-        cls.report = utils.sync_repo(cls.cfg, repo['_href'])
+        cls.report = utils.sync_repo(cls.cfg, repo)
         cls.tasks = tuple(api.poll_spawned_tasks(cls.cfg, cls.report.json()))
 
     def test_task_progress_report(self):

--- a/pulp_smash/tests/puppet/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/puppet/api_v2/test_sync_publish.py
@@ -189,7 +189,7 @@ class SyncValidFeedTestCase(utils.BaseAPITestCase):
 
     def sync_repo(self, repo):
         """Sync a repository, and verify no tasks contain an error message."""
-        report = utils.sync_repo(self.cfg, repo['_href']).json()
+        report = utils.sync_repo(self.cfg, repo).json()
         for task in api.poll_spawned_tasks(self.cfg, report):
             self.assertIsNone(
                 task['progress_report']['puppet_importer']['metadata']['error_message']  # noqa pylint:disable=line-too-long
@@ -258,7 +258,7 @@ class SyncNoFeedTestCase(utils.BaseAPITestCase):
         # Sync the repository. An error *should* occur. We just want the error
         # to be sane.
         with self.assertRaises(exceptions.TaskReportError) as err:
-            utils.sync_repo(cfg, repo['_href'])
+            utils.sync_repo(cfg, repo)
         with self.subTest(comment='check task "error" field'):
             self.assertIsNotNone(err.exception.task['error'])
             self.assertNotEqual(
@@ -288,7 +288,7 @@ class SyncValidManifestFeedTestCase(utils.BaseAPITestCase):
         cls.resources.add(repo['_href'])
 
         # Trigger a repository sync and collect completed tasks.
-        cls.report = utils.sync_repo(cls.cfg, repo['_href'])
+        cls.report = utils.sync_repo(cls.cfg, repo)
         cls.tasks = list(api.poll_spawned_tasks(cls.cfg, cls.report.json()))
 
     def test_status_code(self):

--- a/pulp_smash/tests/python/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/python/api_v2/test_sync_publish.py
@@ -73,7 +73,7 @@ class BaseTestCase(unittest.TestCase):
         }
         repo = client.post(constants.REPOSITORY_PATH, body)
         self.repos.append(repo)
-        call_report = utils.sync_repo(self.cfg, repo['_href'])
+        call_report = utils.sync_repo(self.cfg, repo)
         with self.subTest(comment='verify the sync succeeded'):
             self.verify_sync(self.cfg, call_report)
         with self.subTest(comment='verify content units are present'):
@@ -129,7 +129,7 @@ class SyncTestCase(BaseTestCase):
         body['distributors'] = [gen_distributor()]
         repo = client.post(constants.REPOSITORY_PATH, body)
         self.repos.append(repo)
-        call_report = utils.sync_repo(self.cfg, repo['_href'])
+        call_report = utils.sync_repo(self.cfg, repo)
         with self.subTest(comment='verify the sync succeeded'):
             self.verify_sync(self.cfg, call_report)
         with self.subTest(comment='verify content units are present'):

--- a/pulp_smash/tests/rpm/api_v2/test_broker.py
+++ b/pulp_smash/tests/rpm/api_v2/test_broker.py
@@ -122,7 +122,7 @@ class BrokerTestCase(unittest.TestCase):
         repo = client.post(REPOSITORY_PATH, body)
         self.addCleanup(client.delete, repo['_href'])
         repo = client.get(repo['_href'], params={'details': True})
-        utils.sync_repo(self.cfg, repo['_href'])
+        utils.sync_repo(self.cfg, repo)
         utils.publish_repo(self.cfg, repo)
         pulp_rpm = get_unit(self.cfg, repo['distributors'][0], RPM).content
 

--- a/pulp_smash/tests/rpm/api_v2/test_comps_xml.py
+++ b/pulp_smash/tests/rpm/api_v2/test_comps_xml.py
@@ -140,7 +140,7 @@ class SyncRepoTestCase(utils.BaseAPITestCase):
         repo = client.get(repo['_href'], params={'details': True})
 
         # Sync and publish the repo.
-        utils.sync_repo(cls.cfg, repo['_href'])
+        utils.sync_repo(cls.cfg, repo)
         utils.publish_repo(cls.cfg, repo)
 
         # Fetch and parse comps.xml.

--- a/pulp_smash/tests/rpm/api_v2/test_crud.py
+++ b/pulp_smash/tests/rpm/api_v2/test_crud.py
@@ -98,7 +98,7 @@ class PulpDistributionTestCase(utils.BaseAPITestCase):
         }
         repo = client.post(REPOSITORY_PATH, body)
         self.addCleanup(client.delete, repo['_href'])
-        utils.sync_repo(self.cfg, repo['_href'])
+        utils.sync_repo(self.cfg, repo)
         repo = client.get(repo['_href'], params={'details': True})
         self.assertEqual(repo['content_unit_counts']['distribution'], 1)
         cli_client = cli.Client(self.cfg, cli.code_handler)
@@ -249,7 +249,7 @@ class LastUnitAddedTestCase(utils.BaseAPITestCase):
         4. Assert the repository's ``last_unit_added`` attribute is non-null.
         """
         self.assertIsNone(self.repo['last_unit_added'])
-        utils.sync_repo(self.cfg, self.repo['_href'])
+        utils.sync_repo(self.cfg, self.repo)
         self.repo = self.client.get(
             self.repo['_href'], params={'details': True})
         self.assertIsNotNone(self.repo['last_unit_added'])
@@ -271,7 +271,7 @@ class LastUnitAddedTestCase(utils.BaseAPITestCase):
             self.skipTest('https://pulp.plan.io/issues/2688')
 
         # create a repo with a feed and sync it
-        utils.sync_repo(self.cfg, self.repo['_href'])
+        utils.sync_repo(self.cfg, self.repo)
         self.repo = self.client.get(
             self.repo['_href'], params={'details': True})
 

--- a/pulp_smash/tests/rpm/api_v2/test_download_policies.py
+++ b/pulp_smash/tests/rpm/api_v2/test_download_policies.py
@@ -89,7 +89,7 @@ class BackgroundTestCase(utils.BaseAPITestCase):
         # Create, sync and publish a repository.
         repo = _create_repo(cls.cfg, 'background')
         cls.resources.add(repo['_href'])
-        report = utils.sync_repo(cls.cfg, repo['_href']).json()
+        report = utils.sync_repo(cls.cfg, repo).json()
 
         # Record the tasks spawned when syncing the repository, and the state
         # of the repository itself after the sync.
@@ -161,7 +161,7 @@ class OnDemandTestCase(utils.BaseAPITestCase):
         # Create, sync and publish a repository.
         repo = _create_repo(cls.cfg, 'on_demand')
         cls.resources.add(repo['_href'])
-        utils.sync_repo(cls.cfg, repo['_href'])
+        utils.sync_repo(cls.cfg, repo)
 
         # Read the repository.
         client = api.Client(cls.cfg)
@@ -258,7 +258,7 @@ class FixFileCorruptionTestCase(utils.BaseAPITestCase):
         # Create, sync and publish a repository.
         repo = _create_repo(cls.cfg, 'on_demand')
         cls.resources.add(repo['_href'])
-        utils.sync_repo(cls.cfg, repo['_href'])
+        utils.sync_repo(cls.cfg, repo)
 
         # Trigger a repository download. Read the repo before and after.
         api_client = api.Client(cls.cfg, api.json_handler)
@@ -397,7 +397,7 @@ class SwitchPoliciesTestCase(utils.BaseAPITestCase):
             repo['_href'], params={'details': True}).json()
         self.assertEqual(
             repo['importers'][0]['config']['download_policy'], second)
-        report = utils.sync_repo(self.cfg, repo['_href']).json()
+        report = utils.sync_repo(self.cfg, repo).json()
         tasks = tuple(api.poll_spawned_tasks(self.cfg, report))
         return repo, tasks
 

--- a/pulp_smash/tests/rpm/api_v2/test_export.py
+++ b/pulp_smash/tests/rpm/api_v2/test_export.py
@@ -186,7 +186,7 @@ class BaseExportChecksumTypeTestCase(ExportDirMixin, utils.BaseAPITestCase):
         body['importer_config']['feed'] = RPM_SIGNED_FEED_URL
         cls.repo = api.Client(cls.cfg).post(REPOSITORY_PATH, body).json()
         cls.resources.add(cls.repo['_href'])
-        utils.sync_repo(cls.cfg, cls.repo['_href'])
+        utils.sync_repo(cls.cfg, cls.repo)
 
     def _publish_to_web(self, entity, distributor):
         """Publish ``entity`` to web using the ``distributor``.
@@ -421,7 +421,7 @@ class ExportDistributorTestCase(ExportDirMixin, utils.BaseAPITestCase):
         body['importer_config']['feed'] = RPM_SIGNED_FEED_URL
         cls.repo = api.Client(cls.cfg).post(REPOSITORY_PATH, body).json()
         cls.resources.add(cls.repo['_href'])
-        utils.sync_repo(cls.cfg, cls.repo['_href'])
+        utils.sync_repo(cls.cfg, cls.repo)
         if (cls.cfg.version >= Version('2.9') and
                 selectors.bug_is_untestable(1928, cls.cfg.version)):
             cls.distributor = None

--- a/pulp_smash/tests/rpm/api_v2/test_force_full.py
+++ b/pulp_smash/tests/rpm/api_v2/test_force_full.py
@@ -34,7 +34,7 @@ class ForceFullTestCase(utils.BaseAPITestCase):
         body['distributors'] = [gen_distributor()]
         repo = client.post(REPOSITORY_PATH, body)
         cls.resources.add(repo['_href'])
-        utils.sync_repo(cls.cfg, repo['_href'])
+        utils.sync_repo(cls.cfg, repo)
         cls.repo = client.get(repo['_href'], params={'details': True})
 
     def get_step(self, steps, step_type):

--- a/pulp_smash/tests/rpm/api_v2/test_iso_crud.py
+++ b/pulp_smash/tests/rpm/api_v2/test_iso_crud.py
@@ -322,7 +322,7 @@ class PulpManifestTestCase(utils.BaseAPITestCase):
         client = api.Client(self.cfg, api.json_handler)
         repo = client.post(REPOSITORY_PATH, _gen_iso_repo(FILE_FEED_URL))
         self.addCleanup(client.delete, repo['_href'])
-        utils.sync_repo(self.cfg, repo['_href'])
+        utils.sync_repo(self.cfg, repo)
         repo = client.get(repo['_href'], params={'details': True})
         self.assertEqual(repo['total_repository_units'], pulp_manifest_count)
         self.assertEqual(
@@ -346,7 +346,7 @@ class PulpManifestTestCase(utils.BaseAPITestCase):
         repo = client.post(REPOSITORY_PATH, _gen_iso_repo(FILE_MIXED_FEED_URL))
         self.addCleanup(client.delete, repo['_href'])
         with self.assertRaises(exceptions.TaskReportError) as context:
-            utils.sync_repo(self.cfg, repo['_href'])
+            utils.sync_repo(self.cfg, repo)
         task = context.exception.task
         self.assertIsNotNone(task['error'])
         # Description is a string generated after a Python's list of dicts

--- a/pulp_smash/tests/rpm/api_v2/test_iso_sync_publish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_iso_sync_publish.py
@@ -96,7 +96,7 @@ class ServeHttpsFalseTestCase(TemporaryUserMixin, unittest.TestCase):
         #     "/var/lib/pulp/published/https/isos/repo-id/PULP_MANIFEST"
         #     failed: No such file or directory (2)
         #
-        utils.sync_repo(self.cfg, repo['_href'])
+        utils.sync_repo(self.cfg, repo)
         dists = get_dists_by_type_id(self.cfg, repo)
         utils.publish_repo(self.cfg, repo, {
             'id': dists['iso_distributor']['id'],

--- a/pulp_smash/tests/rpm/api_v2/test_mirrorlist.py
+++ b/pulp_smash/tests/rpm/api_v2/test_mirrorlist.py
@@ -130,7 +130,7 @@ class GoodMirrorlistTestCase(UtilsMixin, unittest.TestCase):
         self.check_issue_2277(cfg)
         self.check_issue_2326(cfg)
         repo = self.create_repo(cfg, RPM_MIRRORLIST_GOOD)
-        utils.sync_repo(cfg, repo['_href'])
+        utils.sync_repo(cfg, repo)
         utils.publish_repo(cfg, repo)
         actual_rpm = get_unit(cfg, repo['distributors'][0], RPM).content
         target_rpm = utils.http_get(RPM_UNSIGNED_URL)
@@ -146,7 +146,7 @@ class GoodRelativeUrlTestCase(UtilsMixin, unittest.TestCase):
         self.check_issue_2277(cfg)
         self.check_issue_2326(cfg)
         repo = self.create_repo(cfg, RPM_MIRRORLIST_GOOD, _gen_rel_url())
-        utils.sync_repo(cfg, repo['_href'])
+        utils.sync_repo(cfg, repo)
         utils.publish_repo(cfg, repo)
         actual_rpm = get_unit(cfg, repo['distributors'][0], RPM).content
         target_rpm = utils.http_get(RPM_UNSIGNED_URL)
@@ -168,7 +168,7 @@ class MixedMirrorlistTestCase(UtilsMixin, unittest.TestCase):
         self.check_issue_2277(cfg)
         self.check_issue_2321(cfg)
         repo = self.create_repo(cfg, RPM_MIRRORLIST_MIXED)
-        utils.sync_repo(cfg, repo['_href'])
+        utils.sync_repo(cfg, repo)
         utils.publish_repo(cfg, repo)
         actual_rpm = get_unit(cfg, repo['distributors'][0], RPM).content
         target_rpm = utils.http_get(RPM_UNSIGNED_URL)
@@ -184,7 +184,7 @@ class MixedRelativeUrlTestCase(UtilsMixin, unittest.TestCase):
         self.check_issue_2277(cfg)
         self.check_issue_2321(cfg)
         repo = self.create_repo(cfg, RPM_MIRRORLIST_MIXED, _gen_rel_url())
-        utils.sync_repo(cfg, repo['_href'])
+        utils.sync_repo(cfg, repo)
         utils.publish_repo(cfg, repo)
         actual_rpm = get_unit(cfg, repo['distributors'][0], RPM).content
         target_rpm = utils.http_get(RPM_UNSIGNED_URL)
@@ -207,7 +207,7 @@ class BadMirrorlistTestCase(UtilsMixin, unittest.TestCase):
         self.check_issue_2363(cfg)
         repo = self.create_repo(cfg, RPM_MIRRORLIST_BAD)
         with self.assertRaises(TaskReportError):
-            utils.sync_repo(cfg, repo['_href'])
+            utils.sync_repo(cfg, repo)
 
 
 class BadRelativeUrlTestCase(UtilsMixin, unittest.TestCase):
@@ -219,4 +219,4 @@ class BadRelativeUrlTestCase(UtilsMixin, unittest.TestCase):
         self.check_issue_2363(cfg)
         repo = self.create_repo(cfg, RPM_MIRRORLIST_BAD, _gen_rel_url())
         with self.assertRaises(TaskReportError):
-            utils.sync_repo(cfg, repo['_href'])
+            utils.sync_repo(cfg, repo)

--- a/pulp_smash/tests/rpm/api_v2/test_no_op_publish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_no_op_publish.py
@@ -76,7 +76,7 @@ def setUpModule():  # pylint:disable=invalid-name
     _REPO.update(client.post(REPOSITORY_PATH, body))
     _CLEANUP.append((client.delete, [_REPO['_href']], {}))
     try:
-        utils.sync_repo(cfg, _REPO['_href'])
+        utils.sync_repo(cfg, _REPO)
     except (exceptions.CallReportError, exceptions.TaskReportError,
             exceptions.TaskTimedOutError):
         tearDownModule()

--- a/pulp_smash/tests/rpm/api_v2/test_orphan_remove.py
+++ b/pulp_smash/tests/rpm/api_v2/test_orphan_remove.py
@@ -55,7 +55,7 @@ class OrphansTestCase(unittest.TestCase):
         body['importer_config']['feed'] = RPM_SIGNED_FEED_URL
         repo = client.post(REPOSITORY_PATH, body)
         try:
-            utils.sync_repo(cfg, repo['_href'])
+            utils.sync_repo(cfg, repo)
         finally:
             client.delete(repo['_href'])
         cls.orphans_available = False

--- a/pulp_smash/tests/rpm/api_v2/test_package_paths.py
+++ b/pulp_smash/tests/rpm/api_v2/test_package_paths.py
@@ -80,7 +80,7 @@ class ReuseContentTestCase(unittest.TestCase):
             for feed in (RPM_ALT_LAYOUT_FEED_URL, RPM_UNSIGNED_FEED_URL)
         ]
         for repo in repos:
-            utils.sync_repo(cfg, repo['_href'])
+            utils.sync_repo(cfg, repo)
         for repo in repos:
             utils.publish_repo(cfg, repo)
         rpms = []

--- a/pulp_smash/tests/rpm/api_v2/test_remove_unit.py
+++ b/pulp_smash/tests/rpm/api_v2/test_remove_unit.py
@@ -71,7 +71,7 @@ class RemoveMissingTestCase(unittest.TestCase):
         body['distributors'] = [gen_distributor()]
         self.repos['root'] = client.post(REPOSITORY_PATH, body)
         self.repos['root'] = _get_details(self.cfg, self.repos['root'])
-        utils.sync_repo(self.cfg, self.repos['root']['_href'])
+        utils.sync_repo(self.cfg, self.repos['root'])
         utils.publish_repo(self.cfg, self.repos['root'])
 
     def test_02_create_immediate_child(self):
@@ -95,7 +95,7 @@ class RemoveMissingTestCase(unittest.TestCase):
         self.repos['immediate'] = (
             _get_details(self.cfg, self.repos['immediate'])
         )
-        utils.sync_repo(self.cfg, self.repos['immediate']['_href'])
+        utils.sync_repo(self.cfg, self.repos['immediate'])
 
         # Verify the two repositories have the same contents.
         root_ids = _get_rpm_ids(_get_rpms(self.cfg, self.repos['root']))
@@ -125,7 +125,7 @@ class RemoveMissingTestCase(unittest.TestCase):
         self.repos['on demand'] = (
             _get_details(self.cfg, self.repos['on demand'])
         )
-        utils.sync_repo(self.cfg, self.repos['on demand']['_href'])
+        utils.sync_repo(self.cfg, self.repos['on demand'])
 
         # Verify the two repositories have the same contents.
         root_ids = _get_rpm_ids(_get_rpms(self.cfg, self.repos['root']))
@@ -156,7 +156,7 @@ class RemoveMissingTestCase(unittest.TestCase):
 
         Verify it has the same contents as the root repository.
         """
-        utils.sync_repo(self.cfg, self.repos['immediate']['_href'])
+        utils.sync_repo(self.cfg, self.repos['immediate'])
         root_ids = _get_rpm_ids(_get_rpms(self.cfg, self.repos['root']))
         immediate_ids = _get_rpm_ids(
             _get_rpms(self.cfg, self.repos['immediate'])
@@ -168,7 +168,7 @@ class RemoveMissingTestCase(unittest.TestCase):
 
         Verify it has the same contents as the root repository.
         """
-        utils.sync_repo(self.cfg, self.repos['on demand']['_href'])
+        utils.sync_repo(self.cfg, self.repos['on demand'])
         root_ids = _get_rpm_ids(_get_rpms(self.cfg, self.repos['root']))
         on_demand_ids = _get_rpm_ids(
             _get_rpms(self.cfg, self.repos['on demand'])

--- a/pulp_smash/tests/rpm/api_v2/test_repomd.py
+++ b/pulp_smash/tests/rpm/api_v2/test_repomd.py
@@ -135,7 +135,7 @@ class FastForwardIntegrityTestCase(unittest.TestCase):
         # Create a dummy-primary.xml. Trigger an incremental fast-forward pub.
         # Fast-forward publish described here: https://pulp.plan.io/issues/2113
         self._create_dummy_primary_xml(cfg, repo, old_phrase, new_phrase)
-        utils.sync_repo(cfg, repo['_href'])
+        utils.sync_repo(cfg, repo)
         utils.publish_repo(cfg, repo)
         primary_xml = self._read_primary_xml(cfg, repo)
         self.assertIn(old_phrase, primary_xml)
@@ -199,7 +199,7 @@ class FastForwardIntegrityTestCase(unittest.TestCase):
         body['distributors'] = [gen_distributor()]
         repo = client.post(REPOSITORY_PATH, body)
         self.addCleanup(client.delete, repo['_href'])
-        utils.sync_repo(cfg, repo['_href'])
+        utils.sync_repo(cfg, repo)
         repo = client.get(repo['_href'], params={'details': True})
         return client.get(repo['_href'], params={'details': True})
 

--- a/pulp_smash/tests/rpm/api_v2/test_repository_layout.py
+++ b/pulp_smash/tests/rpm/api_v2/test_repository_layout.py
@@ -120,7 +120,7 @@ class RepositoryLayoutTestCase(utils.BaseAPITestCase):
         repo = client.post(REPOSITORY_PATH, body)
         self.addCleanup(client.delete, repo['_href'])
         repo = client.get(repo['_href'], params={'details': True})
-        utils.sync_repo(self.cfg, repo['_href'])
+        utils.sync_repo(self.cfg, repo)
         distributor = client.post(
             urljoin(repo['_href'], 'distributors/'),
             gen_distributor(),

--- a/pulp_smash/tests/rpm/api_v2/test_republish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_republish.py
@@ -55,7 +55,7 @@ class RepublishTestCase(unittest.TestCase):
         repo = client.post(REPOSITORY_PATH, body)
         self.addCleanup(client.delete, repo['_href'])
         repo = client.get(repo['_href'], params={'details': True})
-        utils.sync_repo(cfg, repo['_href'])
+        utils.sync_repo(cfg, repo)
         utils.publish_repo(cfg, repo)
 
         # Pick a random content unit and verify it's accessible.

--- a/pulp_smash/tests/rpm/api_v2/test_retain_old_count.py
+++ b/pulp_smash/tests/rpm/api_v2/test_retain_old_count.py
@@ -35,7 +35,7 @@ class RetainOldCountTestCase(utils.BaseAPITestCase):
         cls.resources.add(cls.repo['_href'])
         try:
             cls.repo = client.get(cls.repo['_href'], params={'details': True})
-            utils.sync_repo(cls.cfg, cls.repo['_href'])
+            utils.sync_repo(cls.cfg, cls.repo)
             utils.publish_repo(cls.cfg, cls.repo)
             cls.repo = client.get(cls.repo['_href'], params={'details': True})
         except:
@@ -84,5 +84,5 @@ class RetainOldCountTestCase(utils.BaseAPITestCase):
         body['importer_config']['ssl_validation'] = False
         repo = client.post(REPOSITORY_PATH, body)
         self.addCleanup(client.delete, repo['_href'])
-        utils.sync_repo(self.cfg, repo['_href'])
+        utils.sync_repo(self.cfg, repo)
         return client.get(repo['_href'], params={'details': True})

--- a/pulp_smash/tests/rpm/api_v2/test_rsync_distributor.py
+++ b/pulp_smash/tests/rpm/api_v2/test_rsync_distributor.py
@@ -323,7 +323,7 @@ class ForceFullTestCase(
             'ssh_identity_file': ssh_identity_file,
             'ssh_user': ssh_user,
         }})
-        utils.sync_repo(cfg, repo['_href'])
+        utils.sync_repo(cfg, repo)
 
         # Publish the repo with the yum and rsync distributors, respectively.
         # Verify that the RPM rsync distributor has placed files.
@@ -492,7 +492,7 @@ class RemoteUnitsPathTestCase(
             'remote_units_path': paths[0],
         })
         distribs = get_dists_by_type_id(cfg, repo)
-        utils.sync_repo(cfg, repo['_href'])
+        utils.sync_repo(cfg, repo)
 
         # Publish the repo with the yum and rpm rsync distributors,
         # respectively. Verify that files have been correctly placed.
@@ -545,7 +545,7 @@ class DeleteTestCase(
             'ssh_identity_file': ssh_identity_file,
             'ssh_user': ssh_user,
         }})
-        utils.sync_repo(cfg, repo['_href'])
+        utils.sync_repo(cfg, repo)
 
         # Publish the repo with the yum and rsync distributors, respectively.
         # Verify that the RPM rsync distributor has placed files.

--- a/pulp_smash/tests/rpm/api_v2/test_schedule_publish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_schedule_publish.py
@@ -38,7 +38,7 @@ class CreateSuccessTestCase(utils.BaseAPITestCase):
         body['importer_config']['feed'] = RPM_SIGNED_FEED_URL
         repo = client.post(REPOSITORY_PATH, body).json()
         cls.resources.add(repo['_href'])
-        utils.sync_repo(cls.cfg, repo['_href'])
+        utils.sync_repo(cls.cfg, repo)
 
         # Schedule a publish to run every 30 seconds
         distributor = gen_distributor()
@@ -91,7 +91,7 @@ class CreateFailureTestCase(utils.BaseAPITestCase):
         body['importer_config']['feed'] = RPM_SIGNED_FEED_URL
         repo = client.post(REPOSITORY_PATH, body).json()
         cls.resources.add(repo['_href'])
-        utils.sync_repo(cls.cfg, repo['_href'])
+        utils.sync_repo(cls.cfg, repo)
 
         # Add a distibutor
         distributor = gen_distributor()
@@ -162,7 +162,7 @@ class ReadUpdateDeleteTestCase(utils.BaseAPITestCase):
         body['importer_config']['feed'] = RPM_SIGNED_FEED_URL
         repo = client.post(REPOSITORY_PATH, body)
         cls.resources.add(repo['_href'])
-        utils.sync_repo(cls.cfg, repo['_href'])
+        utils.sync_repo(cls.cfg, repo)
 
         # Create schedules
         distributor = gen_distributor()
@@ -270,7 +270,7 @@ class ScheduledPublishTestCase(utils.BaseAPITestCase):
         body['importer_config']['feed'] = RPM_SIGNED_FEED_URL
         repo = client.post(REPOSITORY_PATH, body)
         cls.resources.add(repo['_href'])
-        utils.sync_repo(cls.cfg, repo['_href'])
+        utils.sync_repo(cls.cfg, repo)
 
         # Schedule a publish to run every 2 minutes
         distributor = gen_distributor()

--- a/pulp_smash/tests/rpm/api_v2/test_search.py
+++ b/pulp_smash/tests/rpm/api_v2/test_search.py
@@ -46,7 +46,7 @@ class BaseSearchTestCase(utils.BaseAPITestCase):
         body['importer_config']['feed'] = cls.get_feed_url()
         cls.repo = api.Client(cls.cfg).post(REPOSITORY_PATH, body).json()
         cls.resources.add(cls.repo['_href'])
-        utils.sync_repo(cls.cfg, cls.repo['_href'])
+        utils.sync_repo(cls.cfg, cls.repo)
 
     @staticmethod
     def get_feed_url():

--- a/pulp_smash/tests/rpm/api_v2/test_signatures_checked_for_syncs.py
+++ b/pulp_smash/tests/rpm/api_v2/test_signatures_checked_for_syncs.py
@@ -81,10 +81,10 @@ class _BaseTestCase(unittest.TestCase):
         body = gen_repo()
         body['importer_config'] = importer_config
         self.addCleanup(client.delete, ORPHANS_PATH)
-        repo_href = client.post(REPOSITORY_PATH, body)['_href']
-        self.addCleanup(client.delete, repo_href)
-        utils.sync_repo(self.cfg, repo_href)
-        return client.get(repo_href)
+        repo = client.post(REPOSITORY_PATH, body)
+        self.addCleanup(client.delete, repo['_href'])
+        utils.sync_repo(self.cfg, repo)
+        return client.get(repo['_href'])
 
 
 class RequireValidKeyTestCase(_BaseTestCase):

--- a/pulp_smash/tests/rpm/api_v2/test_signatures_saved_for_packages.py
+++ b/pulp_smash/tests/rpm/api_v2/test_signatures_saved_for_packages.py
@@ -187,10 +187,10 @@ class SyncPackageTestCase(_BaseTestCase):
         self.addCleanup(self.client.delete, ORPHANS_PATH)
         body = gen_repo()
         body['importer_config']['feed'] = feed_url
-        repo_href = self.client.post(REPOSITORY_PATH, body)['_href']
-        self.addCleanup(self.client.delete, repo_href)
-        utils.sync_repo(self.cfg, repo_href)
-        return repo_href
+        repo = self.client.post(REPOSITORY_PATH, body)
+        self.addCleanup(self.client.delete, repo['_href'])
+        utils.sync_repo(self.cfg, repo)
+        return repo['_href']
 
     def test_signed_drpm(self):
         """Assert signature is stored for signed drpm during sync."""

--- a/pulp_smash/tests/rpm/api_v2/test_unassociate.py
+++ b/pulp_smash/tests/rpm/api_v2/test_unassociate.py
@@ -56,7 +56,7 @@ class RemoveUnitsTestCase(unittest.TestCase):
         body['importer_config']['feed'] = RPM_UNSIGNED_FEED_URL
         cls.repo = client.post(REPOSITORY_PATH, body).json()
         try:
-            utils.sync_repo(cls.cfg, cls.repo['_href'])
+            utils.sync_repo(cls.cfg, cls.repo)
             cls.initial_units = utils.search_units(cls.cfg, cls.repo)
         except:
             cls.tearDownClass()
@@ -296,7 +296,7 @@ class SelectiveAssociateTestCase(utils.BaseAPITestCase):
         body['importer_config']['feed'] = RPM_UNSIGNED_FEED_URL
         repo = client.post(REPOSITORY_PATH, body)
         self.addCleanup(client.delete, repo['_href'])
-        utils.sync_repo(self.cfg, repo['_href'])
+        utils.sync_repo(self.cfg, repo)
         rpm_units = (
             _get_units_by_type(utils.search_units(self.cfg, repo), 'rpm')
         )

--- a/pulp_smash/tests/rpm/api_v2/test_updateinfo.py
+++ b/pulp_smash/tests/rpm/api_v2/test_updateinfo.py
@@ -360,7 +360,7 @@ class UpdateRepoTestCase(utils.BaseAPITestCase):
         * one of its child ``<package>`` elements has a "name" attribute equal
           to :data:`pulp_smash.constants.RPM_ERRATUM_RPM_NAME`.
         """
-        utils.sync_repo(self.cfg, self.repo['_href'])
+        utils.sync_repo(self.cfg, self.repo)
         utils.publish_repo(self.cfg, self.repo)
         updates_element = (
             get_repodata(self.cfg, self.repo['distributors'][0], 'updateinfo')
@@ -433,7 +433,7 @@ class PkglistsTestCase(unittest.TestCase):
         repo = client.post(REPOSITORY_PATH, body)
         self.addCleanup(client.delete, repo['_href'])
         repo = client.get(repo['_href'], params={'details': True})
-        utils.sync_repo(cfg, repo['_href'])
+        utils.sync_repo(cfg, repo)
         utils.publish_repo(cfg, repo)
 
         # Fetch and parse ``updateinfo.xml``.
@@ -500,7 +500,7 @@ class CleanUpTestCase(unittest.TestCase):
 
     def test_01_first_publish(self):
         """Populate and publish the repository."""
-        utils.sync_repo(self.cfg, self.repo['_href'])
+        utils.sync_repo(self.cfg, self.repo)
         client = api.Client(self.cfg)
         client.post(urljoin(self.repo['_href'], 'actions/unassociate/'), {
             'criteria': {
@@ -521,7 +521,7 @@ class CleanUpTestCase(unittest.TestCase):
 
     def test_02_second_publish(self):
         """Add an additional content unit and publish the repository again."""
-        utils.sync_repo(self.cfg, self.repo['_href'])
+        utils.sync_repo(self.cfg, self.repo)
         utils.publish_repo(self.cfg, self.repo)
         self.updateinfo_xml_hrefs.append(self.get_updateinfo_xml_href())
 

--- a/pulp_smash/utils.py
+++ b/pulp_smash/utils.py
@@ -469,18 +469,17 @@ def get_unit_type_ids(server_config):
     return {unit_type['id'] for unit_type in unit_types}
 
 
-def sync_repo(server_config, href):
-    """Sync the referenced repository via the API. Return the server response.
+def sync_repo(cfg, repo):
+    """Sync a repository.
 
-    Checks are run against the server's response. If the sync appears to have
-    failed, an exception is raised.
-
-    :param pulp_smash.config.PulpSmashConfig server_config: Information about
-        the Pulp deployment being targeted.
-    :param href: The API v2 path to the repository to sync.
-    :returns: The server's response.
+    :param pulp_smash.config.PulpSmashConfig cfg: Information about the Pulp
+        host.
+    :param repo: A dict of detailed information about the repository to be
+        published.
+    :returns: The server's reponse. Call ``.json()`` on the response to get a
+        call report.
     """
-    return api.Client(server_config).post(urljoin(href, 'actions/sync/'))
+    return api.Client(cfg).post(urljoin(repo['_href'], 'actions/sync/'))
 
 
 def get_sha256_checksum(url):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -169,7 +169,10 @@ class SyncRepoTestCase(unittest.TestCase):
     def test_post(self):
         """Assert the function makes an HTTP POST request."""
         with mock.patch.object(api, 'Client') as client:
-            response = utils.sync_repo(mock.Mock(), 'http://example.com')
+            response = utils.sync_repo(
+                mock.Mock(),
+                {'_href': 'http://example.com'},
+            )
         self.assertIs(response, client.return_value.post.return_value)
 
 


### PR DESCRIPTION
The `sync_repo` method has been around for a long time. A typical usage
is as follows, where `repo_href` is a simple string path:

```python
utils.sync_repo(cfg, repo_href)
```

Update the method so that it accepts a dict of repository information
instead of a simple string path. A typical usage is as follows, where
`repo` is a dict like `{'_href': repo_href}`:

```python
utils.sync_repo(cfg, repo)
```

This change has two advantages. First, Pulp's API returns information
about repositories as a dict. Letting `sync_repo` accept a dict means
that it can accept the data returned by Pulp's API with no munging.
Second, this change makes `sync_repo` more consistent with other modern
methods like `publish_repo`. Both of these advantages are well explained
by an example. Consider this legacy code:

```python
repo = api_client.post(REPOSITORY_PATH, body)
utils.sync_repo(cfg, repo['_href'])
utils.publish_repo(cfg, repo)
```

The code above can now be written as follows:

```python
repo = api_client.post(REPOSITORY_PATH, body)
utils.sync_repo(cfg, repo)
utils.publish_repo(cfg, repo)
```