### PR TITLE
Tweak with assertions in rsync test case

### DIFF
--- a/pulp_smash/tests/rpm/api_v2/test_rsync_distributor.py
+++ b/pulp_smash/tests/rpm/api_v2/test_rsync_distributor.py
@@ -698,12 +698,13 @@ class PublishTwiceTestCase(
         }})
 
         # Add content.
-        utils.upload_import_unit(
-            cfg,
-            utils.http_get(RPM_UNSIGNED_URL),
-            {'unit_type_id': 'rpm'},
-            repo
-        )
+        for url in (RPM_UNSIGNED_URL, RPM2_UNSIGNED_URL):
+            utils.upload_import_unit(
+                cfg,
+                utils.http_get(url),
+                {'unit_type_id': 'rpm'},
+                repo
+            )
         dists = get_dists_by_type_id(cfg, repo)
 
         # Publish with yum and rsync.
@@ -714,7 +715,7 @@ class PublishTwiceTestCase(
             publish_task = self.get_publish_task(cfg, report)
         num_processed = self.get_num_processed(publish_task)
         with self.subTest(comment='first rsync publish'):
-            self.assertGreater(num_processed, 0, publish_task)
+            self.assertEqual(num_processed, 2, publish_task)
 
         # Publish with yum and rsync again.
         for dist in 'yum_distributor', 'rpm_rsync_distributor':


### PR DESCRIPTION
When executed, `PublishTwiceTestCase` will:

    1. Create a yum repository with a yum and rsync distributor.
    2. Add some content to the repository.
    3. Publish with the yum and rsync distributor.
    4. Publish with the yum and rsync distributor again.

    The second publish with the rsync distributor should be a fast-forward
    publish, as no new units were added to the repository between the first and
    second publishes.

Update the test case. In step 2, upload two RPMs, not one. In step 3,
assert that the "unit query step" processes exactly two RPMs, instead of
some vague number greater than zero. In step 4, continue to assert that
the "unit query step" processes exactly zero RPMs.

The rsync distributor uses iterators for much of its functionality,
meaning that several steps will always state that one item was
processed. In contrast, the "unit query step" doesn't use iterators,
which is why we can make assertions about the number of RPMs processed.
Uploading two RPMs instead of one makes it easier to parse the meaning
of test results in the future:

* If zero RPMs are processed, then this indicates that a fast-forward
  publish occurred.
* If two RPMs was processed, then this indicates that a full publish
  occurred.
* If one RPM was processed, then this might indicate that an iterator is
  being used for publishes, in which case the test needs to be
  redesigned.

See: https://pulp.plan.io/issues/2844