### PR TITLE
Skip test affected by Pulp issue 2844

### DIFF
--- a/pulp_smash/tests/rpm/api_v2/test_rsync_distributor.py
+++ b/pulp_smash/tests/rpm/api_v2/test_rsync_distributor.py
@@ -74,7 +74,7 @@ from pulp_smash.tests.rpm.api_v2.utils import (
     get_dists_by_type_id,
     set_pulp_manage_rsync,
 )
-from pulp_smash.tests.rpm.utils import set_up_module
+from pulp_smash.tests.rpm.utils import check_issue_2844, set_up_module
 
 
 def _split_path(path):
@@ -684,6 +684,8 @@ class PublishTwiceTestCase(
         cfg = config.get_config()
         if selectors.bug_is_untestable(2666, cfg.version):
             self.skipTest('https://pulp.plan.io/issues/2666')
+        if check_issue_2844(cfg):
+            self.skipTest('https://pulp.plan.io/issues/2844')
 
         # Create a user and a repository.
         ssh_user, priv_key = self.make_user(cfg)

--- a/pulp_smash/tests/rpm/utils.py
+++ b/pulp_smash/tests/rpm/utils.py
@@ -76,6 +76,17 @@ def check_issue_2798(cfg):
             selectors.bug_is_untestable(2798, cfg.version))
 
 
+def check_issue_2844(cfg):
+    """Return true if `Pulp #2844`_ affects the targeted Pulp system.
+
+    :param pulp_smash.config.PulpSmashConfig cfg: The Pulp system under test.
+
+    .. _Pulp #2844: https://pulp.plan.io/issues/2844
+    """
+    return (cfg.version >= Version('2.14') and
+            selectors.bug_is_untestable(2844, cfg.version))
+
+
 def os_is_rhel6(cfg):
     """Return ``True`` if the server runs RHEL 6, or ``False`` otherwise.
 


### PR DESCRIPTION
The test continues to run when Pulp 2.13.1 systems and newer are under
test.

See: https://pulp.plan.io/issues/2844