### PR TITLE
Provide RPM name, version, etc in constants.py

### DIFF
--- a/pulp_smash/constants.py
+++ b/pulp_smash/constants.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 """Values usable by multiple test modules."""
 from urllib.parse import quote_plus, urljoin
+from types import MappingProxyType  # used to form an immutable dictionary
 
 PULP_FIXTURES_BASE_URL = 'https://repos.fedorapeople.org/pulp/pulp/fixtures/'
 """A URL at which generated `pulp fixtures`_ are hosted.
@@ -344,10 +345,76 @@ REPOSITORY_PATH = '/pulp/api/v2/repositories/'
     https://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/repo/index.html
 """
 
-RPM = 'bear-4.1-1.noarch.rpm'
+RPM_DATA = MappingProxyType({
+    'name': 'bear',
+    'epoch': '0',
+    'version': '4.1',
+    'release': '1',
+    'arch': 'noarch',
+    'vendor': None,
+    'metadata': {
+        'release': '1',
+        'license': 'GPLv2',
+        'description': 'A dummy package of bear',
+        'files': {'dir': [], 'file': ['/tmp/bear.txt']},
+        'group': 'Internet/Applications',
+        'size': '42',
+        'sourcerpm': 'bear-4.1-1.src.rpm',
+        'summary': 'A dummy package of bear',
+    },
+})
+"""Metadata for an RPM with an associated erratum.
+
+The metadata tags that may be present in an RPM may be printed with:
+
+.. code-block:: sh
+
+    rpm --querytags
+
+Metadata for an RPM can be printed with a command like the following:
+
+.. code-block:: sh
+
+    for tag in name epoch version release arch vendor; do
+        echo "$(rpm -qp bear-4.1-1.noarch.rpm --qf "%{$tag}")"
+    done
+"""
+
+RPM = '{}-{}{}-{}.{}.rpm'.format(
+    RPM_DATA['name'],
+    RPM_DATA['epoch'] + '!' if RPM_DATA['epoch'] != '0' else '',
+    RPM_DATA['version'],
+    RPM_DATA['release'],
+    RPM_DATA['arch'],
+)
 """The name of an RPM file. See :data:`pulp_smash.constants.RPM_SIGNED_URL`."""
 
-RPM2 = 'camel-0.1-1.noarch.rpm'
+RPM2_DATA = MappingProxyType({
+    'name': 'camel',
+    'epoch': '0',
+    'version': '0.1',
+    'release': '1',
+    'arch': 'noarch',
+    'vendor': None,
+    'metadata': {
+        'release': '1',
+        'license': 'GPLv2',
+        'description': 'A dummy package of camel',
+        'files': {'dir': [], 'file': ['/tmp/camel.txt']},
+        'group': 'Internet/Applications',
+        'size': '42',
+        'sourcerpm': 'camel-0.1-1.src.rpm',
+        'summary': 'A dummy package of camel',
+    },
+})
+
+RPM2 = '{}-{}{}-{}.{}.rpm'.format(
+    RPM2_DATA['name'],
+    RPM2_DATA['epoch'] + '!' if RPM_DATA['epoch'] != '0' else '',
+    RPM2_DATA['version'],
+    RPM2_DATA['release'],
+    RPM2_DATA['arch'],
+)
 """The name of an RPM. See :data:`pulp_smash.constants.RPM2_UNSIGNED_URL`."""
 
 RPM_ALT_LAYOUT_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'rpm-alt-layout/')

--- a/pulp_smash/tests/rpm/api_v2/test_content_applicability.py
+++ b/pulp_smash/tests/rpm/api_v2/test_content_applicability.py
@@ -17,44 +17,30 @@ from pulp_smash.constants import (
     CONSUMERS_PATH,
     REPOSITORY_PATH,
     RPM_UNSIGNED_FEED_URL,
+    RPM_DATA,
+    RPM2_DATA,
 )
 from pulp_smash.tests.rpm.api_v2.utils import gen_distributor, gen_repo
 from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 # MappingProxyType is used to make an immutable dict.
 RPM_WITH_ERRATUM_METADATA = MappingProxyType({
-    'name': 'bear',
-    'epoch': None,
-    'version': '4.1',
-    'release': 1,
-    'arch': 'noarch',
-    'vendor': None,
+    'name': RPM_DATA['name'],
+    'epoch': RPM_DATA['epoch'],
+    'version': RPM_DATA['version'],
+    'release': int(RPM_DATA['release']),
+    'arch': RPM_DATA['arch'],
+    'vendor': RPM_DATA['vendor'],
 })
-"""Metadata for an RPM with an associated erratum.
-
-The metadata tags that may be present in an RPM may be printed with:
-
-.. code-block:: sh
-
-    rpm --querytags
-
-Metadata for an RPM can be printed with a command like the following:
-
-.. code-block:: sh
-
-    for tag in name epoch version release arch vendor; do
-        echo "$(rpm -qp bear-4.1-1.noarch.rpm --qf "%{$tag}")"
-    done
-
-"""
+"""Metadata for an RPM with an associated erratum."""
 
 RPM_WITHOUT_ERRATUM_METADATA = MappingProxyType({
-    'name': 'camel',
-    'epoch': None,
-    'version': '0.1',
-    'release': 1,
-    'arch': 'noarch',
-    'vendor': None,
+    'name': RPM2_DATA['name'],
+    'epoch': RPM2_DATA['epoch'],
+    'version': RPM2_DATA['version'],
+    'release': int(RPM2_DATA['release']),
+    'arch': RPM2_DATA['arch'],
+    'vendor': RPM2_DATA['vendor'],
 })
 """Metadata for an RPM without an associated erratum."""
 

--- a/pulp_smash/tests/rpm/api_v2/test_upload_publish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_upload_publish.py
@@ -19,6 +19,7 @@ from pulp_smash.constants import (
     ORPHANS_PATH,
     REPOSITORY_PATH,
     RPM,
+    RPM_DATA,
     RPM_UNSIGNED_URL,
     SRPM,
     SRPM_UNSIGNED_URL,
@@ -210,26 +211,35 @@ class UploadRpmTestCase(utils.BaseAPITestCase):
         with self.subTest():
             self.assertEqual(units[0]['metadata']['filename'], RPM)
         with self.subTest():
-            self.assertEqual(units[0]['metadata']['epoch'], '0')
+            self.assertEqual(units[0]['metadata']['epoch'], RPM_DATA['epoch'])
         with self.subTest():
-            self.assertEqual(units[0]['metadata']['name'], 'bear')
+            self.assertEqual(units[0]['metadata']['name'], RPM_DATA['name'])
         with self.subTest():
-            self.assertEqual(units[0]['metadata']['version'], '4.1')
+            self.assertEqual(
+                units[0]['metadata']['version'],
+                RPM_DATA['version']
+            )
         with self.subTest():
-            self.assertEqual(units[0]['metadata']['release'], '1')
+            self.assertEqual(
+                units[0]['metadata']['release'],
+                RPM_DATA['release']
+            )
 
         # other attributes
         with self.subTest():
-            self.assertEqual(units[0]['metadata']['license'], 'GPLv2')
+            self.assertEqual(
+                units[0]['metadata']['license'],
+                RPM_DATA['metadata']['license']
+            )
         with self.subTest():
             self.assertEqual(
                 units[0]['metadata']['description'],
-                'A dummy package of bear',
+                RPM_DATA['metadata']['description'],
             )
         with self.subTest():
             self.assertEqual(
                 units[0]['metadata']['files'],
-                {'dir': [], 'file': ['/tmp/bear.txt']},
+                RPM_DATA['metadata']['files'],
             )
 
     def verify_repo_download(self, repo):


### PR DESCRIPTION
Closes #693
Unblocks #667

I also updated two tests that hard coded in these values.
In the future, more metadata could be added.

@preethit @Ichimonji10 if either of you could give this a review I'd appreciate it!

I'm not sure about nesting some of the fields under `RPM_DATA['metadata']` and some not. I differentiated them soley based on what information actually constitutes the `RPM` name and what is additional information.