### PR TITLE
Test failing Pulp workers

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -94,6 +94,7 @@ developers, not a gospel.
     api/pulp_smash.tests.rpm.api_v2.test_schedule_publish
     api/pulp_smash.tests.rpm.api_v2.test_schedule_sync
     api/pulp_smash.tests.rpm.api_v2.test_search
+    api/pulp_smash.tests.rpm.api_v2.test_service_resiliency
     api/pulp_smash.tests.rpm.api_v2.test_signatures_checked_for_copies
     api/pulp_smash.tests.rpm.api_v2.test_signatures_checked_for_syncs
     api/pulp_smash.tests.rpm.api_v2.test_signatures_checked_for_uploads

--- a/docs/api/pulp_smash.tests.rpm.api_v2.test_service_resiliency.rst
+++ b/docs/api/pulp_smash.tests.rpm.api_v2.test_service_resiliency.rst
@@ -1,0 +1,6 @@
+`pulp_smash.tests.rpm.api_v2.test_service_resiliency`
+=====================================================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.rpm.api_v2.test_service_resiliency`
+
+.. automodule:: pulp_smash.tests.rpm.api_v2.test_service_resiliency

--- a/pulp_smash/api.py
+++ b/pulp_smash/api.py
@@ -89,6 +89,19 @@ def echo_handler(server_config, response):  # pylint:disable=unused-argument
     return response
 
 
+def code_handler(server_config, response):  # pylint:disable=unused-argument
+    """Check the response status code, and return the response.
+
+    Unlike :meth:`safe_handler`, this method doesn't wait for asynchronous
+    tasks to complete if ``response`` has an HTTP 202 status code.
+
+    :raises: ``requests.exceptions.HTTPError`` if the response status code is
+        in the 4XX or 5XX range.
+    """
+    response.raise_for_status()
+    return response
+
+
 def safe_handler(server_config, response):
     """Check status code, wait for tasks to complete, and check tasks.
 

--- a/pulp_smash/constants.py
+++ b/pulp_smash/constants.py
@@ -456,6 +456,15 @@ RPM_ERRATUM_URL = (
 RPM_ERRATUM_COUNT = 4
 """The number of errata listed in :data:`RPM_ERRATUM_URL`."""
 
+RPM_MIRRORLIST_LARGE = (
+    'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=x86_64'
+)
+"""A mirrorlist referencing a large RPM repository.
+
+.. NOTE: The mirrors referenced by this mirrorlist are not operated by Pulp QE.
+    They're public resources and should be sparingly used.
+"""
+
 RPM_MIRRORLIST_BAD = urljoin(PULP_FIXTURES_BASE_URL, 'rpm-mirrorlist-bad')
 """The URL to a mirrorlist file containing only invalid entries."""
 

--- a/pulp_smash/tests/rpm/api_v2/test_service_resiliency.py
+++ b/pulp_smash/tests/rpm/api_v2/test_service_resiliency.py
@@ -1,0 +1,86 @@
+# coding=utf-8
+"""Test the resiliency of Pulp's services.
+
+Pulp is designed to be resilient. It should be possible for a service to
+disappear and reappear, with the only consequence being slower processing of
+tasks. This module has tests for Pulp's resilience in the face of such issues.
+"""
+import unittest
+from urllib.parse import urljoin
+
+from pulp_smash import api, cli, config, selectors, utils
+from pulp_smash.constants import (
+    PULP_SERVICES,
+    REPOSITORY_PATH,
+    RPM_MIRRORLIST_LARGE,
+    RPM_UNSIGNED_FEED_URL,
+)
+from pulp_smash.tests.rpm.api_v2.utils import gen_distributor, gen_repo
+
+_PULP_WORKERS_CFG = '/etc/default/pulp_workers'
+
+
+class MissingWorkersTestCase(unittest.TestCase):
+    """Test that Pulp deals well with missing workers.
+
+    When executed, this test case will do the following:
+
+    1. Ensure there is only one Pulp worker.
+    2. Create a repository. Let its feed reference a large repository. (For
+       example, EPEL.)
+    3. Start a sync. Immediately restart the ``pulp_workers`` service. (It's
+       important that ``pulp_workers`` be restarted, not started and stopped.
+       For details, see `Pulp #2835`_.) This should cause the first sync to
+       abort.
+    4. Update the repository. Let its feed reference a small repository. (For
+       example, :data:`pulp_smash.constants.RPM_UNSIGNED_FEED_URL`.)
+    5. Start a sync. Verify that it completes. If `Pulp #2835`_ still affects
+       Pulp, then the worker will be broken, and the sync will never start.
+
+    .. _Pulp #2835: https://pulp.plan.io/issues/2835
+    """
+
+    def setUp(self):
+        """Ensure there is only one Pulp worker."""
+        self.cfg = config.get_config()
+        if selectors.bug_is_untestable(2835, self.cfg.version):
+            self.skipTest('https://pulp.plan.io/issues/2835')
+        sudo = '' if utils.is_root(self.cfg) else 'sudo'
+        cli.Client(self.cfg).machine.session().run(
+            "{} bash -c 'echo PULP_CONCURRENCY=1 >> {}'"
+            .format(sudo, _PULP_WORKERS_CFG)
+        )
+        cli.GlobalServiceManager(self.cfg).restart(PULP_SERVICES)
+
+    def test_all(self):
+        """Test that Pulp deals well with missing workers."""
+        # Create a repository. No repository addCleanup is necessary, because
+        # Pulp will be reset after this test.
+        client = api.Client(self.cfg, api.json_handler)
+        body = gen_repo()
+        body['importer_config']['feed_url'] = RPM_MIRRORLIST_LARGE
+        body['distributors'] = [gen_distributor()]
+        repo = client.post(REPOSITORY_PATH, body)
+        repo = client.get(repo['_href'], params={'details': True})
+
+        # Start syncing the repository and restart pulp_workers.
+        client.response_handler = api.code_handler
+        client.post(urljoin(repo['_href'], 'actions/sync/'))
+        cli.GlobalServiceManager(self.cfg).restart(('pulp_workers',))
+
+        # Update and sync the repository.
+        client.response_handler = api.safe_handler
+        client.put(repo['_href'], {
+            'importer_config': {'feed': RPM_UNSIGNED_FEED_URL},
+        })
+        utils.sync_repo(self.cfg, repo)
+
+    def tearDown(self):
+        """Reset the number of Pul pworkers, and reset Pulp.
+
+        Reset Pulp because :meth:`test_all` may break Pulp.
+        """
+        sudo = () if utils.is_root(self.cfg) else ('sudo',)
+        # Delete last line from file.
+        cli.Client(self.cfg).run(sudo + ('sed', '-i', '$d', _PULP_WORKERS_CFG))
+        utils.reset_pulp(self.cfg)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -28,6 +28,28 @@ class EchoHandlerTestCase(unittest.TestCase):
         self.assertEqual(handle_202.call_count, 0)
 
 
+class CodeHandlerTestCase(unittest.TestCase):
+    """Tests for :func:`pulp_smash.api.code_handler`."""
+
+    def test_return(self):
+        """Assert the passed-in ``response`` is returned."""
+        kwargs = {key: mock.Mock() for key in ('server_config', 'response')}
+        self.assertIs(kwargs['response'], api.code_handler(**kwargs))
+
+    def test_raise_for_status(self):
+        """Assert ``response.raise_for_status()`` is called."""
+        kwargs = {key: mock.Mock() for key in ('server_config', 'response')}
+        api.code_handler(**kwargs)
+        self.assertEqual(kwargs['response'].raise_for_status.call_count, 1)
+
+    def test_202_check_skipped(self):
+        """Assert HTTP 202 responses are not treated specially."""
+        kwargs = {key: mock.Mock() for key in ('server_config', 'response')}
+        with mock.patch.object(api, '_handle_202') as handle_202:
+            api.code_handler(**kwargs)
+        self.assertEqual(handle_202.call_count, 0)
+
+
 class SafeHandlerTestCase(unittest.TestCase):
     """Tests for :func:`pulp_smash.api.safe_handler`."""
 


### PR DESCRIPTION
Add a new module, `pulp_smash.tests.rpm.api_v2.test_service_resiliency`.
This module should contain tests that check Pulp's ability to continue
working in the face of service failures. Initially, it contains only
`MissingWorkersTestCase`. When executed, it will:

> 1. Ensure there is only one Pulp worker.
> 2. Create a repository. Let its feed reference a large repository.
>    (For example, EPEL.)
> 3. Start a sync. Immediately restart the ``pulp_workers`` service.
>    (It's important that ``pulp_workers`` be restarted, not started and
>    stopped.  For details, see `Pulp #2835`_.) This should cause the
>    first sync to abort.
> 4. Update the repository. Let its feed reference a small repository.
>    (For example, :data:`pulp_smash.constants.RPM_UNSIGNED_FEED_URL`.)
> 5. Start a sync. Verify that it completes. If `Pulp #2835`_ still
>    affects Pulp, then the worker will be broken, and the sync will
>    never start.

Add a new function, `pulp_smash.api.echo_handler`. Add unit tests for
it.

Fix: https://github.com/PulpQE/pulp-smash/issues/694
