### PR TITLE
Use `code_handler` throughout code base

### DIFF
--- a/pulp_smash/tests/ostree/api_v2/test_sync.py
+++ b/pulp_smash/tests/ostree/api_v2/test_sync.py
@@ -33,14 +33,14 @@ from pulp_smash.tests.ostree.utils import set_up_module as setUpModule  # noqa p
 def _sync_repo(server_config, href):
     """Sync a repository and wait for the sync to complete.
 
-    Verify only the call report's status code. Do not verify each individual
-    task, as the default response handler does. Return ``call_report, tasks``.
+    Verify only the HTTP status codes of Pulp's responses. Don't verify
+    response contents, as the default response handler does. Return ``call
+    report, tasks``.
     """
-    response = api.Client(server_config, api.echo_handler).post(
+    response = api.Client(server_config, api.code_handler).post(
         urljoin(href, 'actions/sync/'),
         {'override_config': {}},
     )
-    response.raise_for_status()
     tasks = tuple(api.poll_spawned_tasks(server_config, response.json()))
     return response, tasks
 

--- a/pulp_smash/tests/puppet/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/puppet/api_v2/test_sync_publish.py
@@ -210,9 +210,8 @@ class SyncInvalidFeedTestCase(utils.BaseAPITestCase):
         cls.resources.add(repo['_href'])
 
         # Trigger a repository sync and collect completed tasks.
-        client.response_handler = api.echo_handler
+        client.response_handler = api.code_handler
         cls.report = client.post(urljoin(repo['_href'], 'actions/sync/'))
-        cls.report.raise_for_status()
         cls.tasks = list(api.poll_spawned_tasks(cls.cfg, cls.report.json()))
 
     def test_status_code(self):

--- a/pulp_smash/tests/rpm/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/rpm/api_v2/test_sync_publish.py
@@ -169,9 +169,8 @@ class SyncInvalidFeedTestCase(utils.BaseAPITestCase):
         repo = client.post(REPOSITORY_PATH, body)
         self.addCleanup(client.delete, repo['_href'])
 
-        client.response_handler = api.echo_handler
+        client.response_handler = api.code_handler
         report = client.post(urljoin(repo['_href'], 'actions/sync/'))
-        report.raise_for_status()
         self.tasks.extend(list(
             api.poll_spawned_tasks(self.cfg, report.json())
         ))


### PR DESCRIPTION
Let the newly added function `pulp_smash.api.code_handler` can replace
several calls to `requests.response.raise_for_status` throughout the
code base.