### PR TITLE
Use RPM_DATA instead of hard coded values

### DIFF
--- a/pulp_smash/tests/rpm/api_v2/test_updateinfo.py
+++ b/pulp_smash/tests/rpm/api_v2/test_updateinfo.py
@@ -49,6 +49,7 @@ from pulp_smash.constants import (
     ORPHANS_PATH,
     REPOSITORY_PATH,
     RPM,
+    RPM_DATA,
     RPM_ERRATUM_ID,
     RPM_ERRATUM_RPM_NAME,
     RPM_NAMESPACES,
@@ -98,17 +99,17 @@ def _gen_errata():
             'name': 'pkglist-name',
             # This package is present in Pulp Fixtures.
             'packages': [{
-                'arch': 'noarch',
-                'epoch': '0',
-                'filename': 'bear-4.1-1.noarch.rpm',
-                'name': 'bear',
-                'release': '1',
+                'arch': RPM_DATA['arch'],
+                'epoch': RPM_DATA['epoch'],
+                'filename': RPM,
+                'name': RPM_DATA['name'],
+                'release': RPM_DATA['release'],
                 'sum': [
                     'sha256',
                     ('ceb0f0bb58be244393cc565e8ee5ef0ad36884d8ba8eec74542ff47'
                      'd299a34c1')
                 ],
-                'version': '4.1',
+                'version': RPM_DATA['version'],
             }],
         }],
         'references': [{


### PR DESCRIPTION
Continues to address #693 

I ran the tests in the affected file in Fedora 25 VM with pulp 2.13.2 installed. All is well.

@Ichimonji10 I was working on another issue and noticed these hard coded values. 
I could perhaps put the 'sum' in the `constants.py` RPM_DATA metadata as well, if that seems like a good idea. Let me know what you think.
