### PR TITLE
Add tests that specify checksumtype in drpm upload

### DIFF
--- a/pulp_smash/tests/rpm/cli/test_upload.py
+++ b/pulp_smash/tests/rpm/cli/test_upload.py
@@ -18,7 +18,8 @@ class UploadDrpmTestCase(unittest.TestCase):
     """Test whether one can upload a DRPM into a repository.
 
     This test case targets `Pulp Smash #336
-    <https://github.com/PulpQE/pulp-smash/issues/336>`_
+    <https://github.com/PulpQE/pulp-smash/issues/336>`_ and
+    `Pulp Smash #585 <https://github.com/PulpQE/pulp-smash/issues/585>`_
     """
 
     def test_upload(self):
@@ -72,6 +73,62 @@ class UploadDrpmTestCase(unittest.TestCase):
         proc = client.run(
             ('pulp-admin rpm repo uploads drpm --repo-id {} --file {} '
              '--skip-existing')
+            .format(repo_id, drpm_file).split()
+        )
+        self.assertIn('No files eligible for upload', proc.stdout)
+
+    def test_upload_with_checksumtype(self):
+        """Create a repository and upload DRPMs into it.
+
+        Specifically, do the following:
+
+        1. Create a yum repository.
+        2. Download a DRPM file.
+        3. Upload the DRPM into it specifying the checksumtype
+        4. Use ``pulp-admin`` to verify its presence
+           in the repository.
+        5. Upload the same DRPM into the same repository, and use the
+           ``--skip-existing`` flag during the upload. Verify that Pulp skips
+           the upload.
+        """
+        if selectors.bug_is_untestable(2627, config.get_config().version):
+            self.skipTest('https://pulp.plan.io/issues/2627')
+
+        # Create a repository
+        client = cli.Client(config.get_config())
+        repo_id = utils.uuid4()
+        client.run(
+            'pulp-admin rpm repo create --repo-id {}'.format(repo_id).split()
+        )
+        self.addCleanup(
+            client.run,
+            'pulp-admin rpm repo delete --repo-id {}'.format(repo_id).split()
+        )
+
+        # Create a temporary directory, and download a DRPM file into it
+        temp_dir = client.run('mktemp --directory'.split()).stdout.strip()
+        self.addCleanup(client.run, 'rm -rf {}'.format(temp_dir).split())
+        drpm_file = os.path.join(temp_dir, os.path.split(DRPM)[-1])
+        client.run(
+            'curl -o {} {}'.format(drpm_file, DRPM_UNSIGNED_URL).split()
+        )
+
+        # Upload the DRPM into the repository using checksum-type
+        client.run(
+            'pulp-admin rpm repo uploads drpm --repo-id {} --file {} '
+            '--checksum-type sha256'
+            .format(repo_id, drpm_file).split()
+        )
+        proc = client.run(
+            'pulp-admin rpm repo content drpm --repo-id {} --fields filename'
+            .format(repo_id).split()
+        )
+        self.assertEqual(proc.stdout.split('Filename:')[1].strip(), DRPM)
+
+        # Upload the DRPM into the repository. Pass --skip-existing.
+        proc = client.run(
+            'pulp-admin rpm repo uploads drpm --repo-id {} --file {} '
+            '--skip-existing'
             .format(repo_id, drpm_file).split()
         )
         self.assertIn('No files eligible for upload', proc.stdout)


### PR DESCRIPTION
Includes tests in both API and CLI

Closes #585 

@Ichimonji10 
Let me know what you think.

While re-creating this issue, [Pulp issue #2871](https://pulp.plan.io/issues/2871) was discovered. The consequence of 2871 is that if a checksumtype is specified that does not match a specified checksum, no error is thrown, which is a problem. 

Another consequence seems to be that, no matter what "checksumtype" is specified, "sha256" is chosen.

I have not filed a pulp-smash issue yet because it seems there is still some debate about what the problem is -- i.e. should all references be "checksumtype" or is it valid for some to be "checksum_type".