### PR TITLE
Add tests for vendor data in uploaded files.

### DIFF
--- a/pulp_smash/constants.py
+++ b/pulp_smash/constants.py
@@ -351,7 +351,6 @@ RPM_DATA = MappingProxyType({
     'version': '4.1',
     'release': '1',
     'arch': 'noarch',
-    'vendor': None,
     'metadata': {
         'release': '1',
         'license': 'GPLv2',
@@ -361,6 +360,7 @@ RPM_DATA = MappingProxyType({
         'size': '42',
         'sourcerpm': 'bear-4.1-1.src.rpm',
         'summary': 'A dummy package of bear',
+        'vendor': None,
     },
 })
 """Metadata for an RPM with an associated erratum.
@@ -395,7 +395,6 @@ RPM2_DATA = MappingProxyType({
     'version': '0.1',
     'release': '1',
     'arch': 'noarch',
-    'vendor': None,
     'metadata': {
         'release': '1',
         'license': 'GPLv2',
@@ -405,6 +404,7 @@ RPM2_DATA = MappingProxyType({
         'size': '42',
         'sourcerpm': 'camel-0.1-1.src.rpm',
         'summary': 'A dummy package of camel',
+        'vendor': None,
     },
 })
 
@@ -416,6 +416,34 @@ RPM2 = '{}-{}{}-{}.{}.rpm'.format(
     RPM2_DATA['arch'],
 )
 """The name of an RPM. See :data:`pulp_smash.constants.RPM2_UNSIGNED_URL`."""
+
+RPM_WITH_VENDOR_DATA = MappingProxyType({
+    'name': 'rpm-with-vendor',
+    'epoch': '0',
+    'version': '1',
+    'release': '1.fc25',
+    'arch': 'noarch',
+    'metadata': {
+        'release': '1',
+        'license': 'Public Domain',
+        'description': 'This RPM has a vendor',
+        'files': {'dir': [], 'file': []},
+        'group': None,
+        'size': None,
+        'sourcerpm': None,
+        'summary': None,
+        'vendor': 'Pulp Fixtures',
+    },
+})
+
+RPM_WITH_VENDOR = '{}-{}{}-{}.{}.rpm'.format(
+    RPM_WITH_VENDOR_DATA['name'],
+    RPM_WITH_VENDOR_DATA['epoch'] + '!' if RPM_DATA['epoch'] != '0' else '',
+    RPM_WITH_VENDOR_DATA['version'],
+    RPM_WITH_VENDOR_DATA['release'],
+    RPM_WITH_VENDOR_DATA['arch'],
+)
+"""The name of an RPM. See :data:`pulp_smash.constants.RPM_WITH_VENDOR_URL`."""
 
 RPM_ALT_LAYOUT_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'rpm-alt-layout/')
 """The URL to a signed RPM repository. See :data:`RPM_SIGNED_URL`."""
@@ -563,6 +591,12 @@ RPM_WITH_NON_UTF_8_URL = urljoin(
     'rpm-with-non-utf-8/rpm-with-non-utf-8-1-1.fc25.noarch.rpm'
 )
 """The URL to an RPM with non-UTF-8 metadata in its header."""
+
+RPM_WITH_VENDOR_URL = urljoin(
+    PULP_FIXTURES_BASE_URL,
+    'rpm-with-vendor/rpm-with-vendor-1-1.fc25.noarch.rpm'
+)
+"""The URL of an RPM with a specified vendor in its header."""
 
 SRPM = 'test-srpm02-1.0-1.src.rpm'
 """An SRPM file at :data:`pulp_smash.constants.SRPM_SIGNED_FEED_URL`."""

--- a/pulp_smash/tests/rpm/api_v2/test_content_applicability.py
+++ b/pulp_smash/tests/rpm/api_v2/test_content_applicability.py
@@ -30,7 +30,7 @@ RPM_WITH_ERRATUM_METADATA = MappingProxyType({
     'version': RPM_DATA['version'],
     'release': int(RPM_DATA['release']),
     'arch': RPM_DATA['arch'],
-    'vendor': RPM_DATA['vendor'],
+    'vendor': RPM_DATA['metadata']['vendor'],
 })
 """Metadata for an RPM with an associated erratum."""
 
@@ -40,7 +40,7 @@ RPM_WITHOUT_ERRATUM_METADATA = MappingProxyType({
     'version': RPM2_DATA['version'],
     'release': int(RPM2_DATA['release']),
     'arch': RPM2_DATA['arch'],
-    'vendor': RPM2_DATA['vendor'],
+    'vendor': RPM2_DATA['metadata']['vendor'],
 })
 """Metadata for an RPM without an associated erratum."""
 

--- a/pulp_smash/tests/rpm/cli/test_upload.py
+++ b/pulp_smash/tests/rpm/cli/test_upload.py
@@ -2,9 +2,16 @@
 """Tests that upload content units into repositories."""
 import os
 import unittest
+import urllib
 
 from pulp_smash import cli, config, selectors, utils
-from pulp_smash.constants import DRPM, DRPM_UNSIGNED_URL
+from pulp_smash.constants import (
+    DRPM,
+    DRPM_UNSIGNED_URL,
+    RPM_WITH_VENDOR,
+    RPM_WITH_VENDOR_URL,
+    RPM_WITH_VENDOR_DATA,
+)
 from pulp_smash.tests.rpm.utils import set_up_module
 
 
@@ -14,7 +21,115 @@ def setUpModule():  # pylint:disable=invalid-name
     utils.pulp_admin_login(config.get_config())
 
 
-class UploadDrpmTestCase(unittest.TestCase):
+class _BaseCLIDownloadTestCase(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.cfg = config.get_config()
+        cls.client = cli.Client(cls.cfg)
+
+    def temp_download(self, file_url, filename='tmp.rpm'):
+        """Download a file from the given url to a temp directory.
+
+        Args:
+            file_url: String. The URL of the file to download. Required
+            filename: String. Assigns a name to the file downloaded. Optional.
+
+        Returns:
+            String. Full path to file downloaded.
+
+        After the test case runs, the temp directory and file is destroyed.
+
+        """
+        temp_dir = self.client.run('mktemp --directory'.split()).stdout.strip()
+        self.addCleanup(self.client.run, 'rm -rf {}'.format(temp_dir).split())
+        file_path = os.path.join(temp_dir, os.path.split(filename)[-1])
+        try:
+            self.client.run(
+                'curl -o {} {}'.format(file_path, file_url).split()
+            )
+        except urllib.error.HTTPError:
+            raise self.skipTest('Skipping test, could not download resource')
+
+        return file_path
+
+    def create_repo(self, plugin, repo_id):
+        """Create a repo with given plugin.
+
+        Args:
+            plugin: String. Name of plugin. Required
+            repo_id: String. Name of repo to be created. Required
+
+        Returns:
+            Completed process
+
+        After the test case runs, the repo is destroyed.
+
+        """
+        result = self.client.run(
+            'pulp-admin {} repo create --repo-id {}'
+            .format(plugin, repo_id).split()
+        )
+        self.addCleanup(
+            self.client.run,
+            'pulp-admin {} repo delete --repo-id {}'
+            .format(plugin, repo_id).split()
+        )
+        return result
+
+    def upload_to_repo(self, **kwargs):
+        """Upload a file to a repo.
+
+        Args:
+            plugin: String. Name of plugin. Required
+            filetype: String. Name of filetype. Required
+            filename: String. Full path of file. Required
+            args: String. Additional arguments to uploads command. Optional
+
+        Returns:
+            Completed process.
+
+        """
+        if 'args' not in kwargs.keys():
+            kwargs['args'] = ''
+        return self.client.run(
+            'pulp-admin {} repo uploads {} --repo-id {} --file {} {}'
+            .format(
+                kwargs['plugin'],
+                kwargs['filetype'],
+                kwargs['repo_id'],
+                kwargs['filename'],
+                kwargs['args']
+            ).split()
+        )
+
+    def check_field(self, **kwargs):
+        """Check that the expected output is in the result of search query.
+
+        Args:
+            plugin: String. Name of plugin. Required
+            filetype: String. Name of filetype. Required
+            repo_id: String. Name of repo to be searched. Required
+            expected: String. Expected content of search querey. Required
+            search_field: String. Field to be searched for. Required
+                    Examples: filename, vendor, group, summary
+        Returns:
+            Completed process.
+        """
+        proc = self.client.run(
+            'pulp-admin {} repo content {} --repo-id {} --fields {}'
+            .format(
+                kwargs['plugin'],
+                kwargs['filetype'],
+                kwargs['repo_id'],
+                kwargs['search_field']
+            ).split()
+        )
+        self.assertIn(kwargs['expected'], proc.stdout.split())
+        return proc
+
+
+class UploadDrpmTestCase(_BaseCLIDownloadTestCase):
     """Test whether one can upload a DRPM into a repository.
 
     This test case targets `Pulp Smash #336
@@ -35,45 +150,37 @@ class UploadDrpmTestCase(unittest.TestCase):
            ``--skip-existing`` flag during the upload. Verify that Pulp skips
            the upload.
         """
-        if selectors.bug_is_untestable(1806, config.get_config().version):
+        if selectors.bug_is_untestable(1806, self.cfg.version):
             self.skipTest('https://pulp.plan.io/issues/1806')
 
         # Create a repository
-        client = cli.Client(config.get_config())
         repo_id = utils.uuid4()
-        client.run(
-            'pulp-admin rpm repo create --repo-id {}'.format(repo_id).split()
-        )
-        self.addCleanup(
-            client.run,
-            'pulp-admin rpm repo delete --repo-id {}'.format(repo_id).split()
-        )
-
-        # Create a temporary directory, and download a DRPM file into it
-        temp_dir = client.run('mktemp --directory'.split()).stdout.strip()
-        self.addCleanup(client.run, 'rm -rf {}'.format(temp_dir).split())
-        drpm_file = os.path.join(temp_dir, os.path.split(DRPM)[-1])
-        client.run(
-            'curl -o {} {}'.format(drpm_file, DRPM_UNSIGNED_URL).split()
-        )
+        self.create_repo('rpm', repo_id)
+        drpm_file_path = self.temp_download(DRPM_UNSIGNED_URL, DRPM)
 
         # Upload the DRPM into the repository. Don't use subTest, as if this
         # test fails, the following one is invalid anyway.
-        client.run(
-            'pulp-admin rpm repo uploads drpm --repo-id {} --file {}'
-            .format(repo_id, drpm_file).split()
+        self.upload_to_repo(
+            plugin='rpm',
+            filetype='drpm',
+            repo_id=repo_id,
+            filename=drpm_file_path,
         )
-        proc = client.run(
-            'pulp-admin rpm repo content drpm --repo-id {} --fields filename'
-            .format(repo_id).split()
+        self.check_field(
+            plugin='rpm',
+            filetype='drpm',
+            repo_id=repo_id,
+            expected=DRPM,
+            search_field='filename'
         )
-        self.assertEqual(proc.stdout.split('Filename:')[1].strip(), DRPM)
 
         # Upload the DRPM into the repository. Pass --skip-existing.
-        proc = client.run(
-            ('pulp-admin rpm repo uploads drpm --repo-id {} --file {} '
-             '--skip-existing')
-            .format(repo_id, drpm_file).split()
+        proc = self.upload_to_repo(
+            plugin='rpm',
+            filetype='drpm',
+            repo_id=repo_id,
+            filename=drpm_file_path,
+            args='--skip-existing',
         )
         self.assertIn('No files eligible for upload', proc.stdout)
 
@@ -87,48 +194,83 @@ class UploadDrpmTestCase(unittest.TestCase):
         3. Upload the DRPM into it specifying the checksumtype
         4. Use ``pulp-admin`` to verify its presence
            in the repository.
-        5. Upload the same DRPM into the same repository, and use the
-           ``--skip-existing`` flag during the upload. Verify that Pulp skips
-           the upload.
         """
         if selectors.bug_is_untestable(2627, config.get_config().version):
             self.skipTest('https://pulp.plan.io/issues/2627')
 
         # Create a repository
-        client = cli.Client(config.get_config())
         repo_id = utils.uuid4()
-        client.run(
-            'pulp-admin rpm repo create --repo-id {}'.format(repo_id).split()
+        self.create_repo('rpm', repo_id)
+        drpm_file_path = self.temp_download(DRPM_UNSIGNED_URL, DRPM)
+
+        # Upload the DRPM into the repository. Don't use subTest, as if this
+        # test fails, the following one is invalid anyway.
+        self.upload_to_repo(
+            plugin='rpm',
+            filetype='drpm',
+            repo_id=repo_id,
+            filename=drpm_file_path,
+            args='--checksum-type sha256',
         )
-        self.addCleanup(
-            client.run,
-            'pulp-admin rpm repo delete --repo-id {}'.format(repo_id).split()
+        self.check_field(
+            plugin='rpm',
+            filetype='drpm',
+            repo_id=repo_id,
+            expected=DRPM,
+            search_field='filename'
         )
 
-        # Create a temporary directory, and download a DRPM file into it
-        temp_dir = client.run('mktemp --directory'.split()).stdout.strip()
-        self.addCleanup(client.run, 'rm -rf {}'.format(temp_dir).split())
-        drpm_file = os.path.join(temp_dir, os.path.split(DRPM)[-1])
-        client.run(
-            'curl -o {} {}'.format(drpm_file, DRPM_UNSIGNED_URL).split()
+
+class UploadRPMTestCase(_BaseCLIDownloadTestCase):
+    """Test whether one can upload a RPM into a repository."""
+
+    def test_with_vendor(self):
+        """Create a repository and upload an RPM with a vendor into it.
+
+        Specifically, do the following:
+
+        1. Create a yum repository.
+        2. Download a RPM file.
+        3. Upload the RPM into it.
+        4. Verify its presence in the repository
+        5. Verify the vendor information is intact
+
+
+        Targets `Pulp Smash #680
+        <https://github.com/PulpQE/pulp-smash/issues/680>`_
+        """
+        if selectors.bug_is_untestable(2781, self.cfg.version):
+            self.skipTest('https://pulp.plan.io/issues/2781')
+
+        # Create a repository
+        repo_id = utils.uuid4()
+        self.create_repo('rpm', repo_id)
+        rpm_file_path = self.temp_download(
+            RPM_WITH_VENDOR_URL,
+            RPM_WITH_VENDOR
         )
 
-        # Upload the DRPM into the repository using checksum-type
-        client.run(
-            'pulp-admin rpm repo uploads drpm --repo-id {} --file {} '
-            '--checksum-type sha256'
-            .format(repo_id, drpm_file).split()
+        # Upload the RPM into the repository.
+        self.upload_to_repo(
+            plugin='rpm',
+            filetype='rpm',
+            repo_id=repo_id,
+            filename=rpm_file_path
         )
-        proc = client.run(
-            'pulp-admin rpm repo content drpm --repo-id {} --fields filename'
-            .format(repo_id).split()
+        # Search for filename in repo to confirm upload
+        self.check_field(
+            plugin='rpm',
+            filetype='rpm',
+            repo_id=repo_id,
+            expected=RPM_WITH_VENDOR,
+            search_field='filename'
         )
-        self.assertEqual(proc.stdout.split('Filename:')[1].strip(), DRPM)
 
-        # Upload the DRPM into the repository. Pass --skip-existing.
-        proc = client.run(
-            'pulp-admin rpm repo uploads drpm --repo-id {} --file {} '
-            '--skip-existing'
-            .format(repo_id, drpm_file).split()
-        )
-        self.assertIn('No files eligible for upload', proc.stdout)
+        # Check for vendor data
+        for word in RPM_WITH_VENDOR_DATA['metadata']['vendor'].split():
+            self.check_field(
+                plugin='rpm',
+                filetype='rpm',
+                repo_id=repo_id,
+                expected=word,
+                search_field='vendor')


### PR DESCRIPTION
Closes #680

Includes a refactor of existing test in pulp_smash.tests.rpm.cli.test_upload

@Ichimonji10 I maybe got a little crazy on the refactor. I just felt silly literally copying and pasting the code to make a repo, upload, and check for results of a search query. 

I believe that because the individual tests each call these "helper functions" that if an exception is thrown within them, only that test will fail and addCleanup will still run if resources like the repo were successfully created and need to be deleted.