### PR TITLE
Update OSTree constants and tests that use them.

### DIFF
--- a/pulp_smash/constants.py
+++ b/pulp_smash/constants.py
@@ -186,16 +186,14 @@ ORPHANS_PATH = 'pulp/api/v2/content/orphans/'
     http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/content/orphan.html
 """
 
-OSTREE_BRANCH = 'fedora-atomic/f21/x86_64/updates/docker-host'
+OSTREE_BRANCHES = ['rawhide', 'stable']
 """A branch in :data:`OSTREE_FEED`. See OSTree `Importer Configuration`_.
 
 .. _Importer Configuration:
     http://docs.pulpproject.org/plugins/pulp_ostree/tech-reference/importer.html
 """
 
-OSTREE_FEED = (
-    'https://repos.fedorapeople.org/pulp/pulp/demo_repos/test-ostree-small'
-)
+OSTREE_FEED = urljoin(PULP_FIXTURES_BASE_URL, 'ostree/small/')
 """The URL to a URL of OSTree branches. See OSTree `Importer Configuration`_.
 
 .. _Importer Configuration:

--- a/pulp_smash/tests/ostree/api_v2/test_publish.py
+++ b/pulp_smash/tests/ostree/api_v2/test_publish.py
@@ -3,7 +3,7 @@
 import unittest
 
 from pulp_smash import api, config, utils
-from pulp_smash.constants import OSTREE_BRANCH, OSTREE_FEED, REPOSITORY_PATH
+from pulp_smash.constants import OSTREE_BRANCHES, OSTREE_FEED, REPOSITORY_PATH
 from pulp_smash.tests.ostree.utils import gen_distributor, gen_repo
 from pulp_smash.tests.ostree.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
@@ -28,7 +28,7 @@ class PublishTestCase(unittest.TestCase):
         # Create a repository.
         body = gen_repo()
         body['importer_config']['feed'] = OSTREE_FEED
-        body['importer_config']['branches'] = [OSTREE_BRANCH]
+        body['importer_config']['branches'] = OSTREE_BRANCHES
         body['distributors'].append(gen_distributor())
         repo = client.post(REPOSITORY_PATH, body)
         self.addCleanup(client.delete, repo['_href'])

--- a/pulp_smash/tests/ostree/api_v2/test_sync.py
+++ b/pulp_smash/tests/ostree/api_v2/test_sync.py
@@ -25,7 +25,7 @@ import unittest
 from urllib.parse import urljoin
 
 from pulp_smash import api, selectors, utils
-from pulp_smash.constants import OSTREE_FEED, OSTREE_BRANCH, REPOSITORY_PATH
+from pulp_smash.constants import OSTREE_FEED, OSTREE_BRANCHES, REPOSITORY_PATH
 from pulp_smash.tests.ostree.utils import gen_repo
 from pulp_smash.tests.ostree.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
@@ -114,7 +114,7 @@ class SyncTestCase(_SyncMixin, utils.BaseAPITestCase):
             raise unittest.SkipTest('https://pulp.plan.io/issues/1934')
         body = gen_repo()
         body['importer_config']['feed'] = OSTREE_FEED
-        body['importer_config']['branches'] = [OSTREE_BRANCH]
+        body['importer_config']['branches'] = OSTREE_BRANCHES
         repo = api.Client(cls.cfg).post(REPOSITORY_PATH, body).json()
         cls.resources.add(repo['_href'])
         cls.report = utils.sync_repo(cls.cfg, repo)
@@ -142,7 +142,7 @@ class SyncInvalidFeedTestCase(
         client = api.Client(cls.cfg)
         body = gen_repo()
         body['importer_config']['feed'] = utils.uuid4()
-        body['importer_config']['branches'] = [OSTREE_BRANCH]
+        body['importer_config']['branches'] = OSTREE_BRANCHES
         repo_href = client.post(REPOSITORY_PATH, body).json()['_href']
         cls.resources.add(repo_href)
         cls.report, cls.tasks = _sync_repo(cls.cfg, repo_href)


### PR DESCRIPTION
From now on OSTree files will be generated using pulp_fixtures scripts.
OSTree fixtures are now available. See: https://github.com/PulpQE/pulp-fixtures/pull/56