### PR TITLE
Test docker manifests

### DIFF
--- a/pulp_smash/constants.py
+++ b/pulp_smash/constants.py
@@ -86,6 +86,17 @@ DOCKER_IMAGE_URL = urljoin(PULP_FIXTURES_BASE_URL, 'docker/busybox:latest.tar')
 DOCKER_UPSTREAM_NAME = 'library/busybox'
 """The name of a repository present in each of the two docker feeds."""
 
+DOCKER_UPSTREAM_NAME_MANIFEST_LIST = 'dmage/manifest-list-test'
+"""The name of a docker v2 repository with a manifest list.
+
+One can verify that this repository has a manifest list by executing:
+
+.. code-block:: sh
+
+    curl -s https://registry.hub.docker.com/v2/repositories/$this_constant \
+    | python -m json.tool
+"""
+
 DOCKER_V1_FEED_URL = 'https://index.docker.io'
 """The URL to a V1 Docker registry.
 

--- a/pulp_smash/tests/docker/cli/test_sync_publish.py
+++ b/pulp_smash/tests/docker/cli/test_sync_publish.py
@@ -16,11 +16,13 @@ from pulp_smash.tests.docker.utils import set_up_module
 
 from jsonschema import validate
 
-IMAGE_MANIFEST_V2_SCHEMA_1 = {
+# Variable name derived from HTTP content-type.
+MANIFEST_V1 = {
     '$schema': 'http://json-schema.org/schema#',
     'title': 'Image Manifest Version 2, Schema 1',
     'description': (
-        'Derived from: https://docs.docker.com/registry/spec/manifest-v2-1/'
+        'Derived from: '
+        'https://docs.docker.com/registry/spec/manifest-v2-1/'
     ),
     'type': 'object',
     'properties': {
@@ -72,11 +74,13 @@ IMAGE_MANIFEST_V2_SCHEMA_1 = {
 }
 """A schema for docker v2 image manifests, schema 1."""
 
-IMAGE_MANIFEST_V2_SCHEMA_2 = {
+# Variable name derived from HTTP content-type.
+MANIFEST_V2 = {
     '$schema': 'http://json-schema.org/schema#',
     'title': 'Image Manifest Version 2, Schema 2',
     'description': (
-        'Derived from: https://docs.docker.com/registry/spec/manifest-v2-2/'
+        'Derived from: '
+        'https://docs.docker.com/registry/spec/manifest-v2-2/#image-manifest'
     ),
     'type': 'object',
     'properties': {
@@ -341,7 +345,7 @@ class SyncPublishV2TestCase(SyncPublishMixin, utils.BaseAPITestCase):
                     '/v2/{}/manifests/latest'.format(self.repo_id),
                     headers=headers,
                 )
-                validate(manifest, IMAGE_MANIFEST_V2_SCHEMA_1)
+                validate(manifest, MANIFEST_V1)
 
     @selectors.skip_if(bool, 'repo_id', False)
     def test_02_get_manifest_v2(self):
@@ -363,7 +367,7 @@ class SyncPublishV2TestCase(SyncPublishMixin, utils.BaseAPITestCase):
             client.request_kwargs['url']
         )
         manifest = client.get('/v2/{}/manifests/latest'.format(self.repo_id))
-        validate(manifest, IMAGE_MANIFEST_V2_SCHEMA_2)
+        validate(manifest, MANIFEST_V1)
 
 
 class SyncNonNamespacedV2TestCase(SyncPublishMixin, utils.BaseAPITestCase):


### PR DESCRIPTION
The first commit renames several constants. The second commit adds a test to verify that Pulp can sync and publish a Docker repository with a manifest list.

These tests rightfully belong in `pulp_smash.tests.docker.api_v2.???`. However, this new test case inherits from `SyncPublishMixin`, and it will be easiest to move this test case and all of the other ones that also inherit from `SyncPublishMixin` at the same time. Tested against Pulp 2.14 beta 3 on F24, F25 and RHEL 7.