### PR TITLE
Consolidate two Docker-related constants into one

### DIFF
--- a/pulp_smash/constants.py
+++ b/pulp_smash/constants.py
@@ -83,17 +83,30 @@ CONTENT_UPLOAD_PATH = '/pulp/api/v2/content/uploads/'
 DOCKER_IMAGE_URL = urljoin(PULP_FIXTURES_BASE_URL, 'docker/busybox:latest.tar')
 """The URL to a Docker image as created by ``docker save``."""
 
-DOCKER_UPSTREAM_NAME = 'library/busybox'
-"""The name of a repository present in each of the two docker feeds."""
+DOCKER_UPSTREAM_NAME = 'dmage/manifest-list-test'
+"""The name of a Docker repository.
 
-DOCKER_UPSTREAM_NAME_MANIFEST_LIST = 'dmage/manifest-list-test'
-"""The name of a docker v2 repository with a manifest list.
+This repository has several desireable properties:
 
-One can verify that this repository has a manifest list by executing:
+* It is available via both :data:`DOCKER_V1_FEED_URL` and
+  :data:`DOCKER_V2_FEED_URL`.
+* It has a manifest list, where one entry has an architecture of amd64 and an
+  os of linux. (The "latest" tag offers this.)
+* It is relatively small.
+
+There are also several ways in which this repository is lacking:
+
+* This repository isn't an official repository. It's less trustworthy, and may
+  be more likely to change with little or no notice.
+* It doesn't have a manifest list, where no entries have an architecture of
+  amd64 and an os of linux. (The "arm32v7" tag provides schema v1 content.)
+
+One can get a high-level view of the content in this repository by executing:
 
 .. code-block:: sh
 
-    curl -s https://registry.hub.docker.com/v2/repositories/$this_constant \
+    curl --location --silent \
+    https://registry.hub.docker.com/v2/repositories/$this_constant/tags \
     | python -m json.tool
 """
 

--- a/pulp_smash/tests/docker/api_v2/test_copy.py
+++ b/pulp_smash/tests/docker/api_v2/test_copy.py
@@ -6,7 +6,6 @@ from urllib.parse import urljoin
 from pulp_smash import api, config, selectors, utils
 from pulp_smash.constants import (
     DOCKER_UPSTREAM_NAME,
-    DOCKER_UPSTREAM_NAME_MANIFEST_LIST,
     DOCKER_V1_FEED_URL,
     DOCKER_V2_FEED_URL,
     REPOSITORY_PATH,
@@ -94,7 +93,7 @@ class CopyV2ContentTestCase(unittest.TestCase):
             'enable_v1': False,
             'enable_v2': True,
             'feed': DOCKER_V2_FEED_URL,
-            'upstream_name': DOCKER_UPSTREAM_NAME_MANIFEST_LIST,
+            'upstream_name': DOCKER_UPSTREAM_NAME,
         })
         type(self).repo = client.post(REPOSITORY_PATH, body)
         utils.sync_repo(self.cfg, self.repo)

--- a/pulp_smash/tests/docker/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/docker/api_v2/test_sync_publish.py
@@ -9,7 +9,6 @@ from packaging.version import Version
 from pulp_smash import api, cli, config, selectors, utils
 from pulp_smash.constants import (
     DOCKER_UPSTREAM_NAME,
-    DOCKER_UPSTREAM_NAME_MANIFEST_LIST,
     DOCKER_V1_FEED_URL,
     DOCKER_V2_FEED_URL,
     REPOSITORY_PATH,
@@ -334,7 +333,7 @@ class V2RegistryTestCase(SyncPublishMixin, unittest.TestCase):
             'enable_v1': False,
             'enable_v2': True,
             'feed': DOCKER_V2_FEED_URL,
-            'upstream_name': DOCKER_UPSTREAM_NAME_MANIFEST_LIST,
+            'upstream_name': DOCKER_UPSTREAM_NAME,
         })
         body['distributors'] = [gen_distributor()]
         type(self).repo = client.post(REPOSITORY_PATH, body)
@@ -473,7 +472,7 @@ class NonNamespacedImageTestCase(SyncPublishMixin, unittest.TestCase):
             'enable_v1': False,
             'enable_v2': True,
             'feed': DOCKER_V2_FEED_URL,
-            'upstream_name': DOCKER_UPSTREAM_NAME.split('/')[-1],
+            'upstream_name': 'busybox',
         })
         body['distributors'] = [gen_distributor()]
         repo = client.post(REPOSITORY_PATH, body)


### PR DESCRIPTION
There are two extremely similar Docker constants:

* `DOCKER_UPSTREAM_NAME`
* `DOCKER_UPSTREAM_NAME_MANIFEST_LIST`

Consolidate these two constants into just one: `DOCKER_UPSTREAM_NAME`.
Update the tests that depend on these constants as appropriate.