### PR TITLE
Re-sync a child repository with the remove_missing enabled.

### DIFF
--- a/pulp_smash/tests/rpm/api_v2/test_remove_unit.py
+++ b/pulp_smash/tests/rpm/api_v2/test_remove_unit.py
@@ -8,7 +8,7 @@ import random
 import unittest
 from urllib.parse import urljoin
 
-from pulp_smash import api, config, utils
+from pulp_smash import api, config, selectors, utils
 from pulp_smash.constants import (
     ORPHANS_PATH,
     REPOSITORY_PATH,
@@ -174,6 +174,75 @@ class RemoveMissingTestCase(unittest.TestCase):
             _get_rpms(self.cfg, self.repos['on demand'])
         )
         self.assertEqual(root_ids, on_demand_ids)
+
+
+class RemoveCountTestCase(unittest.TestCase):
+    """Re-sync a child repository with the `remove_missing` enabled.
+
+    After removing an arbitrary number of units from the parent repository.
+
+    Do the following:
+
+    1. Create 1st repository with, feed, sync and publish it.
+    2. Create 2nd repository with feed pointed to 1st repository, and
+       `remove_missing` enabled, sync.
+    3. Remove an arbitrary number of units from 1st repository, re-publish it.
+    4. Re-sync the 2nd repository. Assert that `removed_count` is equal to
+       number of removed units.
+
+    `Pulp issue #2616 <https://pulp.plan.io/issues/2616>`_ caused
+    after sync with remove_missing option the next publish is no-op.
+    """
+
+    def test_all(self):
+        """Re-sync a child repository with the `remove_missing` enabled."""
+        repos = []
+        cfg = config.get_config()
+        if selectors.bug_is_untestable(2616, cfg.version):
+            self.skipTest('https://pulp.plan.io/issues/2616')
+        # Create 1st repo, sync and publish it.
+        client = api.Client(cfg, api.json_handler)
+        body = gen_repo()
+        body['importer_config']['feed'] = RPM_SIGNED_FEED_URL
+        body['distributors'] = [gen_distributor()]
+        repos.append(client.post(REPOSITORY_PATH, body))
+        self.addCleanup(client.delete, repos[0]['_href'])
+        repos[0] = (_get_details(cfg, repos[0]))
+        utils.sync_repo(cfg, repos[0])
+        utils.publish_repo(cfg, repos[0])
+
+        # Create 2nd repo, sync.
+        body = gen_repo()
+        body['importer_config']['feed'] = urljoin(
+            cfg.base_url,
+            _PUBLISH_DIR +
+            repos[0]['distributors'][0]['config']['relative_url'],
+        )
+        body['importer_config']['remove_missing'] = True
+        repos.append(client.post(REPOSITORY_PATH, body))
+        self.addCleanup(client.delete, repos[1]['_href'])
+        repos[1] = (_get_details(cfg, repos[1]))
+        utils.sync_repo(cfg, repos[1])
+
+        # Arbitrary number of units to be removed.
+        units_removed = random.randint(1, len(_get_rpms(cfg, repos[0])))
+        # Remove an arbitrary number of units from 1 st repo , re-publish it.
+        units = random.sample(_get_rpms(cfg, repos[0]), units_removed)
+        for unit in units:
+            criteria = {
+                'filters': {'unit': {'name': unit['metadata']['name']}},
+                'type_ids': [unit['unit_type_id']],
+            }
+            client.post(
+                urljoin(repos[0]['_href'], 'actions/unassociate/'),
+                {'criteria': criteria}
+            )
+        utils.publish_repo(cfg, repos[0])
+
+        # Re-sync 2nd repo.
+        report = utils.sync_repo(cfg, repos[1])
+        tasks = tuple(api.poll_spawned_tasks(cfg, report.json()))
+        self.assertEqual(tasks[0]['result']['removed_count'], units_removed)
 
 
 def _get_rpms(cfg, repo):


### PR DESCRIPTION
* Problem: After sync with remove_missing option the next publish is no-op sometimes.

* Test:
    1 - Create 1st repo with, feed, sync and publish.
    2 - Create 2nd repo with feed pointed to 1st repo, and
        `remove_missing` enabled, sync.
    3 - Remove an arbitrary number of units from 1st repo, re-publish it.
    4 - Re-sync the 2nd repo. Assert that `removed_count` is equal to
    number of removed units.

Closes: #572