### PR TITLE
Add more tests to inspect XML files.

### DIFF
--- a/pulp_smash/constants.py
+++ b/pulp_smash/constants.py
@@ -571,6 +571,8 @@ RPM_MISSING_PRIMARY_FEED_URL = urljoin(
 
 RPM_NAMESPACES = {
     'metadata/common': 'http://linux.duke.edu/metadata/common',
+    'metadata/filelists': 'http://linux.duke.edu/metadata/filelists',
+    'metadata/other': 'http://linux.duke.edu/metadata/other',
     'metadata/repo': 'http://linux.duke.edu/metadata/repo',
     'metadata/rpm': 'http://linux.duke.edu/metadata/rpm',
 }
@@ -581,6 +583,12 @@ namespaces. Some of the files that use these namespaces are listed below:
 
 metadata/common
     Used by ``repodata/primary.xml``.
+
+metadata/filelists
+    Used by ``repodata/filelists.xml``.
+
+metadata/other
+    Used by ``repodata/other.xml``.
 
 metadata/repo
     Used by ``repodata/repomd.xml``.


### PR DESCRIPTION
Inspected XML files:

1. `filelists.xml` and `other.xml` - Assert that length of `pkgid`
    is according to the given checksum type.
2.  `prestodelta.xml` - Assert that given checksum type is the only
     one present.

Add more XML namespaces to constants file, RPM_NAMESPACES.

See also: 897ac1c

Closes: #286