### PR TITLE
Don't lint generated files with flake8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ docs-clean:
 	@cd docs; $(MAKE) clean
 
 lint-flake8:
-	flake8 . --ignore D203
+	flake8 . --ignore D203 --exclude docs/_build
 
 lint-pylint:
 	pylint -j $(CPU_COUNT) --reports=n --disable=I \


### PR DESCRIPTION
Sphinx creates `docs/_build` when generating documentation. The files in
this directory can make flake8 unhappy. Make flake8 ignore this
directory.