### PR TITLE
Remove format string and split in the pulp_admin_login function.

### DIFF
--- a/pulp_smash/utils.py
+++ b/pulp_smash/utils.py
@@ -85,8 +85,10 @@ def pulp_admin_login(server_config):
     :return: The completed process.
     :rtype: pulp_smash.cli.CompletedProcess
     """
-    cmd = 'pulp-admin login -u {} -p {}'.format(*server_config.pulp_auth)
-    return cli.Client(server_config).run(cmd.split())
+    return cli.Client(server_config).run((
+        'pulp-admin', 'login', '-u', server_config.pulp_auth[0],
+        '-p', server_config.pulp_auth[1]
+    ))
 
 
 def reset_pulp(server_config):


### PR DESCRIPTION
* In the utils module, `pulp_admin_login` function, it was using `'...'.format().split()`
what can produce unexpected results in case of whitespace sneaks in.
To avoid this situation the function was refactored, and the use of `.format` followed by `.split` was removed.