### PR TITLE
Add a new section related to Pulp3.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -18,6 +18,12 @@ developers, not a gospel.
     api/pulp_smash.exceptions
     api/pulp_smash.pulp_smash_cli
     api/pulp_smash.selectors
+    api/pulp_smash.pulp3
+    api/pulp_smash.pulp3.constants
+    api/pulp_smash.pulp3.tests
+    api/pulp_smash.pulp3.utils
+    api/pulp_smash.pulp3.tests.platform
+    api/pulp_smash.pulp3.tests.platform.test_auth
     api/pulp_smash.tests
     api/pulp_smash.tests.docker
     api/pulp_smash.tests.docker.api_v2

--- a/docs/api/pulp_smash.pulp3.constants.rst
+++ b/docs/api/pulp_smash.pulp3.constants.rst
@@ -1,0 +1,6 @@
+`pulp_smash.pulp3.constants`
+============================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.pulp3.constants`
+
+.. automodule:: pulp_smash.pulp3.constants

--- a/docs/api/pulp_smash.pulp3.rst
+++ b/docs/api/pulp_smash.pulp3.rst
@@ -1,0 +1,6 @@
+`pulp_smash.pulp3`
+==================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.pulp3`
+
+.. automodule:: pulp_smash.pulp3

--- a/docs/api/pulp_smash.pulp3.tests.platform.rst
+++ b/docs/api/pulp_smash.pulp3.tests.platform.rst
@@ -1,0 +1,6 @@
+`pulp_smash.pulp3.tests.platform`
+=================================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.pulp3.tests.platform`
+
+.. automodule:: pulp_smash.pulp3.tests.platform

--- a/docs/api/pulp_smash.pulp3.tests.platform.test_auth.rst
+++ b/docs/api/pulp_smash.pulp3.tests.platform.test_auth.rst
@@ -1,0 +1,6 @@
+`pulp_smash.pulp3.tests.platform.test_auth`
+===========================================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.pulp3.tests.platform.test_auth`
+
+.. automodule:: pulp_smash.pulp3.tests.platform.test_auth

--- a/docs/api/pulp_smash.pulp3.tests.rst
+++ b/docs/api/pulp_smash.pulp3.tests.rst
@@ -1,0 +1,6 @@
+`pulp_smash.pulp3.tests`
+========================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.pulp3.tests`
+
+.. automodule:: pulp_smash.pulp3.tests

--- a/docs/api/pulp_smash.pulp3.utils.rst
+++ b/docs/api/pulp_smash.pulp3.utils.rst
@@ -1,0 +1,6 @@
+`pulp_smash.pulp3.utils`
+========================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.pulp3.utils`
+
+.. automodule:: pulp_smash.pulp3.utils

--- a/pulp_smash/pulp3/__init__.py
+++ b/pulp_smash/pulp3/__init__.py
@@ -1,0 +1,2 @@
+# coding=utf-8
+"""The root of Pulp3 namespace."""

--- a/pulp_smash/pulp3/constants.py
+++ b/pulp_smash/pulp3/constants.py
@@ -1,0 +1,7 @@
+# coding=utf-8
+"""Values usable by Pulp3 multiple test modules."""
+
+
+USER_PATH = '/api/v3/users/'
+
+JWT_PATH = '/api/v3/jwt/'

--- a/pulp_smash/pulp3/tests/__init__.py
+++ b/pulp_smash/pulp3/tests/__init__.py
@@ -1,0 +1,2 @@
+# coding=utf-8
+"""The root of Pulp3 tests namespace."""

--- a/pulp_smash/pulp3/tests/platform/__init__.py
+++ b/pulp_smash/pulp3/tests/platform/__init__.py
@@ -1,0 +1,2 @@
+# coding=utf-8
+"""The root of Pulp3 tests platform namespace."""

--- a/pulp_smash/pulp3/tests/platform/test_auth.py
+++ b/pulp_smash/pulp3/tests/platform/test_auth.py
@@ -1,0 +1,39 @@
+# coding=utf-8
+"""Tests for Pulp3 authentication API."""
+import unittest
+
+from packaging.version import Version
+from requests.auth import HTTPBasicAuth
+
+from pulp_smash import api, config
+from pulp_smash.pulp3.constants import USER_PATH, JWT_PATH
+from pulp_smash.pulp3.utils import adjust_url, get_base_url, get_url, JWTAuth
+
+
+class AuthTestCase(unittest.TestCase):
+    """Test Pulp3 Authentication."""
+
+    def setUp(self):
+        """Create config variable."""
+        self.cfg = config.get_config()
+        if self.cfg.version < Version('3.0'):
+            self.skipTest('Requires Pulp 3.0 or higher')
+        self.url = adjust_url(get_url(get_base_url(), USER_PATH))
+
+    def test_auth(self):
+        """Test Pulp3 Basic Authentication."""
+        client = api.Client(self.cfg, api.json_handler)
+        client.request_kwargs['url'] = self.url
+        client.get(USER_PATH, auth=HTTPBasicAuth(
+            self.cfg.pulp_auth[0], self.cfg.pulp_auth[1]
+        ))
+
+    def test_jwt(self):
+        """Test Pulp3 JWT Authentication."""
+        client = api.Client(self.cfg, api.json_handler)
+        client.request_kwargs['url'] = self.url
+        token = client.post(JWT_PATH, {
+            'username': self.cfg.pulp_auth[0],
+            'password': self.cfg.pulp_auth[1],
+        })
+        client.get(USER_PATH, auth=JWTAuth(token['token'], 'JWT'))

--- a/pulp_smash/pulp3/utils.py
+++ b/pulp_smash/pulp3/utils.py
@@ -1,0 +1,60 @@
+# coding=utf-8
+"""Utility functions for Pulp3 tests."""
+from urllib.parse import urljoin, urlsplit, urlunsplit
+
+from requests.auth import AuthBase
+
+from pulp_smash import config
+
+
+class JWTAuth(AuthBase):
+    """An extender of requests ``AuthBase`` class.
+
+    See:
+
+    ``Custom Authentication`` Requests library. See `example
+    <http://docs.python-requests.org/en/latest/user/advanced/#custom-authentication>`_.
+    """
+
+    def __init__(self, token, header_format='Bearer'):
+        """Require token variable."""
+        self.token = token
+        self.header_format = header_format
+
+    def __call__(self, request):
+        """Modify header and return request."""
+        request.headers['Authorization'] = (
+            self.header_format + ' ' + self.token
+        )
+        return request
+
+
+def get_base_url():
+    """Return the base url from settings."""
+    cfg = config.get_config()
+    pulp_system = cfg.get_systems('api')[0]
+    return '{}://{}/'.format(
+        pulp_system.roles['api'].get('scheme', 'https'),
+        pulp_system.hostname
+    )
+
+
+def get_url(base_url, path):
+    """Return joined base_url and path."""
+    return urljoin(base_url, path)
+
+
+def adjust_url(url):
+    """Return a URL that can be used for talking in a certain port.
+
+    The URL returned is the same as ``url``, except that the scheme is set
+    to HTTP, and the port is set to 8000.
+
+    :param url: A string, such as ``https://pulp.example.com/foo``.
+    :returns: A string, such as ``http://pulp.example.com:8000/foo``.
+    """
+    parse_result = urlsplit(url)
+    netloc = parse_result[1].partition(':')[0] + ':8000'
+    return urlunsplit(('http', netloc) + parse_result[2:])
+
+# TODO create function to verify Pulp Version


### PR DESCRIPTION
Why?

* Pulp-Smash will be used to test different versions major releases of Pulp.
  Right now, there are 2 main Pulp X releases: Pulp2 and Pulp3.

* Since both releases will be tested using Pulp-Smas, it is convenient to separate tests, and files
  related to a specific release. This will help address different needs, and run different test in a relative
  easy manner.

* Add tests related to authentication, using `BasicAuth` and `JWT`.

* These tests will part of smoke test of Pulp3 , however there are still a lot of changes to adjust Pulp-Smash to fit all the needs of Pulp3.