### PR TITLE
Let tests skip based on Pulp's version

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -51,6 +51,7 @@ developers, not a gospel.
     api/pulp_smash.tests.platform.cli
     api/pulp_smash.tests.platform.cli.test_pulp_manage_db
     api/pulp_smash.tests.platform.cli.test_selinux
+    api/pulp_smash.tests.platform.utils
     api/pulp_smash.tests.pulp3
     api/pulp_smash.tests.pulp3
     api/pulp_smash.tests.pulp3.constants

--- a/docs/api/pulp_smash.tests.platform.utils.rst
+++ b/docs/api/pulp_smash.tests.platform.utils.rst
@@ -1,0 +1,6 @@
+`pulp_smash.tests.platform.utils`
+=================================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.platform.utils`
+
+.. automodule:: pulp_smash.tests.platform.utils

--- a/pulp_smash/tests/docker/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/docker/api_v2/test_sync_publish.py
@@ -14,7 +14,7 @@ from pulp_smash.constants import (
 )
 from pulp_smash.tests.docker.api_v2.utils import gen_distributor, gen_repo
 from pulp_smash.tests.docker.utils import get_upstream_name
-from pulp_smash.tests.docker.utils import set_up_module  # noqa pylint:disable=unused-import
+from pulp_smash.tests.docker.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 # Variable name derived from HTTP content-type.
 MANIFEST_V1 = {

--- a/pulp_smash/tests/docker/utils.py
+++ b/pulp_smash/tests/docker/utils.py
@@ -14,6 +14,7 @@ def set_up_module():
 
     See :mod:`pulp_smash.tests` for more information.
     """
+    utils.set_up_module()
     utils.skip_if_type_is_unsupported('docker_image')
 
 

--- a/pulp_smash/tests/ostree/utils.py
+++ b/pulp_smash/tests/ostree/utils.py
@@ -8,6 +8,7 @@ def set_up_module():
 
     See :mod:`pulp_smash.tests` for more information.
     """
+    utils.set_up_module()
     utils.skip_if_type_is_unsupported('ostree')
 
 

--- a/pulp_smash/tests/platform/api_v2/test_consumer.py
+++ b/pulp_smash/tests/platform/api_v2/test_consumer.py
@@ -10,6 +10,7 @@ from urllib.parse import urljoin
 from pulp_smash import api, config, utils
 from pulp_smash.constants import CONSUMERS_PATH, REPOSITORY_PATH
 from pulp_smash.tests.rpm.api_v2.utils import gen_repo, gen_distributor
+from pulp_smash.tests.platform.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 
 class BindConsumerTestCase(unittest.TestCase):

--- a/pulp_smash/tests/platform/api_v2/test_content_applicability.py
+++ b/pulp_smash/tests/platform/api_v2/test_content_applicability.py
@@ -20,6 +20,7 @@ from packaging.version import Version
 
 from pulp_smash import api, config
 from pulp_smash.constants import CALL_REPORT_KEYS, GROUP_CALL_REPORT_KEYS
+from pulp_smash.tests.platform.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 _PATHS = {
     'consumer': '/pulp/api/v2/consumers/actions/content/regenerate_applicability/',  # noqa

--- a/pulp_smash/tests/platform/api_v2/test_login.py
+++ b/pulp_smash/tests/platform/api_v2/test_login.py
@@ -84,6 +84,7 @@ import unittest
 
 from pulp_smash import api, config, selectors
 from pulp_smash.constants import ERROR_KEYS, LOGIN_KEYS, LOGIN_PATH
+from pulp_smash.tests.platform.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 
 class LoginTestCase(unittest.TestCase):

--- a/pulp_smash/tests/platform/api_v2/test_repository.py
+++ b/pulp_smash/tests/platform/api_v2/test_repository.py
@@ -21,6 +21,7 @@ from packaging.version import Version
 from pulp_smash import api, utils
 from pulp_smash.constants import REPOSITORY_PATH, ERROR_KEYS
 from pulp_smash.selectors import bug_is_untestable, require
+from pulp_smash.tests.platform.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 
 class CreateSuccessTestCase(utils.BaseAPITestCase):

--- a/pulp_smash/tests/platform/api_v2/test_search.py
+++ b/pulp_smash/tests/platform/api_v2/test_search.py
@@ -31,6 +31,7 @@ import unittest
 
 from pulp_smash import api, config, selectors, utils
 from pulp_smash.constants import USER_PATH
+from pulp_smash.tests.platform.utils import set_up_module
 from pulp_smash.utils import uuid4
 
 
@@ -44,6 +45,7 @@ def setUpModule():  # pylint:disable=invalid-name
     Test cases may search for these users or otherwise perform non-destructive
     actions on them. Test cases should **not** change these users.
     """
+    set_up_module()
     client = api.Client(config.get_config(), api.json_handler)
     del _USERS[:]  # Ensure idempotence
     for _ in range(3):

--- a/pulp_smash/tests/platform/api_v2/test_user.py
+++ b/pulp_smash/tests/platform/api_v2/test_user.py
@@ -15,6 +15,7 @@ The assumptions explored in this module have the following dependencies::
 """
 from pulp_smash import api, utils
 from pulp_smash.constants import LOGIN_PATH, USER_PATH
+from pulp_smash.tests.platform.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 
 def _logins(search_response):

--- a/pulp_smash/tests/platform/cli/test_pulp_manage_db.py
+++ b/pulp_smash/tests/platform/cli/test_pulp_manage_db.py
@@ -11,6 +11,7 @@ import inspect
 import unittest
 
 from pulp_smash import cli, config, exceptions, selectors, utils
+from pulp_smash.tests.platform.utils import set_up_module
 
 REQUIRED_SERVICES = frozenset(('mongod',))
 """If any of these services are stopped, ``pulp-manage-db`` will abort."""
@@ -25,6 +26,7 @@ CONFLICTING_SERVICES = frozenset((
 
 def setUpModule():  # pylint:disable=invalid-name
     """Log in."""
+    set_up_module()
     utils.pulp_admin_login(config.get_config())
 
 

--- a/pulp_smash/tests/platform/cli/test_selinux.py
+++ b/pulp_smash/tests/platform/cli/test_selinux.py
@@ -5,6 +5,7 @@ import unittest
 from collections import namedtuple
 
 from pulp_smash import cli, config, selectors, utils
+from pulp_smash.tests.platform.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 
 CELERY_LABEL = ':system_r:celery_t:s0'

--- a/pulp_smash/tests/platform/utils.py
+++ b/pulp_smash/tests/platform/utils.py
@@ -1,0 +1,8 @@
+# coding=utf-8
+"""Utilities for platform tests."""
+from pulp_smash import utils
+
+
+def set_up_module():
+    """Skip tests if Pulp 2 isn't under test."""
+    utils.set_up_module()

--- a/pulp_smash/tests/puppet/utils.py
+++ b/pulp_smash/tests/puppet/utils.py
@@ -8,4 +8,5 @@ def set_up_module():
 
     See :mod:`pulp_smash.tests` for more information.
     """
+    utils.set_up_module()
     utils.skip_if_type_is_unsupported('puppet_module')

--- a/pulp_smash/tests/python/utils.py
+++ b/pulp_smash/tests/python/utils.py
@@ -8,4 +8,5 @@ def set_up_module():
 
     See :mod:`pulp_smash.tests` for more information.
     """
+    utils.set_up_module()
     utils.skip_if_type_is_unsupported('python_package')

--- a/pulp_smash/tests/rpm/api_v2/test_service_resiliency.py
+++ b/pulp_smash/tests/rpm/api_v2/test_service_resiliency.py
@@ -19,6 +19,7 @@ from pulp_smash.constants import (
     TASKS_PATH,
 )
 from pulp_smash.tests.rpm.api_v2.utils import gen_distributor, gen_repo
+from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 _PULP_WORKERS_CFG = '/etc/default/pulp_workers'
 

--- a/pulp_smash/tests/rpm/cli/test_environments.py
+++ b/pulp_smash/tests/rpm/cli/test_environments.py
@@ -8,6 +8,7 @@ from packaging.version import Version
 
 from pulp_smash import cli, config, utils
 from pulp_smash.constants import RPM_SIGNED_FEED_URL
+from pulp_smash.tests.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 
 class UploadPackageEnvTestCase(unittest.TestCase):

--- a/pulp_smash/tests/rpm/utils.py
+++ b/pulp_smash/tests/rpm/utils.py
@@ -10,6 +10,7 @@ def set_up_module():
 
     See :mod:`pulp_smash.tests` for more information.
     """
+    utils.set_up_module()
     utils.skip_if_type_is_unsupported('rpm')
 
 

--- a/pulp_smash/utils.py
+++ b/pulp_smash/utils.py
@@ -570,3 +570,13 @@ def os_is_f26(cfg, pulp_system=None):
         '/etc/redhat-release',
     ))
     return response.returncode == 0
+
+
+def set_up_module():
+    """Skip tests if Pulp 2 isn't under test."""
+    cfg = config.get_config()
+    if cfg.version >= Version('3'):
+        raise unittest.SkipTest(
+            'These tests are for Pulp 2, but Pulp {} is under test.'
+            .format(cfg.version)
+        )


### PR DESCRIPTION
Update the existing `setUpModule` functions so that they cause tests to
skip if the incorrect version of Pulp is under test. Tests in
`pulp_smash.tests.pulp3` only execute when Pulp 3 is under test, and
other tests (which will eventually be moved to `pulp_smash.tests.pulp2`)
only execute when Pulp 2 is under test.