### PR TITLE
Clean up usages of uuid4() function

### DIFF
--- a/pulp_smash/tests/pulp2/docker/api_v2/test_tags.py
+++ b/pulp_smash/tests/pulp2/docker/api_v2/test_tags.py
@@ -3,7 +3,6 @@
 import hashlib
 import random
 import unittest
-import uuid
 from urllib.parse import urljoin
 
 from packaging.version import Version
@@ -96,7 +95,7 @@ class DockerTagTestCase(utils.BaseAPITestCase):
 
     def test_create_tag(self):
         """Check if a tag can be created."""
-        tag_name = str(uuid.uuid4())
+        tag_name = utils.uuid4()
         random_manifest = random.choice(utils.search_units(
             self.cfg, self.repo, {'type_ids': ['docker_manifest']}))
         # Create the tag
@@ -185,9 +184,9 @@ class DockerTagTestCase(utils.BaseAPITestCase):
 
     def test_update_tag_invalid_manifest(self):  # pylint:disable=invalid-name
         """Check if tagging fail for a invalid manifest."""
-        tag_name = str(uuid.uuid4())
+        tag_name = utils.uuid4()
         manifest_digest = 'sha256:{}'.format(hashlib.sha256(
-            bytes(str(uuid.uuid4()), encoding='utf-8')).hexdigest())
+            bytes(utils.uuid4(), encoding='utf-8')).hexdigest())
         # Create the tag
         with self.assertRaises(TaskReportError) as context:
             import_upload(self.cfg, self.repo, {
@@ -217,7 +216,7 @@ class DockerTagTestCase(utils.BaseAPITestCase):
             other['_href'], params={'details': True})
         other_manifest = random.choice(utils.search_units(
             self.cfg, other, {'type_ids': ['docker_manifest']}))
-        tag_name = str(uuid.uuid4())
+        tag_name = utils.uuid4()
         with self.assertRaises(TaskReportError) as context:
             import_upload(self.cfg, self.repo, {
                 'unit_type_id': 'docker_tag',

--- a/pulp_smash/tests/pulp2/platform/api_v2/test_search.py
+++ b/pulp_smash/tests/pulp2/platform/api_v2/test_search.py
@@ -32,7 +32,6 @@ import unittest
 from pulp_smash import api, config, selectors, utils
 from pulp_smash.constants import USER_PATH
 from pulp_smash.tests.pulp2.platform.utils import set_up_module
-from pulp_smash.utils import uuid4
 
 
 _SEARCH_PATH = USER_PATH + 'search/'
@@ -49,7 +48,7 @@ def setUpModule():  # pylint:disable=invalid-name
     client = api.Client(config.get_config(), api.json_handler)
     del _USERS[:]  # Ensure idempotence
     for _ in range(3):
-        _USERS.append(client.post(USER_PATH, {'login': uuid4()}))
+        _USERS.append(client.post(USER_PATH, {'login': utils.uuid4()}))
 
 
 def tearDownModule():  # pylint:disable=invalid-name

--- a/pulp_smash/tests/pulp2/rpm/cli/test_environments.py
+++ b/pulp_smash/tests/pulp2/rpm/cli/test_environments.py
@@ -2,7 +2,6 @@
 """Tests for RPM package environments."""
 import subprocess
 import unittest
-import uuid
 
 from packaging.version import Version
 
@@ -62,8 +61,8 @@ class UploadPackageEnvTestCase(unittest.TestCase):
 
     def test_upload_environment(self):
         """Test if package environments can be uploaded."""
-        rpm_env_name = str(uuid.uuid4())
-        rpm_env_desc = str(uuid.uuid4())
+        rpm_env_name = utils.uuid4()
+        rpm_env_desc = utils.uuid4()
         result = self.client.run(
             'pulp-admin rpm repo uploads environment --repo-id {0} '
             '--environment-id {1} --name {2} --description {3}'

--- a/pulp_smash/utils.py
+++ b/pulp_smash/utils.py
@@ -28,8 +28,8 @@ _CHECKSUM_CACHE = {}
 
 
 def uuid4():
-    """Return a random UUID, as a unicode string."""
-    return type('')(uuid.uuid4())
+    """Return a random UUID4 as a string."""
+    return str(uuid.uuid4())
 
 
 # See design discussion at: https://github.com/PulpQE/pulp-smash/issues/31


### PR DESCRIPTION
The `pulp_smash.utils.uuid4()` function is written with Python 2 in
mind. Given that Pulp Smash now requires Python 3, that
backwards-compatibility logic may be dropped. Do so.

Where appropriate, use `pulp_smash.utils.uuid4()` instead of
`uuid.uuid4()` from the standard library.