### PR TITLE
Let user specify a port number in config file

### DIFF
--- a/pulp_smash/pulp_smash_cli.py
+++ b/pulp_smash/pulp_smash_cli.py
@@ -44,7 +44,9 @@ def settings_create(ctx):
     """Create a settings file."""
     path = ctx.obj['cfg_path']
     if path:
-        click.echo('Settings file already exist, continuing will override it.')
+        click.echo(
+            'A settings file already exists. Continuing will override it.'
+        )
         click.confirm('Do you want to continue?', abort=True)
     else:
         path = ctx.obj['default_cfg_path']
@@ -53,7 +55,7 @@ def settings_create(ctx):
     pulp_version = click.prompt('Pulp version')
     system_hostname = click.prompt('System hostname')
     if click.confirm(
-            'Is Pulp API available over HTTPS (no for HTTP)?', default=True):
+            "Is Pulp's API available over HTTPS (no for HTTP)?", default=True):
         system_api_scheme = 'https'
     else:
         system_api_scheme = 'http'
@@ -67,6 +69,15 @@ def settings_create(ctx):
             system_api_verify = certificate_path
     else:
         system_api_verify = False
+
+    click.echo(
+        "By default, Pulp Smash will communicate with Pulp's API on the port "
+        "number implied by the scheme. For example, if Pulp's API is "
+        'available over HTTPS, then Pulp Smash will communicate on port 443.'
+        "If Pulp's API is avaialable on a non-standard port, like 8000, then "
+        'Pulp Smash needs to know about that.'
+    )
+    system_api_port = click.prompt('Pulp API port number', type=int, default=0)
 
     if click.confirm(
             'Is Pulp\'s message broker Qpid (no for RabbitMQ)?', default=True):
@@ -119,6 +130,8 @@ def settings_create(ctx):
             }
         }]
     }
+    if system_api_port:
+        config_dict['systems'][0]['roles']['api']['port'] = system_api_port
     with open(path, 'w') as handler:
         handler.write(json.dumps(config_dict, indent=2, sort_keys=True))
     click.echo(

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_auth.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_auth.py
@@ -11,7 +11,7 @@ from requests.exceptions import HTTPError
 
 from pulp_smash import api, config, utils
 from pulp_smash.tests.pulp3.constants import BASE_PATH, JWT_PATH
-from pulp_smash.tests.pulp3.utils import adjust_url, get_base_url, JWTAuth
+from pulp_smash.tests.pulp3.utils import JWTAuth
 from pulp_smash.tests.pulp3.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 
@@ -22,32 +22,27 @@ class AuthTestCase(unittest.TestCase):
     def setUpClass(cls):
         """Create class-wide variables."""
         cls.cfg = config.get_config()
-        cls.url = adjust_url(get_base_url())
 
     def test_base_auth_success(self):
         """Perform HTTP basic authentication with valid credentials.
 
         Assert that a response indicating success is returned.
         """
-        client = api.Client(self.cfg, api.json_handler)
-        client.request_kwargs['url'] = self.url
-        client.get(BASE_PATH, auth=HTTPBasicAuth(
-            self.cfg.pulp_auth[0],
-            self.cfg.pulp_auth[1],
-        ))
+        api.Client(self.cfg, api.json_handler).get(
+            BASE_PATH,
+            auth=HTTPBasicAuth(self.cfg.pulp_auth[0], self.cfg.pulp_auth[1]),
+        )
 
     def test_base_auth_failure(self):
         """Perform HTTP basic authentication with invalid credentials.
 
         Assert that a response indicating failure is returned.
         """
-        client = api.Client(self.cfg, api.json_handler)
-        client.request_kwargs['url'] = self.url
         with self.assertRaises(HTTPError):
-            client.get(BASE_PATH, auth=HTTPBasicAuth(
-                self.cfg.pulp_auth[0],
-                utils.uuid4(),
-            ))
+            api.Client(self.cfg, api.json_handler).get(
+                BASE_PATH,
+                auth=HTTPBasicAuth(self.cfg.pulp_auth[0], utils.uuid4()),
+            )
 
     def test_jwt_success(self):
         """Perform JWT authentication with valid credentials.
@@ -55,7 +50,6 @@ class AuthTestCase(unittest.TestCase):
         Assert that a response indicating success is returned.
         """
         client = api.Client(self.cfg, api.json_handler)
-        client.request_kwargs['url'] = self.url
         token = client.post(JWT_PATH, {
             'username': self.cfg.pulp_auth[0],
             'password': self.cfg.pulp_auth[1],
@@ -67,10 +61,8 @@ class AuthTestCase(unittest.TestCase):
 
         Assert that a response indicating failure is returned.
         """
-        client = api.Client(self.cfg, api.json_handler)
-        client.request_kwargs['url'] = self.url
         with self.assertRaises(HTTPError):
-            client.post(JWT_PATH, {
-                'username': self.cfg.pulp_auth[0],
-                'password': utils.uuid4(),
-            })
+            api.Client(self.cfg, api.json_handler).post(
+                JWT_PATH,
+                {'username': self.cfg.pulp_auth[0], 'password': utils.uuid4()},
+            )

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_repos.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_repos.py
@@ -8,7 +8,7 @@ from requests.exceptions import HTTPError
 from pulp_smash import api, config, selectors, utils
 from pulp_smash.tests.pulp3.constants import REPO_PATH
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
-from pulp_smash.tests.pulp3.utils import adjust_url, get_auth, get_base_url
+from pulp_smash.tests.pulp3.utils import get_auth
 from pulp_smash.tests.pulp3.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 
@@ -26,7 +26,6 @@ class CRUDRepoTestCase(unittest.TestCase):
         """Create an API client."""
         self.client = api.Client(self.cfg, api.code_handler)
         self.client.request_kwargs['auth'] = self.auth
-        self.client.request_kwargs['url'] = adjust_url(get_base_url())
 
     def test_01_create_repo(self):
         """Create repository."""

--- a/pulp_smash/tests/pulp3/utils.py
+++ b/pulp_smash/tests/pulp3/utils.py
@@ -2,7 +2,6 @@
 """Utility functions for Pulp 3 tests."""
 import random
 import unittest
-from urllib.parse import urlsplit, urlunsplit
 
 from packaging.version import Version
 from requests.auth import AuthBase, HTTPBasicAuth
@@ -31,30 +30,6 @@ class JWTAuth(AuthBase):  # pylint:disable=too-few-public-methods
             self.token,
         ))
         return request
-
-
-def get_base_url():
-    """Return the base url from settings."""
-    cfg = config.get_config()
-    pulp_system = cfg.get_systems('api')[0]
-    return '{}://{}/'.format(
-        pulp_system.roles['api'].get('scheme', 'https'),
-        pulp_system.hostname
-    )
-
-
-def adjust_url(url):
-    """Return a URL that can be used for talking in a certain port.
-
-    The URL returned is the same as ``url``, except that the scheme is set
-    to HTTP, and the port is set to 8000.
-
-    :param url: A string, such as ``https://pulp.example.com/foo``.
-    :returns: A string, such as ``http://pulp.example.com:8000/foo``.
-    """
-    parse_result = urlsplit(url)
-    netloc = parse_result[1].partition(':')[0] + ':8000'
-    return urlunsplit(('http', netloc) + parse_result[2:])
 
 
 def set_up_module():
@@ -104,9 +79,7 @@ def _get_basic_auth(cfg):
 
 def _get_jwt_auth(cfg):
     """Return an object for JWT authentication."""
-    client = api.Client(cfg, api.json_handler)
-    client.request_kwargs['url'] = adjust_url(get_base_url())
-    token = client.post(JWT_PATH, {
+    token = api.Client(cfg, api.json_handler).post(JWT_PATH, {
         'username': cfg.pulp_auth[0],
         'password': cfg.pulp_auth[1],
     })

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -23,7 +23,7 @@ PULP_SMASH_CONFIG = """
             "hostname": "first.example.com",
             "roles": {
                 "amqp broker": {"service": "qpidd"},
-                "api": {"scheme": "https", "verify": true},
+                "api": {"port": 1234, "scheme": "https", "verify": true},
                 "mongod": {},
                 "pulp cli": {},
                 "pulp celerybeat": {},
@@ -36,7 +36,7 @@ PULP_SMASH_CONFIG = """
         {
             "hostname": "second.example.com",
             "roles": {
-                "api": {"scheme": "https", "verify": false},
+                "api": {"port": 2345, "scheme": "https", "verify": false},
                 "pulp celerybeat": {},
                 "pulp resource manager": {},
                 "pulp workers": {},
@@ -80,6 +80,7 @@ def _gen_attrs():
                 roles={
                     'amqp broker': {'service': 'qpidd'},
                     'api': {
+                        'port': random.randint(1, 65535),
                         'scheme': 'https',
                         'verify': True
                     },
@@ -248,6 +249,7 @@ class ReadTestCase(unittest.TestCase):
                         roles={
                             'amqp broker': {'service': 'qpidd'},
                             'api': {
+                                'port': 1234,
                                 'scheme': 'https',
                                 'verify': True,
                             },
@@ -264,6 +266,7 @@ class ReadTestCase(unittest.TestCase):
                         hostname='second.example.com',
                         roles={
                             'api': {
+                                'port': 2345,
                                 'scheme': 'https',
                                 'verify': False,
                             },

--- a/tests/test_pulp_smash_cli.py
+++ b/tests/test_pulp_smash_cli.py
@@ -125,6 +125,7 @@ class SettingsCreateTestCase(BasePulpSmashCliTestCase):
             'pulp.example.com\n'  # system hostname
             '\n'  # published via HTTPS
             '\n'  # verify HTTPS
+            '\n'  # API port
             '\n'  # using qpidd
             '\n'  # running on Pulp system
         )
@@ -142,6 +143,7 @@ class SettingsCreateTestCase(BasePulpSmashCliTestCase):
             'pulp.example.com\n'  # system hostname
             '\n'  # published via HTTPS
             '\n'  # verify HTTPS
+            '\n'  # API port
             '\n'  # using qpidd
             '\n'  # running on Pulp system
         )
@@ -160,6 +162,7 @@ class SettingsCreateTestCase(BasePulpSmashCliTestCase):
             '\n'  # published via HTTPS
             'y\n'  # verify HTTPS
             '/path/to/ssl/certificate\n'  # SSL certificate path
+            '\n'  # API port
             '\n'  # using qpidd
             '\n'  # running on Pulp system
         )
@@ -178,6 +181,7 @@ class SettingsCreateTestCase(BasePulpSmashCliTestCase):
             '2.13\n'  # pulp version
             'pulp.example.com\n'  # system hostname
             'n\n'  # published via HTTPS
+            '\n'  # API port
             'n\n'  # using qpidd
             'y\n'  # running on Pulp system
         )


### PR DESCRIPTION
Expand the schema for the Pulp Smash configuration file, and allow users
to set a port number. (The config file typically lives at
`~/.config/pulp_smash/settings.json`.) By default, the port number to
use when communicating with Pulp's API is inferred. For example, if the
scheme is http, then Pulp Smash will communicate with Pulp's API on port
80. This commit makes it possible to override that behaviour. A user can
now specify a specific port number to use when communicating with Pulp's
API.

This is mainly useful for the Pulp 3 API tests. Currently, the API tests
have port number 8,000 hard-coded into them. This commit removes those
hard-coded port numbers.