### PR TITLE
Drop outdated property `version`

### DIFF
--- a/pulp_smash/config.py
+++ b/pulp_smash/config.py
@@ -488,11 +488,6 @@ class PulpSmashConfig(object):
             pass
         return urlunsplit((scheme, netloc, '', '', ''))
 
-    @property
-    def version(self):
-        """Map old config version to the pulp_version."""
-        return self.pulp_version
-
     def get_requests_kwargs(self, pulp_system=None):
         """Get kwargs for use by the Requests functions.
 

--- a/pulp_smash/selectors.py
+++ b/pulp_smash/selectors.py
@@ -207,12 +207,12 @@ def require(version_string):
         @wraps(test_method)
         def new_test_method(self, *args, **kwargs):
             """Wrap a (unittest test) method."""
-            if self.cfg.version < min_version:
+            if self.cfg.pulp_version < min_version:
                 self.skipTest(
                     'This test requires Pulp {} or later, but Pulp {} is '
                     'being tested. If this seems wrong, try checking the '
                     '"settings" option in the Pulp Smash configuration file.'
-                    .format(version_string, self.cfg.version)
+                    .format(version_string, self.cfg.pulp_version)
                 )
             return test_method(self, *args, **kwargs)
         return new_test_method

--- a/pulp_smash/tests/pulp2/docker/api_v2/test_copy.py
+++ b/pulp_smash/tests/pulp2/docker/api_v2/test_copy.py
@@ -151,7 +151,7 @@ class CopyV2ContentTestCase(unittest.TestCase):
         * `Pulp #2385 <https://pulp.plan.io/issues/2385>`_
         """
         for issue_id in (2384, 2385):
-            if selectors.bug_is_untestable(issue_id, self.cfg.version):
+            if selectors.bug_is_untestable(issue_id, self.cfg.pulp_version):
                 self.skipTest(
                     'https://pulp.plan.io/issues/{}'.format(issue_id)
                 )

--- a/pulp_smash/tests/pulp2/docker/api_v2/test_crud.py
+++ b/pulp_smash/tests/pulp2/docker/api_v2/test_crud.py
@@ -18,7 +18,7 @@ from pulp_smash.tests.pulp2.docker.utils import set_up_module
 def setUpModule():  # pylint:disable=invalid-name
     """Skip tests on Pulp versions lower than 2.8."""
     set_up_module()
-    if config.get_config().version < Version('2.8'):
+    if config.get_config().pulp_version < Version('2.8'):
         raise unittest.SkipTest('These tests require at least Pulp 2.8.')
 
 

--- a/pulp_smash/tests/pulp2/docker/api_v2/test_sync.py
+++ b/pulp_smash/tests/pulp2/docker/api_v2/test_sync.py
@@ -21,7 +21,7 @@ from pulp_smash.tests.pulp2.docker.utils import (
 def setUpModule():  # pylint:disable=invalid-name
     """Skip tests on Pulp versions lower than 2.8."""
     set_up_module()
-    if config.get_config().version < Version('2.8'):
+    if config.get_config().pulp_version < Version('2.8'):
         raise unittest.SkipTest('These tests require at least Pulp 2.8.')
 
 
@@ -47,7 +47,7 @@ class UpstreamNameTestsMixin(object):
 
         Verify the sync request is rejected with an HTTP 400 status code.
         """
-        if selectors.bug_is_untestable(2230, self.cfg.version):
+        if selectors.bug_is_untestable(2230, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2230')
         docker_upstream_name = get_upstream_name(self.cfg).replace('/', ' ')
         response = api.Client(self.cfg, api.echo_handler).post(

--- a/pulp_smash/tests/pulp2/docker/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/pulp2/docker/api_v2/test_sync_publish.py
@@ -223,7 +223,7 @@ class V1RegistryTestCase(SyncPublishMixin, unittest.TestCase):
         cls.cfg = config.get_config()
         cls.repo = {}
         if (utils.os_is_f26(cls.cfg) and
-                selectors.bug_is_untestable(3036, cls.cfg.version)):
+                selectors.bug_is_untestable(3036, cls.cfg.pulp_version)):
             raise unittest.SkipTest('https://pulp.plan.io/issues/3036')
 
     @classmethod
@@ -282,8 +282,8 @@ class V1RegistryTestCase(SyncPublishMixin, unittest.TestCase):
         Assert that the response is as described by `Crane Admin
         <http://docs.pulpproject.org/plugins/crane/index.html#crane-admin>`_.
         """
-        if (self.cfg.version < Version('2.14') or
-                selectors.bug_is_untestable(2723, self.cfg.version)):
+        if (self.cfg.pulp_version < Version('2.14') or
+                selectors.bug_is_untestable(2723, self.cfg.pulp_version)):
             self.skipTest('https://pulp.plan.io/issues/2723')
         repo_id = self.repo['id']
         repos = self.make_crane_client(self.cfg).get('/crane/repositories/v1')
@@ -310,10 +310,10 @@ class V2RegistryTestCase(SyncPublishMixin, unittest.TestCase):
         cls.cfg = config.get_config()
         cls.repo = {}
         if (utils.os_is_f26(cls.cfg) and
-                selectors.bug_is_untestable(3036, cls.cfg.version)):
+                selectors.bug_is_untestable(3036, cls.cfg.pulp_version)):
             raise unittest.SkipTest('https://pulp.plan.io/issues/3036')
         for issue_id in (2287, 2384):
-            if selectors.bug_is_untestable(issue_id, cls.cfg.version):
+            if selectors.bug_is_untestable(issue_id, cls.cfg.pulp_version):
                 raise unittest.SkipTest(
                     'https://pulp.plan.io/issues/{}'.format(issue_id)
                 )
@@ -363,8 +363,8 @@ class V2RegistryTestCase(SyncPublishMixin, unittest.TestCase):
         Assert that the response is as described by `Crane Admin
         <http://docs.pulpproject.org/plugins/crane/index.html#crane-admin>`_.
         """
-        if (self.cfg.version < Version('2.14') or
-                selectors.bug_is_untestable(2723, self.cfg.version)):
+        if (self.cfg.pulp_version < Version('2.14') or
+                selectors.bug_is_untestable(2723, self.cfg.pulp_version)):
             self.skipTest('https://pulp.plan.io/issues/2723')
         repo_id = self.repo['id']
         repos = self.make_crane_client(self.cfg).get('/crane/repositories/v2')
@@ -385,7 +385,7 @@ class V2RegistryTestCase(SyncPublishMixin, unittest.TestCase):
 
         This test targets `Pulp #2336 <https://pulp.plan.io/issues/2336>`_.
         """
-        if selectors.bug_is_untestable(2336, self.cfg.version):
+        if selectors.bug_is_untestable(2336, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2336')
         client = api.Client(self.cfg, api.json_handler)
         client.request_kwargs['url'] = self.adjust_url(
@@ -414,7 +414,7 @@ class V2RegistryTestCase(SyncPublishMixin, unittest.TestCase):
 
         This test targets `Pulp #2336 <https://pulp.plan.io/issues/2336>`_.
         """
-        if selectors.bug_is_untestable(2336, self.cfg.version):
+        if selectors.bug_is_untestable(2336, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2336')
         client = api.Client(self.cfg, api.json_handler, {'headers': {
             'accept': 'application/vnd.docker.distribution.manifest.v2+json'
@@ -494,8 +494,8 @@ class NonNamespacedImageTestCase(SyncPublishMixin, unittest.TestCase):
         cli.GlobalServiceManager(cfg).restart(('httpd',))
 
         # Get and inspect /crane/repositories/v2.
-        if (cfg.version >= Version('2.14') and
-                selectors.bug_is_testable(2723, cfg.version)):
+        if (cfg.pulp_version >= Version('2.14') and
+                selectors.bug_is_testable(2723, cfg.pulp_version)):
             client = self.make_crane_client(cfg)
             repo_id = repo['id']
             repos = client.get('/crane/repositories/v2')
@@ -546,9 +546,9 @@ class NoAmd64LinuxTestCase(SyncPublishMixin, unittest.TestCase):
         cls.cfg = config.get_config()
         cls.repo = {}
         if (utils.os_is_f26(cls.cfg) and
-                selectors.bug_is_untestable(3036, cls.cfg.version)):
+                selectors.bug_is_untestable(3036, cls.cfg.pulp_version)):
             raise unittest.SkipTest('https://pulp.plan.io/issues/3036')
-        if selectors.bug_is_untestable(2384, cls.cfg.version):
+        if selectors.bug_is_untestable(2384, cls.cfg.pulp_version):
             raise unittest.SkipTest('https://pulp.plan.io/issues/2384')
 
     @classmethod
@@ -681,8 +681,8 @@ class RepoRegistryIdTestCase(SyncPublishMixin, unittest.TestCase):
         .. _Pulp #2723: https://pulp.plan.io/issues/2723
         """
         cfg = config.get_config()
-        if (cfg.version < Version('2.14') or
-                selectors.bug_is_untestable(2723, cfg.version)):
+        if (cfg.pulp_version < Version('2.14') or
+                selectors.bug_is_untestable(2723, cfg.pulp_version)):
             self.skipTest('https://pulp.plan.io/issues/2723')
         for i in range(1, 4):
             repo_registry_id = '/'.join(utils.uuid4() for _ in range(i))

--- a/pulp_smash/tests/pulp2/docker/api_v2/test_tags.py
+++ b/pulp_smash/tests/pulp2/docker/api_v2/test_tags.py
@@ -25,7 +25,7 @@ from pulp_smash.tests.pulp2.docker.utils import (
 def setUpModule():  # pylint:disable=invalid-name
     """Skip tests on Pulp versions lower than 2.12."""
     set_up_module()
-    if config.get_config().version < Version('2.12'):
+    if config.get_config().pulp_version < Version('2.12'):
         raise unittest.SkipTest('These tests require at least Pulp 2.12.')
 
 
@@ -252,7 +252,7 @@ class DockerTagTestCase(utils.BaseAPITestCase):
             'filters': {'unit': {'name': 'latest'}},
             'type_ids': ['docker_tag'],
         }
-        if self.cfg.version >= Version('2.13'):
+        if self.cfg.pulp_version >= Version('2.13'):
             criteria['filters']['unit']['schema_version'] = 1
         return utils.search_units(self.cfg, self.repo, criteria)
 
@@ -263,6 +263,6 @@ class DockerTagTestCase(utils.BaseAPITestCase):
         schema v1 manifests. See :meth:`get_latest_tags`.
         """
         criteria = {'type_ids': ['docker_manifest']}
-        if self.cfg.version >= Version('2.13'):
+        if self.cfg.pulp_version >= Version('2.13'):
             criteria['filters'] = {'unit': {'schema_version': 1}}
         return utils.search_units(self.cfg, self.repo, criteria)

--- a/pulp_smash/tests/pulp2/docker/cli/test_crud.py
+++ b/pulp_smash/tests/pulp2/docker/cli/test_crud.py
@@ -81,7 +81,7 @@ class DeleteV2TestCase(unittest.TestCase):
         """Provide a server config and a repository ID."""
         cls.cfg = config.get_config()
 
-        if cls.cfg.version < version.Version('2.8'):
+        if cls.cfg.pulp_version < version.Version('2.8'):
             raise unittest.SkipTest('These tests require Pulp 2.8 or above.')
 
         utils.pulp_admin_login(cls.cfg)
@@ -125,9 +125,9 @@ class UpdateEnableV1TestCase(unittest.TestCase):
         """Provide a server config and a repository ID."""
         cls.cfg = config.get_config()
 
-        if cls.cfg.version < version.Version('2.8'):
+        if cls.cfg.pulp_version < version.Version('2.8'):
             raise unittest.SkipTest('These tests require Pulp 2.8 or above.')
-        if selectors.bug_is_untestable(1710, cls.cfg.version):
+        if selectors.bug_is_untestable(1710, cls.cfg.pulp_version):
             raise unittest.SkipTest('https://pulp.plan.io/issues/1710')
 
         utils.pulp_admin_login(cls.cfg)
@@ -179,9 +179,9 @@ class UpdateEnableV2TestCase(unittest.TestCase):
         """Provide a server config and a repository ID."""
         cls.cfg = config.get_config()
 
-        if cls.cfg.version < version.Version('2.8'):
+        if cls.cfg.pulp_version < version.Version('2.8'):
             raise unittest.SkipTest('These tests require Pulp 2.8 or above.')
-        if selectors.bug_is_untestable(1710, cls.cfg.version):
+        if selectors.bug_is_untestable(1710, cls.cfg.pulp_version):
             raise unittest.SkipTest('https://pulp.plan.io/issues/1710')
 
         utils.pulp_admin_login(cls.cfg)
@@ -233,9 +233,9 @@ class UpdateDistributorTestCase(unittest.TestCase):
     def setUpClass(cls):
         """Provide a server config and a repository ID."""
         cls.cfg = config.get_config()
-        if cls.cfg.version < version.Version('2.8'):
+        if cls.cfg.pulp_version < version.Version('2.8'):
             raise unittest.SkipTest('These tests require Pulp 2.8 or above.')
-        if selectors.bug_is_untestable(1710, cls.cfg.version):
+        if selectors.bug_is_untestable(1710, cls.cfg.pulp_version):
             raise unittest.SkipTest('https://pulp.plan.io/issues/1710')
 
         utils.pulp_admin_login(cls.cfg)

--- a/pulp_smash/tests/pulp2/docker/cli/test_sync_publish.py
+++ b/pulp_smash/tests/pulp2/docker/cli/test_sync_publish.py
@@ -31,7 +31,7 @@ class InvalidFeedTestCase(utils.BaseAPITestCase):
         proc = client.run((
             'pulp-admin', 'docker', 'repo', 'sync', 'run', '--repo-id', repo_id
         ))
-        if selectors.bug_is_testable(427, self.cfg.version):
+        if selectors.bug_is_testable(427, self.cfg.pulp_version):
             with self.subTest():
                 self.assertNotEqual(proc.returncode, 0)
         with self.subTest():

--- a/pulp_smash/tests/pulp2/docker/utils.py
+++ b/pulp_smash/tests/pulp2/docker/utils.py
@@ -26,6 +26,6 @@ def get_upstream_name(cfg):
     :data:`pulp_smash.constants.DOCKER_UPSTREAM_NAME`. See the documentation
     for those constants for more information.
     """
-    if cfg.version < Version('2.14'):
+    if cfg.pulp_version < Version('2.14'):
         return DOCKER_UPSTREAM_NAME_NOLIST
     return DOCKER_UPSTREAM_NAME

--- a/pulp_smash/tests/pulp2/ostree/api_v2/test_crud.py
+++ b/pulp_smash/tests/pulp2/ostree/api_v2/test_crud.py
@@ -121,8 +121,8 @@ class CreateDistributorsTestCase(utils.BaseAPITestCase):
         Re-use the same relative path. For example, if an existing relative
         path is ``foo/bar``, then this relative path would be ``foo/bar``.
         """
-        if (self.cfg.version >= Version('2.14') and
-                selectors.bug_is_untestable(2769, self.cfg.version)):
+        if (self.cfg.pulp_version >= Version('2.14') and
+                selectors.bug_is_untestable(2769, self.cfg.pulp_version)):
             self.skipTest('https://pulp.plan.io/issues/2769')
         client = api.Client(self.cfg, api.json_handler)
         path = urljoin(self.repos[1]['_href'], 'distributors/')
@@ -138,8 +138,8 @@ class CreateDistributorsTestCase(utils.BaseAPITestCase):
         Extend an existing relative path. For example, if an existing relative
         path is ``foo/bar``, then this relative path would be ``foo/bar/biz``.
         """
-        if (self.cfg.version >= Version('2.14') and
-                selectors.bug_is_untestable(2769, self.cfg.version)):
+        if (self.cfg.pulp_version >= Version('2.14') and
+                selectors.bug_is_untestable(2769, self.cfg.pulp_version)):
             self.skipTest('https://pulp.plan.io/issues/2769')
         client = api.Client(self.cfg, api.json_handler)
         path = urljoin(self.repos[1]['_href'], 'distributors/')
@@ -157,8 +157,8 @@ class CreateDistributorsTestCase(utils.BaseAPITestCase):
         existing relative path is ``foo/bar``, then this relative path would be
         ``/foo/bar``.
         """
-        if (self.cfg.version >= Version('2.14') and
-                selectors.bug_is_untestable(2769, self.cfg.version)):
+        if (self.cfg.pulp_version >= Version('2.14') and
+                selectors.bug_is_untestable(2769, self.cfg.pulp_version)):
             self.skipTest('https://pulp.plan.io/issues/2769')
         client = api.Client(self.cfg, api.json_handler)
         path = urljoin(self.repos[1]['_href'], 'distributors/')
@@ -249,8 +249,8 @@ class UpdateDistributorsTestCase(utils.BaseAPITestCase):
         Re-use an existing relative path. For example, if an existing relative
         path is ``foo/bar``, then this relative path would be ``foo/bar``.
         """
-        if (self.cfg.version >= Version('2.14') and
-                selectors.bug_is_untestable(2769, self.cfg.version)):
+        if (self.cfg.pulp_version >= Version('2.14') and
+                selectors.bug_is_untestable(2769, self.cfg.pulp_version)):
             self.skipTest('https://pulp.plan.io/issues/2769')
 
         # update
@@ -275,8 +275,8 @@ class UpdateDistributorsTestCase(utils.BaseAPITestCase):
         Extend an existing relative path. For example, if an existing relative
         path is ``foo/bar``, then this relative path would be ``foo/bar/biz``.
         """
-        if (self.cfg.version >= Version('2.14') and
-                selectors.bug_is_untestable(2769, self.cfg.version)):
+        if (self.cfg.pulp_version >= Version('2.14') and
+                selectors.bug_is_untestable(2769, self.cfg.pulp_version)):
             self.skipTest('https://pulp.plan.io/issues/2769')
 
         # update
@@ -305,8 +305,8 @@ class UpdateDistributorsTestCase(utils.BaseAPITestCase):
         existing relative path is ``foo/bar``, then this relative path would be
         ``/foo/bar``.
         """
-        if (self.cfg.version >= Version('2.14') and
-                selectors.bug_is_untestable(2769, self.cfg.version)):
+        if (self.cfg.pulp_version >= Version('2.14') and
+                selectors.bug_is_untestable(2769, self.cfg.pulp_version)):
             self.skipTest('https://pulp.plan.io/issues/2769')
 
         # update

--- a/pulp_smash/tests/pulp2/ostree/api_v2/test_sync.py
+++ b/pulp_smash/tests/pulp2/ostree/api_v2/test_sync.py
@@ -95,7 +95,7 @@ class SyncTestCase(_SyncMixin, utils.BaseAPITestCase):
     def setUpClass(cls):
         """Create an OSTree repository with a valid feed and branch."""
         super(SyncTestCase, cls).setUpClass()
-        if selectors.bug_is_untestable(1934, cls.cfg.version):
+        if selectors.bug_is_untestable(1934, cls.cfg.pulp_version):
             raise unittest.SkipTest('https://pulp.plan.io/issues/1934')
         body = gen_repo()
         body['importer_config']['feed'] = OSTREE_FEED

--- a/pulp_smash/tests/pulp2/platform/api_v2/test_content_applicability.py
+++ b/pulp_smash/tests/pulp2/platform/api_v2/test_content_applicability.py
@@ -87,7 +87,7 @@ class ParallelTestCase(_SuccessTestCase):
     def setUp(self):
         """Ensure this test only runs on Pulp 2.8 and later."""
         min_ver = '2.8'
-        ver = self.cfg.version
+        ver = self.cfg.pulp_version
         if ver < Version(min_ver):
             self.skipTest(
                 'This test requires Pulp {} or later, but Pulp {} is being '

--- a/pulp_smash/tests/pulp2/platform/api_v2/test_login.py
+++ b/pulp_smash/tests/pulp2/platform/api_v2/test_login.py
@@ -147,6 +147,6 @@ class LoginTestCase(unittest.TestCase):
         # The `version` attribute should correspond to the version of the Pulp
         # server under test. This block of code says "if bug 1412 is not fixed
         # in Pulp version X, then skip this test."
-        if selectors.bug_is_testable(1412, cfg.version):
+        if selectors.bug_is_testable(1412, cfg.pulp_version):
             with self.subTest(comment='check response body'):
                 self.assertEqual(frozenset(response.json().keys()), ERROR_KEYS)

--- a/pulp_smash/tests/pulp2/platform/api_v2/test_repository.py
+++ b/pulp_smash/tests/pulp2/platform/api_v2/test_repository.py
@@ -135,7 +135,7 @@ class CreateFailureTestCase(utils.BaseAPITestCase):
         for body, response, status_code in zip(
                 self.bodies, self.responses, self.status_codes):
             if (body == ['Incorrect data type'] and
-                    self.cfg.version < Version('2.8')):
+                    self.cfg.pulp_version < Version('2.8')):
                 continue  # https://pulp.plan.io/issues/1356
             with self.subTest(body=body):
                 self.assertEqual(response.status_code, status_code)
@@ -145,7 +145,7 @@ class CreateFailureTestCase(utils.BaseAPITestCase):
         for body, response, status_code in zip(
                 self.bodies, self.responses, self.status_codes):
             if (body == ['Incorrect data type'] and
-                    self.cfg.version < Version('2.8')):
+                    self.cfg.pulp_version < Version('2.8')):
                 continue  # https://pulp.plan.io/issues/1356
             with self.subTest(body=body):
                 self.assertEqual(response.json()['http_status'], status_code)
@@ -160,7 +160,7 @@ class CreateFailureTestCase(utils.BaseAPITestCase):
         """Assert the JSON body returned contains the correct keys."""
         for body, response in zip(self.bodies, self.responses):
             with self.subTest(body=body):
-                if bug_is_untestable(1413, self.cfg.version):
+                if bug_is_untestable(1413, self.cfg.pulp_version):
                     self.skipTest('https://pulp.plan.io/issues/1413')
                 response_keys = frozenset(response.json().keys())
                 self.assertEqual(response_keys, ERROR_KEYS)

--- a/pulp_smash/tests/pulp2/platform/api_v2/test_search.py
+++ b/pulp_smash/tests/pulp2/platform/api_v2/test_search.py
@@ -147,7 +147,7 @@ class FieldTestCase(_BaseTestCase):
     def setUpClass(cls):
         """Create one user. Execute searches."""
         super(FieldTestCase, cls).setUpClass()
-        if selectors.bug_is_untestable(1933, cls.cfg.version):
+        if selectors.bug_is_untestable(1933, cls.cfg.pulp_version):
             raise unittest.SkipTest('https://pulp.plan.io/issues/1933')
         client = api.Client(cls.cfg)
         cls.searches = {
@@ -179,7 +179,7 @@ class FieldsTestCase(_BaseTestCase):
     def setUpClass(cls):
         """Create one user. Execute searches."""
         super(FieldsTestCase, cls).setUpClass()
-        if selectors.bug_is_untestable(1933, cls.cfg.version):
+        if selectors.bug_is_untestable(1933, cls.cfg.pulp_version):
             raise unittest.SkipTest('https://pulp.plan.io/issues/1933')
         client = api.Client(cls.cfg)
         cls.searches = {

--- a/pulp_smash/tests/pulp2/platform/cli/test_pulp_manage_db.py
+++ b/pulp_smash/tests/pulp2/platform/cli/test_pulp_manage_db.py
@@ -44,7 +44,7 @@ class BaseTestCase(unittest.TestCase):
         if inspect.getmro(cls)[0] == BaseTestCase:
             raise unittest.SkipTest('Abstract base class.')
         cls.cfg = config.get_config()
-        if selectors.bug_is_untestable(2186, cls.cfg.version):
+        if selectors.bug_is_untestable(2186, cls.cfg.pulp_version):
             raise unittest.SkipTest('https://pulp.plan.io/issues/2186')
         cls.cmd = () if utils.is_root(cls.cfg) else ('sudo',)
         cls.cmd += (
@@ -73,7 +73,7 @@ class PositiveTestCase(BaseTestCase):
 
     def test_dry_run(self):
         """Make sure pulp-manage-db runs if --dry-run is passed."""
-        if selectors.bug_is_untestable(2776, self.cfg.version):
+        if selectors.bug_is_untestable(2776, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2776')
         cmd = () if utils.is_root(self.cfg) else ('sudo',)
         cmd += (
@@ -107,7 +107,7 @@ class NegativeTestCase(BaseTestCase):
 
         This test targets `Pulp #2684 <https://pulp.plan.io/issues/2684>`_.
         """
-        if selectors.bug_is_untestable(2684, self.cfg.version):
+        if selectors.bug_is_untestable(2684, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2684')
         cli.GlobalServiceManager(config.get_config()).stop((
             CONFLICTING_SERVICES.difference(('pulp_resource_manager',))
@@ -119,7 +119,7 @@ class NegativeTestCase(BaseTestCase):
 
         This test targets `Pulp #2684 <https://pulp.plan.io/issues/2684>`_.
         """
-        if selectors.bug_is_untestable(2684, self.cfg.version):
+        if selectors.bug_is_untestable(2684, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2684')
         cli.GlobalServiceManager(config.get_config()).stop((
             CONFLICTING_SERVICES.difference(('pulp_workers',))

--- a/pulp_smash/tests/pulp2/platform/cli/test_selinux.py
+++ b/pulp_smash/tests/pulp2/platform/cli/test_selinux.py
@@ -171,7 +171,7 @@ class FileLabelsTestCase(unittest.TestCase):
             ('/usr/share/pulp/wsgi', ':object_r:httpd_sys_content_t:s0'),
             ('/var/log/pulp', ':object_r:httpd_sys_rw_content_t:s0'),
         ]
-        if selectors.bug_is_testable(2508, config.get_config().version):
+        if selectors.bug_is_testable(2508, config.get_config().pulp_version):
             files_labels.append(
                 ('/var/lib/pulp', ':object_r:httpd_sys_rw_content_t:s0')
             )

--- a/pulp_smash/tests/pulp2/puppet/api_v2/test_install_distributor.py
+++ b/pulp_smash/tests/pulp2/puppet/api_v2/test_install_distributor.py
@@ -86,7 +86,7 @@ class InstallDistributorThrowsOnErrorTestCase(utils.BaseAPITestCase):
         3. Assert that an error is thrown
         4. Assert that no repo is created
         """
-        if selectors.bug_is_untestable(1237, self.cfg.version):
+        if selectors.bug_is_untestable(1237, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/1237')
         distributor = gen_install_distributor()
         distributor['distributor_config']['install_path'] = ''

--- a/pulp_smash/tests/pulp2/puppet/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/pulp2/puppet/api_v2/test_sync_publish.py
@@ -221,7 +221,7 @@ class SyncNoFeedTestCase(utils.BaseAPITestCase):
     def test_all(self):
         """Create and sync a puppet repository with no feed."""
         cfg = config.get_config()
-        if selectors.bug_is_untestable(2628, cfg.version):
+        if selectors.bug_is_untestable(2628, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2628')
 
         # Create a repository.
@@ -368,7 +368,7 @@ class PublishTestCase(utils.BaseAPITestCase):
         cls.responses['puppet releases'] = []
         author_name = PUPPET_MODULE_1['author'] + '/' + PUPPET_MODULE_1['name']
         for repo in repos:
-            if selectors.bug_is_untestable(1440, cls.cfg.version):
+            if selectors.bug_is_untestable(1440, cls.cfg.pulp_version):
                 continue
             cls.responses['puppet releases'].append(client.get(
                 '/api/v1/releases.json',
@@ -380,7 +380,7 @@ class PublishTestCase(utils.BaseAPITestCase):
                 .format(repo['id']),
                 params={'module': author_name},
             ))
-            if cls.cfg.version < Version('2.8'):
+            if cls.cfg.pulp_version < Version('2.8'):
                 continue
             cls.responses['puppet releases'].append(client.get(
                 '/v3/releases',

--- a/pulp_smash/tests/pulp2/puppet/cli/test_sync.py
+++ b/pulp_smash/tests/pulp2/puppet/cli/test_sync.py
@@ -71,7 +71,7 @@ class SyncDownloadedContentTestCase(unittest.TestCase):
         non-zero content unit counts.
         """
         cfg = config.get_config()
-        if selectors.bug_is_untestable(1937, cfg.version):
+        if selectors.bug_is_untestable(1937, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/1937')
         utils.pulp_admin_login(cfg)
 

--- a/pulp_smash/tests/pulp2/python/api_v2/test_duplicate_uploads.py
+++ b/pulp_smash/tests/pulp2/python/api_v2/test_duplicate_uploads.py
@@ -33,8 +33,8 @@ class DuplicateUploadsTestCase(
     def setUpClass(cls):
         """Create a Python repo. Upload a Python package into it twice."""
         super(DuplicateUploadsTestCase, cls).setUpClass()
-        if (cls.cfg.version >= Version('2.11') and
-                selectors.bug_is_untestable(2334, cls.cfg.version)):
+        if (cls.cfg.pulp_version >= Version('2.11') and
+                selectors.bug_is_untestable(2334, cls.cfg.pulp_version)):
             raise unittest.SkipTest('https://pulp.plan.io/issues/2334')
         unit = utils.http_get(PYTHON_EGG_URL)
         import_params = {'unit_type_id': 'python_package'}

--- a/pulp_smash/tests/pulp2/python/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/pulp2/python/api_v2/test_sync_publish.py
@@ -34,7 +34,7 @@ class BaseTestCase(unittest.TestCase):
         cls.repos = []
         if inspect.getmro(cls)[0] == BaseTestCase:
             raise unittest.SkipTest('Abstract base class.')
-        if cls.cfg.version < Version('2.12'):
+        if cls.cfg.pulp_version < Version('2.12'):
             raise unittest.SkipTest('This test requires Pulp 2.12 or newer.')
 
     @classmethod
@@ -65,8 +65,8 @@ class BaseTestCase(unittest.TestCase):
         should be created wherein one Pulp application syncs from another
         completely independent Pulp application.
         """
-        if (self.cfg.version < Version('2.13') or
-                selectors.bug_is_untestable(140, self.cfg.version)):
+        if (self.cfg.pulp_version < Version('2.13') or
+                selectors.bug_is_untestable(140, self.cfg.pulp_version)):
             self.skipTest('https://pulp.plan.io/issues/140')
         client = api.Client(self.cfg, api.json_handler)
         body = gen_repo()
@@ -120,8 +120,8 @@ class SyncTestCase(BaseTestCase):
         * `Pulp #135 <https://pulp.plan.io/issues/135>`_
         * `Pulp Smash #494 <https://github.com/PulpQE/pulp-smash/issues/494>`_
         """
-        if (self.cfg.version < Version('2.13') or
-                selectors.bug_is_untestable(135, self.cfg.version)):
+        if (self.cfg.pulp_version < Version('2.13') or
+                selectors.bug_is_untestable(135, self.cfg.pulp_version)):
             self.skipTest('https://pulp.plan.io/issues/135')
         client = api.Client(self.cfg, api.json_handler)
         body = gen_repo()
@@ -153,8 +153,8 @@ class UploadTestCase(BaseTestCase):
         * `Pulp #2334 <https://pulp.plan.io/issues/2334>`_
         * `Pulp Smash #492 <https://github.com/PulpQE/pulp-smash/issues/492>`_
         """
-        if (self.cfg.version < Version('2.13') or
-                selectors.bug_is_untestable(136, self.cfg.version)):
+        if (self.cfg.pulp_version < Version('2.13') or
+                selectors.bug_is_untestable(136, self.cfg.pulp_version)):
             self.skipTest('https://pulp.plan.io/issues/136')
         client = api.Client(self.cfg, api.json_handler)
         body = gen_repo()

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_broker.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_broker.py
@@ -108,10 +108,10 @@ class BrokerTestCase(unittest.TestCase):
         * `Pulp #1635 <https://pulp.plan.io/issues/1635>`_
         * `Pulp #2613 <https://pulp.plan.io/issues/2613>`_
         """
-        if selectors.bug_is_untestable(1635, self.cfg.version):
+        if selectors.bug_is_untestable(1635, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/1635')
-        if (self.cfg.version >= Version('2.13') and
-                selectors.bug_is_untestable(2613, self.cfg.version)):
+        if (self.cfg.pulp_version >= Version('2.13') and
+                selectors.bug_is_untestable(2613, self.cfg.pulp_version)):
             self.skipTest('https://pulp.plan.io/issues/2613')
         # We assume that the broker and other services are already running. As
         # a result, we skip step 1 and go straight to step 2.

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_character_encoding.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_character_encoding.py
@@ -52,7 +52,7 @@ class UploadNonUtf8TestCase(unittest.TestCase):
     def test_all(self):
         """Test whether one can upload an RPM with non-ascii metadata."""
         cfg = config.get_config()
-        if selectors.bug_is_untestable(1903, cfg.version):
+        if selectors.bug_is_untestable(1903, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/1903')
         client = api.Client(cfg, api.json_handler)
         repo = client.post(REPOSITORY_PATH, gen_repo())

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_comps_xml.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_comps_xml.py
@@ -160,7 +160,7 @@ class SyncRepoTestCase(utils.BaseAPITestCase):
         have = [child.tag for child in self.root_element]
         have.sort()
         want = ['category', 'group', 'group']
-        if self.cfg.version >= Version('2.9'):
+        if self.cfg.pulp_version >= Version('2.9'):
             want.append('langpacks')
         self.assertEqual(have, want)
 
@@ -170,7 +170,7 @@ class SyncRepoTestCase(utils.BaseAPITestCase):
         Support for package langpacks has been added in Pulp 2.9. Consequently,
         this test is skipped on earlier versions of Pulp.
         """
-        if self.cfg.version < Version('2.9'):
+        if self.cfg.pulp_version < Version('2.9'):
             self.skipTest('This test requires Pulp 2.9 or greater.')
         langpacks_elements = self.root_element.findall('langpacks')
         self.assertEqual(len(langpacks_elements), 1, self.xml_as_str)
@@ -327,7 +327,7 @@ class UploadPackageGroupsTestCase(utils.BaseAPITestCase):
 
     def test_display_order_occurences(self):
         """Assert ``display_order`` occurs once if omitted from the unit."""
-        if selectors.bug_is_untestable(1787, self.cfg.version):
+        if selectors.bug_is_untestable(1787, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/1787')
         input_id = self.package_groups['minimal']['id']
         output = _get_groups_by_id(self.root_element)[input_id]
@@ -339,7 +339,7 @@ class UploadPackageGroupsTestCase(utils.BaseAPITestCase):
         This test may be skipped if `Pulp #1787
         <https://pulp.plan.io/issues/1787>`_ is open.
         """
-        if selectors.bug_is_untestable(1787, self.cfg.version):
+        if selectors.bug_is_untestable(1787, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/1787')
         input_id = self.package_groups['minimal']['id']
         output = _get_groups_by_id(self.root_element)[input_id]

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_content_sources.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_content_sources.py
@@ -32,7 +32,7 @@ class ValidHeadersTestCase(unittest.TestCase):
     def setUpClass(cls):
         """Create a content source with valid headers."""
         cls.cfg = config.get_config()
-        if selectors.bug_is_untestable(1282, cls.cfg.version):
+        if selectors.bug_is_untestable(1282, cls.cfg.pulp_version):
             raise unittest.SkipTest('https://pulp.plan.io/issues/1282')
         cls.cs_kwargs = {
             'source_id': utils.uuid4(),
@@ -90,7 +90,7 @@ class InvalidHeadersTestCase(unittest.TestCase):
     def setUpClass(cls):
         """Create a content source with invalid headers."""
         cls.cfg = config.get_config()
-        if selectors.bug_is_untestable(1282, cls.cfg.version):
+        if selectors.bug_is_untestable(1282, cls.cfg.pulp_version):
             raise unittest.SkipTest('https://pulp.plan.io/issues/1282')
         cls.cs_kwargs = {
             'source_id': utils.uuid4(),

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_copy.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_copy.py
@@ -39,7 +39,7 @@ class CopyErrataRecursiveTestCase(unittest.TestCase):
         4. Assert that RPM packages were copied.
         """
         cfg = config.get_config()
-        if selectors.bug_is_untestable(3004, cfg.version):
+        if selectors.bug_is_untestable(3004, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/3004')
 
         repos = []
@@ -88,7 +88,7 @@ class MtimeTestCase(unittest.TestCase):
            are the same.
         """
         cfg = config.get_config()
-        if selectors.bug_is_untestable(2783, cfg.version):
+        if selectors.bug_is_untestable(2783, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2783')
 
         # Create, sync and publish a repository.

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_crud.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_crud.py
@@ -63,7 +63,7 @@ class FeedURLUnquoteTestCase(utils.BaseAPITestCase):
 
     def test_all(self):
         """Ensure Pulp unquote feed URLs."""
-        if self.cfg.version < version.Version('2.11'):
+        if self.cfg.pulp_version < version.Version('2.11'):
             self.skipTest('Feed URL unquoting is available on Pulp 2.11+')
         client = api.Client(self.cfg, api.json_handler)
         body = CrudTestCase.create_body()
@@ -86,7 +86,7 @@ class PulpDistributionTestCase(utils.BaseAPITestCase):
 
     def test_all(self):
         """Check for content synced from a feed with PULP_DISTRIBUTION.xml."""
-        if self.cfg.version < version.Version('2.11.2'):
+        if self.cfg.pulp_version < version.Version('2.11.2'):
             self.skipTest(
                 'PULP_DISTRIBUTION.xml improved parsing is available on Pulp '
                 '2.11.2+'
@@ -209,7 +209,7 @@ class RPMDistributorTestCase(unittest.TestCase):
         See: https://pulp.plan.io/issues/2134.
         """
         cfg = config.get_config()
-        if cfg.version < version.Version('2.9'):
+        if cfg.pulp_version < version.Version('2.9'):
             raise unittest.SkipTest('This test requires Pulp 2.9 or above.')
         client = api.Client(cfg, api.json_handler)
         distributor = gen_distributor()
@@ -273,7 +273,7 @@ class LastUnitAddedTestCase(utils.BaseAPITestCase):
         4. Publish the second repository. Assert its ``last_unit_added``
            attribute is non-null.
         """
-        if selectors.bug_is_untestable(2688, self.cfg.version):
+        if selectors.bug_is_untestable(2688, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2688')
 
         # create a repo with a feed and sync it

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_download_policies.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_download_policies.py
@@ -36,18 +36,18 @@ def setUpModule():  # pylint:disable=invalid-name
     """Skip tests if the RPM plugin is not installed."""
     set_up_module()
     cfg = config.get_config()
-    if cfg.version < Version('2.8'):
+    if cfg.pulp_version < Version('2.8'):
         raise unittest.SkipTest('This module requires Pulp 2.8 or greater.')
     if (utils.os_is_f26(cfg) and
-            selectors.bug_is_untestable(3036, cfg.version)):
+            selectors.bug_is_untestable(3036, cfg.pulp_version)):
         raise unittest.SkipTest('https://pulp.plan.io/issues/3036')
     if check_issue_2798(cfg):
         raise unittest.SkipTest('https://pulp.plan.io/issues/2798')
     if check_issue_2387(cfg):
         raise unittest.SkipTest('https://pulp.plan.io/issues/2387')
-    if selectors.bug_is_untestable(2272, cfg.version):
+    if selectors.bug_is_untestable(2272, cfg.pulp_version):
         raise unittest.SkipTest('https://pulp.plan.io/issues/2272')
-    if selectors.bug_is_untestable(2144, cfg.version):
+    if selectors.bug_is_untestable(2144, cfg.pulp_version):
         raise unittest.SkipTest('https://pulp.plan.io/issues/2144')
 
 
@@ -84,7 +84,7 @@ class BackgroundTestCase(utils.BaseAPITestCase):
         super(BackgroundTestCase, cls).setUpClass()
         if check_issue_3104(cls.cfg):
             raise unittest.SkipTest('https://pulp.plan.io/issues/3104')
-        if (selectors.bug_is_untestable(1905, cls.cfg.version) and
+        if (selectors.bug_is_untestable(1905, cls.cfg.pulp_version) and
                 os_is_rhel6(cls.cfg)):
             raise unittest.SkipTest('https://pulp.plan.io/issues/1905')
 
@@ -212,7 +212,7 @@ class OnDemandTestCase(utils.BaseAPITestCase):
 
     def test_rpm_cache_control_header(self):
         """Assert the request has the Cache-Control header set."""
-        if selectors.bug_is_untestable(2587, self.cfg.version):
+        if selectors.bug_is_untestable(2587, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2587')
         key = 'Cache-Control'
         headers = self.rpm.headers
@@ -231,7 +231,7 @@ class OnDemandTestCase(utils.BaseAPITestCase):
 
     def test_same_rpm_cache_header(self):
         """Assert the second request resulted in a cache hit from Squid."""
-        if selectors.bug_is_untestable(2587, self.cfg.version):
+        if selectors.bug_is_untestable(2587, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2587')
         headers = self.same_rpm.headers
         self.assertIn('HIT', headers['X-Cache-Lookup'], headers)
@@ -255,7 +255,7 @@ class FixFileCorruptionTestCase(utils.BaseAPITestCase):
         7. Trigger a repository download, with unit verification.
         """
         super(FixFileCorruptionTestCase, cls).setUpClass()
-        if (selectors.bug_is_untestable(1905, cls.cfg.version) and
+        if (selectors.bug_is_untestable(1905, cls.cfg.pulp_version) and
                 os_is_rhel6(cls.cfg)):
             raise unittest.SkipTest('https://pulp.plan.io/issues/1905')
 
@@ -316,7 +316,7 @@ class FixFileCorruptionTestCase(utils.BaseAPITestCase):
         # Support for package langpacks has been added in Pulp 2.9. In earlier
         # versions, langpacks are ignored.
         locally_stored_units = 39  # See repo['content_unit_counts']
-        if self.cfg.version >= Version('2.9'):
+        if self.cfg.pulp_version >= Version('2.9'):
             locally_stored_units += 1
         self.assertEqual(
             self.repo_post_download['locally_stored_units'],
@@ -511,7 +511,7 @@ class SwitchPoliciesTestCase(utils.BaseAPITestCase):
 
     def test_background_to_on_demand(self):
         """Check if switching from background to on_demand works."""
-        if selectors.bug_is_untestable(2587, self.cfg.version):
+        if selectors.bug_is_untestable(2587, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2587')
         repo, _ = self.repository_setup('background', 'on_demand')
         self.assert_on_demand(repo)
@@ -523,7 +523,7 @@ class SwitchPoliciesTestCase(utils.BaseAPITestCase):
 
     def test_immediate_to_on_demand(self):
         """Check if switching from immediate to on_demand works."""
-        if selectors.bug_is_untestable(2587, self.cfg.version):
+        if selectors.bug_is_untestable(2587, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2587')
         repo, _ = self.repository_setup('immediate', 'on_demand')
         self.assert_on_demand(repo)

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_duplicate_uploads.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_duplicate_uploads.py
@@ -27,7 +27,7 @@ class DuplicateUploadsTestCase(unittest.TestCase):
         * `Pulp Smash #81 <https://github.com/PulpQE/pulp-smash/issues/81>`_
         * `Pulp #1406 <https://pulp.plan.io/issues/1406>`_
         """
-        if selectors.bug_is_untestable(1406, self.cfg.version):
+        if selectors.bug_is_untestable(1406, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/1406')
         self.do_test(RPM_UNSIGNED_URL, 'rpm', gen_repo())
 
@@ -39,7 +39,7 @@ class DuplicateUploadsTestCase(unittest.TestCase):
         * `Pulp Smash #582 <https://github.com/PulpQE/pulp-smash/issues/582>`_
         * `Pulp #2274 <https://pulp.plan.io/issues/2274>`_
         """
-        if selectors.bug_is_untestable(2274, self.cfg.version):
+        if selectors.bug_is_untestable(2274, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2274')
         body = {
             'id': utils.uuid4(),

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_export.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_export.py
@@ -176,7 +176,7 @@ class BaseExportChecksumTypeTestCase(ExportDirMixin, utils.BaseAPITestCase):
         if inspect.getmro(cls)[0] == BaseExportChecksumTypeTestCase:
             raise unittest.SkipTest('Abstract base class.')
         super(BaseExportChecksumTypeTestCase, cls).setUpClass()
-        if cls.cfg.version < Version('2.9'):
+        if cls.cfg.pulp_version < Version('2.9'):
             raise unittest.SkipTest('This test requires Pulp 2.9 or newer')
         body = gen_repo()
         body['importer_config']['feed'] = RPM_SIGNED_FEED_URL
@@ -422,8 +422,8 @@ class ExportDistributorTestCase(ExportDirMixin, utils.BaseAPITestCase):
         cls.repo = api.Client(cls.cfg).post(REPOSITORY_PATH, body).json()
         cls.resources.add(cls.repo['_href'])
         utils.sync_repo(cls.cfg, cls.repo)
-        if (cls.cfg.version >= Version('2.9') and
-                selectors.bug_is_untestable(1928, cls.cfg.version)):
+        if (cls.cfg.pulp_version >= Version('2.9') and
+                selectors.bug_is_untestable(1928, cls.cfg.pulp_version)):
             cls.distributor = None
         else:
             cls.distributor = _create_distributor(
@@ -478,7 +478,7 @@ class ExportDistributorTestCase(ExportDirMixin, utils.BaseAPITestCase):
             export_dir,
             self.distributor['config']['relative_url'],
         )
-        if self.cfg.version >= Version('2.12'):
+        if self.cfg.pulp_version >= Version('2.12'):
             path = os.path.join(path, 'Packages', RPM[0], RPM)
         else:
             path = os.path.join(path, RPM)

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_force_full.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_force_full.py
@@ -74,8 +74,8 @@ class ForceFullTestCase(utils.BaseAPITestCase):
 
         .. _Pulp #1966: https://pulp.plan.io/issues/1966
         """
-        if (self.cfg.version >= Version('2.9') and
-                selectors.bug_is_untestable(1966, self.cfg.version)):
+        if (self.cfg.pulp_version >= Version('2.9') and
+                selectors.bug_is_untestable(1966, self.cfg.pulp_version)):
             self.skipTest('https://pulp.plan.io/issues/1966')
         call_report = utils.publish_repo(self.cfg, self.repo).json()
         last_task = next(api.poll_spawned_tasks(self.cfg, call_report))
@@ -92,7 +92,7 @@ class ForceFullTestCase(utils.BaseAPITestCase):
 
         .. _Pulp #1938: https://pulp.plan.io/issues/1938
         """
-        if self.cfg.version < Version('2.9'):
+        if self.cfg.pulp_version < Version('2.9'):
             self.skipTest(
                 'This test requires Pulp 2.9. See: '
                 'https://pulp.plan.io/issues/1938'

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_iso_crud.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_iso_crud.py
@@ -203,8 +203,8 @@ class ReadUpdateDeleteTestCase(utils.BaseAPITestCase):
 
     def test_read_distributors(self):
         """Assert each read w/distributors contains info about distributors."""
-        if (self.cfg.version < Version('2.8') and
-                selectors.bug_is_untestable(1452, self.cfg.version)):
+        if (self.cfg.pulp_version < Version('2.8') and
+                selectors.bug_is_untestable(1452, self.cfg.pulp_version)):
             self.skipTest('https://pulp.plan.io/issues/1452')
         for key in {'read_distributors', 'read_details'}:
             with self.subTest(key=key):
@@ -242,8 +242,8 @@ class AddImporterDistributorTestCase(utils.BaseAPITestCase):
         4. Re-read the repository's importers and distributors.
         """
         super(AddImporterDistributorTestCase, cls).setUpClass()
-        if (cls.cfg.version >= Version('2.10') and
-                selectors.bug_is_untestable(2082, cls.cfg.version)):
+        if (cls.cfg.pulp_version >= Version('2.10') and
+                selectors.bug_is_untestable(2082, cls.cfg.pulp_version)):
             raise SkipTest('https://pulp.plan.io/issues/2082')
 
         # Steps 1 and 2.
@@ -334,7 +334,7 @@ class PulpManifestTestCase(utils.BaseAPITestCase):
         Assert that the sync fails with the information that some units were
         not available.
         """
-        if self.cfg.version < Version('2.11'):
+        if self.cfg.pulp_version < Version('2.11'):
             self.skipTest(
                 'Pulp reports 404 for ISO repos only on 2.11 or greater.')
         pulp_manifest = self.parse_pulp_manifest(FILE_MIXED_FEED_URL)

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_iso_sync_publish.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_iso_sync_publish.py
@@ -50,7 +50,7 @@ class ServeHttpsFalseTestCase(TemporaryUserMixin, unittest.TestCase):
 
     def test_all(self):
         """Publish w/an rsync distributor when ``serve_https`` is false."""
-        if selectors.bug_is_untestable(2657, self.cfg.version):
+        if selectors.bug_is_untestable(2657, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2657')
 
         # Create a user with which to rsync files

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_mirrorlist.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_mirrorlist.py
@@ -82,7 +82,7 @@ class UtilsMixin(object):
 
         .. _issue #2277: https://pulp.plan.io/issues/2277
         """
-        if cfg.version < Version('2.11') and check_issue_2277(cfg):
+        if cfg.pulp_version < Version('2.11') and check_issue_2277(cfg):
             self.skipTest('https://pulp.plan.io/issues/2277')
 
     def check_issue_2321(self, cfg):
@@ -90,8 +90,8 @@ class UtilsMixin(object):
 
         .. _issue #2321: https://pulp.plan.io/issues/2321
         """
-        if (cfg.version >= Version('2.11') and
-                selectors.bug_is_untestable(2321, cfg.version)):
+        if (cfg.pulp_version >= Version('2.11') and
+                selectors.bug_is_untestable(2321, cfg.pulp_version)):
             self.skipTest('https://pulp.plan.io/issues/2321')
 
     def check_issue_2326(self, cfg):
@@ -99,8 +99,8 @@ class UtilsMixin(object):
 
         .. _issue #2326: https://pulp.plan.io/issues/2326
         """
-        if (cfg.version >= Version('2.11') and
-                selectors.bug_is_untestable(2326, cfg.version)):
+        if (cfg.pulp_version >= Version('2.11') and
+                selectors.bug_is_untestable(2326, cfg.pulp_version)):
             self.skipTest('https://pulp.plan.io/issues/2326')
 
     def check_issue_2363(self, cfg):
@@ -108,8 +108,8 @@ class UtilsMixin(object):
 
         .. _issue #2363: https://pulp.plan.io/issues/2363
         """
-        if (cfg.version >= Version('2.11') and
-                selectors.bug_is_untestable(2363, cfg.version)):
+        if (cfg.pulp_version >= Version('2.11') and
+                selectors.bug_is_untestable(2363, cfg.pulp_version)):
             self.skipTest('https://pulp.plan.io/issues/2363')
 
 

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_no_op_publish.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_no_op_publish.py
@@ -62,7 +62,7 @@ def setUpModule():  # pylint:disable=invalid-name
     """
     set_up_module()
     cfg = config.get_config()
-    if cfg.version < Version('2.9'):
+    if cfg.pulp_version < Version('2.9'):
         raise unittest.SkipTest('This module requires Pulp 2.9 or greater.')
     if check_issue_2277(cfg):
         raise unittest.SkipTest('https://pulp.plan.io/issues/2277')
@@ -144,7 +144,7 @@ class NoOpPublishMixin(object):
         call_report = self.call_reports[1]
         last_task = next(api.poll_spawned_tasks(self.cfg, call_report))
 
-        if hasattr(self, 'cfg') and self.cfg.version < Version('2.10'):
+        if hasattr(self, 'cfg') and self.cfg.pulp_version < Version('2.10'):
             summary = 'Skipped. Nothing changed since last publish'
         else:
             summary = (

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_orphan_remove.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_orphan_remove.py
@@ -72,7 +72,7 @@ class OrphansTestCase(unittest.TestCase):
         actual_count = _count_orphans(orphans)
         # Support for langpack content units was added in Pulp 2.9.
         expected_count = 39
-        if config.get_config().version >= Version('2.9'):
+        if config.get_config().pulp_version >= Version('2.9'):
             expected_count += 1
         self.assertEqual(actual_count, expected_count, orphans)
         type(self).orphans_available = True
@@ -131,7 +131,7 @@ class OrphansTestCase(unittest.TestCase):
         call_report = client.delete(urljoin(ORPHANS_PATH, 'erratum/'))
         orphans_post = client.get(ORPHANS_PATH)
         with self.subTest(comment='verify "result" field'):
-            if selectors.bug_is_untestable(1268, cfg.version):
+            if selectors.bug_is_untestable(1268, cfg.pulp_version):
                 self.skipTest('https://pulp.plan.io/issues/1268')
             task = tuple(api.poll_spawned_tasks(cfg, call_report))[-1]
             self.assertIsInstance(task['result'], int)
@@ -149,7 +149,7 @@ class OrphansTestCase(unittest.TestCase):
         """Delete all orphans."""
         cfg = config.get_config()
         call_report = api.Client(cfg).delete(ORPHANS_PATH).json()
-        if selectors.bug_is_untestable(1268, cfg.version):
+        if selectors.bug_is_untestable(1268, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/1268')
         task = tuple(api.poll_spawned_tasks(cfg, call_report))[-1]
         self.assertIsInstance(task['result'], dict)

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_package_paths.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_package_paths.py
@@ -82,7 +82,7 @@ class ReuseContentTestCase(unittest.TestCase):
         if check_issue_2354(cfg):
             self.skipTest('https://pulp.plan.io/issues/2354')
         if (utils.os_is_f26(cfg) and
-                selectors.bug_is_untestable(3036, cfg.version)):
+                selectors.bug_is_untestable(3036, cfg.pulp_version)):
             # Here, the calls to get_unit() cause pulp_streamer.service to die
             # without logging out anything. In Pulp #3036, certain actions
             # cause pulp_streamer.service to die while logging out a core dump.

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_remove_unit.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_remove_unit.py
@@ -205,7 +205,7 @@ class RemoveCountTestCase(unittest.TestCase):
         """Re-sync a child repository with the ``remove_missing`` enabled."""
         repos = []
         cfg = config.get_config()
-        if selectors.bug_is_untestable(2616, cfg.version):
+        if selectors.bug_is_untestable(2616, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2616')
 
         # Create 1st repo, sync and publish it.

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_repomd.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_repomd.py
@@ -109,7 +109,7 @@ class FastForwardIntegrityTestCase(unittest.TestCase):
     def test_all(self):
         """Ensure fast-forward publishes use files referenced by repomd.xml."""
         cfg = config.get_config()
-        if selectors.bug_is_untestable(1088, cfg.version):
+        if selectors.bug_is_untestable(1088, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/1088')
         repo = self._create_sync_repo(cfg)
         old_phrase = 'A dummy package of'

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_repository_layout.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_repository_layout.py
@@ -134,7 +134,7 @@ class RepositoryLayoutTestCase(utils.BaseAPITestCase):
         for package_href in package_hrefs:
             with self.subTest(package_href=package_href):
                 dirname = os.path.dirname(package_href)
-                if self.cfg.version < Version('2.12'):
+                if self.cfg.pulp_version < Version('2.12'):
                     self.assertEqual(dirname, '')
                 else:
                     # e.g. 'Packages/a'[:-1] == 'Packages/'

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_repoview.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_repoview.py
@@ -35,7 +35,7 @@ class RepoviewTestCase(unittest.TestCase):
     def test_all(self):
         """Publish a repository with the repoview feature on and off."""
         cfg = config.get_config()
-        if cfg.version < Version('2.9'):
+        if cfg.pulp_version < Version('2.9'):
             self.skipTest('https://pulp.plan.io/issues/189')
 
         # Create a repo, and add content
@@ -74,7 +74,7 @@ class RepoviewTestCase(unittest.TestCase):
             )
 
         # Publish the repo a third time
-        if selectors.bug_is_untestable(2349, cfg.version):
+        if selectors.bug_is_untestable(2349, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2349')
         utils.publish_repo(cfg, repo)
         response = client.get(pub_path)

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_rsync_distributor.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_rsync_distributor.py
@@ -98,7 +98,7 @@ def setUpModule():  # pylint:disable=invalid-name
     """
     set_up_module()
     cfg = config.get_config()
-    if selectors.bug_is_untestable(1759, cfg.version):
+    if selectors.bug_is_untestable(1759, cfg.pulp_version):
         raise unittest.SkipTest('https://pulp.plan.io/issues/1759')
     set_pulp_manage_rsync(cfg, True)
 
@@ -246,7 +246,7 @@ class PublishBeforeYumDistTestCase(
     def test_all(self):
         """Publish the rpm rsync distributor before the yum distributor."""
         cfg = config.get_config()
-        if selectors.bug_is_untestable(2187, cfg.version):
+        if selectors.bug_is_untestable(2187, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2187')
 
         # Create a user and a repository.
@@ -271,7 +271,7 @@ class PublishBeforeYumDistTestCase(
         self.assertNotIn('content', dirs)
 
         # Publish with the rsync distributor again, and verify again.
-        if selectors.bug_is_testable(2722, cfg.version):
+        if selectors.bug_is_testable(2722, cfg.pulp_version):
             self.verify_publish_is_skip(cfg, utils.publish_repo(*args).json())
             dirs = set(cli.Client(cfg).run(cmd).stdout.strip().split('\n'))
             self.assertNotIn('content', dirs)
@@ -349,7 +349,7 @@ class ForceFullTestCase(
 
         # Publish the repo with ``force_full`` set to true. Verify that the RPM
         # rsync distributor placed files.
-        if selectors.bug_is_untestable(2202, cfg.version):
+        if selectors.bug_is_untestable(2202, cfg.pulp_version):
             return
         utils.publish_repo(cfg, repo, {
             'id': distribs['rpm_rsync_distributor']['id'],
@@ -411,7 +411,7 @@ class VerifyOptionsTestCase(_RsyncDistUtilsMixin, unittest.TestCase):
 
     def test_predistributor_id(self):
         """Pass a bogus ID as the ``predistributor_id`` config option."""
-        if selectors.bug_is_untestable(2191, self.cfg.version):
+        if selectors.bug_is_untestable(2191, self.cfg.pulp_version):
             raise self.skipTest('https://pulp.plan.io/issues/2191')
         api_client = api.Client(self.cfg, api.json_handler)
         body = gen_repo()
@@ -434,7 +434,7 @@ class VerifyOptionsTestCase(_RsyncDistUtilsMixin, unittest.TestCase):
 
     def test_root(self):
         """Pass a relative path to the ``root`` configuration option."""
-        if selectors.bug_is_untestable(2192, self.cfg.version):
+        if selectors.bug_is_untestable(2192, self.cfg.pulp_version):
             raise self.skipTest('https://pulp.plan.io/issues/2192')
         remote = self.remote.copy()
         remote['root'] = remote['root'][1:]
@@ -533,7 +533,7 @@ class DeleteTestCase(
     def test_all(self):
         """Use the ``delete`` RPM rsync distributor option."""
         cfg = config.get_config()
-        if selectors.bug_is_untestable(2221, cfg.version):
+        if selectors.bug_is_untestable(2221, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2221')
         api_client = api.Client(cfg)
 
@@ -629,7 +629,7 @@ class AddUnitTestCase(
     def test_all(self):
         """Add a content unit to a repo in the middle of several publishes."""
         cfg = config.get_config()
-        if selectors.bug_is_untestable(2532, cfg.version):
+        if selectors.bug_is_untestable(2532, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2532')
         rpms = (
             utils.http_get(RPM_UNSIGNED_URL), utils.http_get(RPM2_UNSIGNED_URL)
@@ -683,7 +683,7 @@ class PublishTwiceTestCase(
     def test_all(self):
         """Publish with a yum and rsync distributor twice."""
         cfg = config.get_config()
-        if selectors.bug_is_untestable(2666, cfg.version):
+        if selectors.bug_is_untestable(2666, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2666')
         if check_issue_2844(cfg):
             self.skipTest('https://pulp.plan.io/issues/2844')

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_schedule_sync.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_schedule_sync.py
@@ -136,7 +136,7 @@ class CreateFailureTestCase(CreateRepoMixin, utils.BaseAPITestCase):
                 self.responses,
                 self.status_codes):
             if (body == ['Incorrect data type'] and
-                    self.cfg.version < Version('2.8')):
+                    self.cfg.pulp_version < Version('2.8')):
                 continue  # https://pulp.plan.io/issues/1745
             with self.subTest(body=body):
                 self.assertEqual(response.status_code, status_code)

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_service_resiliency.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_service_resiliency.py
@@ -47,7 +47,7 @@ class MissingWorkersTestCase(unittest.TestCase):
     def setUp(self):
         """Ensure there is only one Pulp worker."""
         self.cfg = config.get_config()
-        if selectors.bug_is_untestable(2835, self.cfg.version):
+        if selectors.bug_is_untestable(2835, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2835')
         sudo = '' if utils.is_root(self.cfg) else 'sudo'
         cli.Client(self.cfg).machine.session().run(
@@ -109,7 +109,7 @@ class TaskDispatchTestCase(unittest.TestCase):
            so, and assert that no tasks are left in the ``waiting`` state.
         """
         cfg = config.get_config()
-        if selectors.bug_is_untestable(2770, cfg.version):
+        if selectors.bug_is_untestable(2770, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2770')
 
         # Create a repository.

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_signatures_checked_for_copies.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_signatures_checked_for_copies.py
@@ -49,7 +49,7 @@ _UNSIGNED_PACKAGES = {}
 def setUpModule():  # pylint:disable=invalid-name
     """Conditionally skip tests. Create repositories with fixture data."""
     cfg = config.get_config()
-    if selectors.bug_is_untestable(1991, cfg.version):
+    if selectors.bug_is_untestable(1991, cfg.pulp_version):
         raise unittest.SkipTest('https://pulp.plan.io/issues/1991')
     set_up_module()
 
@@ -58,7 +58,7 @@ def setUpModule():  # pylint:disable=invalid-name
     _SIGNED_PACKAGES['srpm'] = utils.http_get(SRPM_SIGNED_URL)
     _UNSIGNED_PACKAGES['rpm'] = utils.http_get(RPM_UNSIGNED_URL)
     _UNSIGNED_PACKAGES['srpm'] = utils.http_get(SRPM_UNSIGNED_URL)
-    if selectors.bug_is_testable(1806, cfg.version):
+    if selectors.bug_is_testable(1806, cfg.pulp_version):
         _SIGNED_PACKAGES['drpm'] = utils.http_get(DRPM_SIGNED_URL)
         _UNSIGNED_PACKAGES['drpm'] = utils.http_get(DRPM_UNSIGNED_URL)
 

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_signatures_checked_for_syncs.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_signatures_checked_for_syncs.py
@@ -45,9 +45,9 @@ from pulp_smash.tests.pulp2.rpm.utils import set_up_module
 
 def setUpModule():  # pylint:disable=invalid-name
     """Conditionally skip tests."""
-    if selectors.bug_is_untestable(1991, config.get_config().version):
+    if selectors.bug_is_untestable(1991, config.get_config().pulp_version):
         raise unittest.SkipTest('https://pulp.plan.io/issues/1991')
-    if selectors.bug_is_untestable(2242, config.get_config().version):
+    if selectors.bug_is_untestable(2242, config.get_config().pulp_version):
         raise unittest.SkipTest('https://pulp.plan.io/issues/2242')
     set_up_module()
 

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_signatures_checked_for_uploads.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_signatures_checked_for_uploads.py
@@ -79,7 +79,7 @@ def setUpModule():  # pylint:disable=invalid-name
       version of Pulp under test.
     """
     cfg = config.get_config()
-    if selectors.bug_is_untestable(1991, cfg.version):
+    if selectors.bug_is_untestable(1991, cfg.pulp_version):
         raise unittest.SkipTest('https://pulp.plan.io/issues/1991')
     set_up_module()
     try:
@@ -87,7 +87,7 @@ def setUpModule():  # pylint:disable=invalid-name
         _SIGNED_PACKAGES['srpm'] = utils.http_get(SRPM_SIGNED_URL)
         _UNSIGNED_PACKAGES['rpm'] = utils.http_get(RPM_UNSIGNED_URL)
         _UNSIGNED_PACKAGES['srpm'] = utils.http_get(SRPM_UNSIGNED_URL)
-        if selectors.bug_is_testable(1806, cfg.version):
+        if selectors.bug_is_testable(1806, cfg.pulp_version):
             _SIGNED_PACKAGES['drpm'] = utils.http_get(DRPM_SIGNED_URL)
             _UNSIGNED_PACKAGES['drpm'] = utils.http_get(DRPM_UNSIGNED_URL)
     except:  # noqa:E722

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_signatures_saved_for_packages.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_signatures_saved_for_packages.py
@@ -68,7 +68,7 @@ class _BaseTestCase(unittest.TestCase):
         if inspect.getmro(cls)[0] == _BaseTestCase:
             raise unittest.SkipTest('Abstract base class.')
         cls.cfg = config.get_config()
-        if selectors.bug_is_untestable(1156, cls.cfg.version):
+        if selectors.bug_is_untestable(1156, cls.cfg.pulp_version):
             raise unittest.SkipTest('https://pulp.plan.io/issues/1156')
         cls.client = api.Client(cls.cfg, api.json_handler)
 
@@ -129,7 +129,7 @@ class UploadPackageTestCase(_BaseTestCase):
 
     def test_signed_drpm(self):
         """Import a signed DRPM into Pulp. Verify its signature."""
-        if selectors.bug_is_untestable(1806, self.cfg.version):
+        if selectors.bug_is_untestable(1806, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/1806')
         repo_href = self._create_repo_import_unit(DRPM_SIGNED_URL)
         unit = self._find_unit(repo_href, DRPM_SIGNED_URL)
@@ -153,7 +153,7 @@ class UploadPackageTestCase(_BaseTestCase):
 
     def test_unsigned_drpm(self):
         """Import an unsigned DRPM into Pulp. Verify it has no signature."""
-        if selectors.bug_is_untestable(1806, self.cfg.version):
+        if selectors.bug_is_untestable(1806, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/1806')
         repo_href = self._create_repo_import_unit(DRPM_UNSIGNED_URL)
         unit = self._find_unit(repo_href, DRPM_UNSIGNED_URL)

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_sync_publish.py
@@ -113,7 +113,8 @@ class SyncRpmRepoTestCase(SyncRepoBaseTestCase):
             'package_group': 2,
             'package_category': 1,
         }
-        if self.cfg.version >= Version('2.9'):  # langpack support added in 2.9
+        # langpack support was added in 2.9
+        if self.cfg.pulp_version >= Version('2.9'):
             content_unit_counts['package_langpacks'] = 1
         repo = api.Client(self.cfg).get(self.repo['_href']).json()
         self.assertEqual(repo['content_unit_counts'], content_unit_counts)
@@ -389,14 +390,14 @@ class ErrorReportTestCase(unittest.TestCase):
         task = context.exception.task
 
         with self.subTest(comment='check task error description'):
-            if selectors.bug_is_untestable(1376, cfg.version):
+            if selectors.bug_is_untestable(1376, cfg.pulp_version):
                 self.skipTest('https://pulp.plan.io/issues/1376')
             self.assertNotEqual(
                 'Unsupported scheme: ',
                 task['error']['description']
             )
         with self.subTest(comment='check task traceback'):
-            if selectors.bug_is_untestable(1455, cfg.version):
+            if selectors.bug_is_untestable(1455, cfg.pulp_version):
                 self.skipTest('https://pulp.plan.io/issues/1455')
             self.assertIsNotNone(task['traceback'], task)
 

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_tasks.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_tasks.py
@@ -47,11 +47,11 @@ class TasksOperationsTestCase(unittest.TestCase):
         6. Purge tasks.
         """
         cfg = config.get_config()
-        if selectors.bug_is_untestable(1418, cfg.version):
+        if selectors.bug_is_untestable(1418, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/1418')
-        if selectors.bug_is_untestable(1483, cfg.version):
+        if selectors.bug_is_untestable(1483, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/1483')
-        if selectors.bug_is_untestable(1664, cfg.version):
+        if selectors.bug_is_untestable(1664, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/1664')
 
         # Create, sync and publish a repository.

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_unassociate.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_unassociate.py
@@ -94,7 +94,7 @@ class RemoveUnitsTestCase(unittest.TestCase):
             }
             self.assertEqual(removed_ids & remaining_ids, set())
 
-        if selectors.bug_is_testable(2630, self.cfg.version):
+        if selectors.bug_is_testable(2630, self.cfg.pulp_version):
             with self.subTest('last removed unit'):
                 lur_before = self.get_repo_last_unit_removed(repo)
                 time.sleep(1)  # ensure last_unit_removed increments
@@ -188,7 +188,7 @@ class RepublishTestCase(utils.BaseAPITestCase):
         utils.publish_repo(self.cfg, repo_before)
         repo_after = self.get_repo()
         with self.subTest(comment='last_unit_added'):
-            if selectors.bug_is_untestable(1847, self.cfg.version):
+            if selectors.bug_is_untestable(1847, self.cfg.pulp_version):
                 self.skipTest('https://pulp.plan.io/issues/1847')
             pre = repo_before['last_unit_added']
             post = repo_after['last_unit_added']
@@ -221,7 +221,7 @@ class RepublishTestCase(utils.BaseAPITestCase):
         utils.publish_repo(self.cfg, repo_before)
         repo_after = self.get_repo()
         with self.subTest(comment='last_unit_added'):
-            if selectors.bug_is_untestable(1847, self.cfg.version):
+            if selectors.bug_is_untestable(1847, self.cfg.pulp_version):
                 self.skipTest('https://pulp.plan.io/issues/1847')
             pre = parse(repo_before['last_unit_added'])
             post = parse(repo_after['last_unit_added'])
@@ -299,7 +299,7 @@ class SelectiveAssociateTestCase(utils.BaseAPITestCase):
 
     def test_all(self):
         """Check if Pulp only associate missing repo content."""
-        if self.cfg.version < Version('2.11'):
+        if self.cfg.pulp_version < Version('2.11'):
             self.skipTest(
                 'Selective association is available on Pulp 2.11+ see Pulp '
                 '#2457 for more information'

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_updateinfo.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_updateinfo.py
@@ -79,7 +79,7 @@ def setUpModule():  # pylint:disable=invalid-name
     """
     set_up_module()
     cfg = config.get_config()
-    if cfg.version < Version('2.11') and check_issue_2277(cfg):
+    if cfg.pulp_version < Version('2.11') and check_issue_2277(cfg):
         raise unittest.SkipTest('https://pulp.plan.io/issues/2277')
 
 
@@ -239,7 +239,7 @@ class UpdateInfoTestCase(utils.BaseAPITestCase):
         .. _Pulp #1782: https://pulp.plan.io/issues/1782
         .. _Pulp #2032: https://pulp.plan.io/issues/2032
         """
-        if selectors.bug_is_untestable(2032, self.cfg.version):
+        if selectors.bug_is_untestable(2032, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2032')
         erratum = self.errata['full']
         update_element = (
@@ -430,7 +430,7 @@ class PkglistsTestCase(unittest.TestCase):
         cfg = config.get_config()
         if check_issue_3104(cfg):
             self.skipTest('https://pulp.plan.io/issues/3104')
-        if selectors.bug_is_untestable(2227, cfg.version):
+        if selectors.bug_is_untestable(2227, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2277')
 
         # Create, sync and publish a repository.

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_upload_publish.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_upload_publish.py
@@ -49,7 +49,7 @@ class UploadDrpmTestCase(unittest.TestCase):
     def test_all(self):
         """Import a DRPM into a repository and search it for content units."""
         cfg = config.get_config()
-        if selectors.bug_is_untestable(1806, cfg.version):
+        if selectors.bug_is_untestable(1806, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/1806')
         client = api.Client(cfg)
         repo = client.post(REPOSITORY_PATH, gen_repo()).json()
@@ -90,9 +90,9 @@ class UploadDrpmTestCaseWithCheckSumType(utils.BaseAPITestCase):
 
     def test_all(self):
         """Test that uploading DRPM with checksumtype specified works."""
-        if selectors.bug_is_untestable(1806, self.cfg.version):
+        if selectors.bug_is_untestable(1806, self.cfg.pulp_version):
             raise unittest.SkipTest('https://pulp.plan.io/issues/1806')
-        if selectors.bug_is_untestable(2627, self.cfg.version):
+        if selectors.bug_is_untestable(2627, self.cfg.pulp_version):
             raise unittest.SkipTest('https://pulp.plan.io/issues/2627')
         client = api.Client(self.cfg)
         repo = client.post(REPOSITORY_PATH, gen_repo()).json()
@@ -149,7 +149,7 @@ class UploadedDrpmChecksumTypeTestCase(unittest.TestCase):
         with self.subTest(comment='verify checksumtype'):
             self.assertEqual(units[0]['metadata']['checksumtype'], 'md5')
         with self.subTest(comment='verify checksum'):
-            if selectors.bug_is_untestable(2774, cfg.version):
+            if selectors.bug_is_untestable(2774, cfg.pulp_version):
                 self.skipTest('https://pulp.plan.io/issues/2774')
             self.assertEqual(
                 units[0]['metadata']['checksum'],
@@ -326,7 +326,7 @@ class UploadRpmTestCase(utils.BaseAPITestCase):
                 RPM_DATA['metadata']['files'],
             )
 
-        if selectors.bug_is_testable(2754, self.cfg.version):
+        if selectors.bug_is_testable(2754, self.cfg.pulp_version):
             # Test that additional fields are available.
             # Affected by Pulp issue #2754
 

--- a/pulp_smash/tests/pulp2/rpm/api_v2/utils.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/utils.py
@@ -172,7 +172,7 @@ class DisableSELinuxMixin(object):  # pylint:disable=too-few-public-methods
         # We cannot execute `PATH=${PATH}:/usr/sbin which getenforce` because
         # Plumbum does a good job of preventing shell expansions. See:
         # https://github.com/PulpQE/pulp-smash/issues/89
-        if selectors.bug_is_testable(pulp_issue_id, cfg.version):
+        if selectors.bug_is_testable(pulp_issue_id, cfg.pulp_version):
             return
         client = cli.Client(cfg, cli.echo_handler)
         cmd = 'test -e /usr/sbin/getenforce'.split()

--- a/pulp_smash/tests/pulp2/rpm/cli/test_character_encoding.py
+++ b/pulp_smash/tests/pulp2/rpm/cli/test_character_encoding.py
@@ -72,7 +72,7 @@ class UploadNonUtf8TestCase(unittest.TestCase):
     def test_all(self):
         """Test whether one can upload an RPM with non-utf-8 metadata."""
         cfg = config.get_config()
-        if selectors.bug_is_untestable(1903, cfg.version):
+        if selectors.bug_is_untestable(1903, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/1903')
         client = cli.Client(cfg)
 

--- a/pulp_smash/tests/pulp2/rpm/cli/test_copy_units.py
+++ b/pulp_smash/tests/pulp2/rpm/cli/test_copy_units.py
@@ -225,7 +225,7 @@ class CopyLangpacksTestCase(UtilsMixin, unittest.TestCase):
         * A non-zero number of langpacks are present in the target repository.
         """
         cfg = config.get_config()
-        if selectors.bug_is_untestable(1367, cfg.version):
+        if selectors.bug_is_untestable(1367, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/1367')
         repo_id = self.create_repo(cfg)
         completed_proc = cli.Client(cfg).run(

--- a/pulp_smash/tests/pulp2/rpm/cli/test_environments.py
+++ b/pulp_smash/tests/pulp2/rpm/cli/test_environments.py
@@ -30,7 +30,7 @@ class UploadPackageEnvTestCase(unittest.TestCase):
     def setUpClass(cls):
         """Create and sync a repository."""
         cls.cfg = config.get_config()
-        if cls.cfg.version < Version('2.9'):
+        if cls.cfg.pulp_version < Version('2.9'):
             raise unittest.SkipTest('These tests require Pulp 2.9 or above.')
         utils.pulp_admin_login(cls.cfg)
         cls.repo_id = utils.uuid4()

--- a/pulp_smash/tests/pulp2/rpm/cli/test_langpacks.py
+++ b/pulp_smash/tests/pulp2/rpm/cli/test_langpacks.py
@@ -27,7 +27,7 @@ class UploadAndRemoveLangpacksTestCase(unittest.TestCase):
     def setUpClass(cls):
         """Create a repository."""
         cls.cfg = config.get_config()
-        if cls.cfg.version < Version('2.9'):
+        if cls.cfg.pulp_version < Version('2.9'):
             raise unittest.SkipTest('This test requires Pulp 2.9 or greater.')
         cls.client = cli.Client(cls.cfg)
         cls.repo_id = utils.uuid4()

--- a/pulp_smash/tests/pulp2/rpm/cli/test_process_recycling.py
+++ b/pulp_smash/tests/pulp2/rpm/cli/test_process_recycling.py
@@ -69,7 +69,7 @@ class MaxTasksPerChildTestCase(unittest.TestCase):
     def test_all(self):
         """Test Pulp's handling of its ``PULP_MAX_TASKS_PER_CHILD`` setting."""
         cfg = config.get_config()
-        if selectors.bug_is_untestable(2172, cfg.version):
+        if selectors.bug_is_untestable(2172, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2172')
         set_opt = [
             'sed', '-i', '-e',

--- a/pulp_smash/tests/pulp2/rpm/cli/test_sync.py
+++ b/pulp_smash/tests/pulp2/rpm/cli/test_sync.py
@@ -107,7 +107,7 @@ class ForceSyncTestCase(_BaseTestCase):
     def test_all(self):
         """Test whether one can force Pulp to perform a full sync."""
         cfg = config.get_config()
-        if selectors.bug_is_untestable(1982, cfg.version):
+        if selectors.bug_is_untestable(1982, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/1982')
 
         # Create and sync a repository.

--- a/pulp_smash/tests/pulp2/rpm/cli/test_upload.py
+++ b/pulp_smash/tests/pulp2/rpm/cli/test_upload.py
@@ -35,7 +35,7 @@ class UploadDrpmTestCase(unittest.TestCase):
            ``--skip-existing`` flag during the upload. Verify that Pulp skips
            the upload.
         """
-        if selectors.bug_is_untestable(1806, config.get_config().version):
+        if selectors.bug_is_untestable(1806, config.get_config().pulp_version):
             self.skipTest('https://pulp.plan.io/issues/1806')
 
         # Create a repository
@@ -91,7 +91,7 @@ class UploadDrpmTestCase(unittest.TestCase):
            ``--skip-existing`` flag during the upload. Verify that Pulp skips
            the upload.
         """
-        if selectors.bug_is_untestable(2627, config.get_config().version):
+        if selectors.bug_is_untestable(2627, config.get_config().pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2627')
 
         # Create a repository

--- a/pulp_smash/tests/pulp2/rpm/utils.py
+++ b/pulp_smash/tests/pulp2/rpm/utils.py
@@ -21,8 +21,8 @@ def check_issue_2277(cfg):
 
     .. _Pulp #2277: https://pulp.plan.io/issues/2277
     """
-    if (cfg.version >= Version('2.10') and
-            selectors.bug_is_untestable(2277, cfg.version)):
+    if (cfg.pulp_version >= Version('2.10') and
+            selectors.bug_is_untestable(2277, cfg.pulp_version)):
         return True
     return False
 
@@ -34,8 +34,8 @@ def check_issue_2387(cfg):
 
     .. _Pulp #2387: https://pulp.plan.io/issues/2387
     """
-    if (cfg.version >= Version('2.10') and os_is_rhel6(cfg) and
-            selectors.bug_is_untestable(2387, cfg.version)):
+    if (cfg.pulp_version >= Version('2.10') and os_is_rhel6(cfg) and
+            selectors.bug_is_untestable(2387, cfg.pulp_version)):
         return True
     return False
 
@@ -47,8 +47,8 @@ def check_issue_2354(cfg):
 
     .. _Pulp #2354: https://pulp.plan.io/issues/2354
     """
-    if (cfg.version >= Version('2.10') and
-            selectors.bug_is_untestable(2354, cfg.version)):
+    if (cfg.pulp_version >= Version('2.10') and
+            selectors.bug_is_untestable(2354, cfg.pulp_version)):
         return True
     return False
 
@@ -60,8 +60,8 @@ def check_issue_2620(cfg):
 
     .. _Pulp #2620: https://pulp.plan.io/issues/2620
     """
-    if (cfg.version >= Version('2.12') and
-            selectors.bug_is_untestable(2620, cfg.version)):
+    if (cfg.pulp_version >= Version('2.12') and
+            selectors.bug_is_untestable(2620, cfg.pulp_version)):
         return True
     return False
 
@@ -73,8 +73,8 @@ def check_issue_2798(cfg):
 
     .. _Pulp #2798: https://pulp.plan.io/issues/2798
     """
-    return (cfg.version >= Version('2.14') and
-            selectors.bug_is_untestable(2798, cfg.version))
+    return (cfg.pulp_version >= Version('2.14') and
+            selectors.bug_is_untestable(2798, cfg.pulp_version))
 
 
 def check_issue_2844(cfg):
@@ -84,8 +84,8 @@ def check_issue_2844(cfg):
 
     .. _Pulp #2844: https://pulp.plan.io/issues/2844
     """
-    return (cfg.version >= Version('2.14') and
-            selectors.bug_is_untestable(2844, cfg.version))
+    return (cfg.pulp_version >= Version('2.14') and
+            selectors.bug_is_untestable(2844, cfg.pulp_version))
 
 
 def check_issue_3104(cfg):
@@ -95,8 +95,8 @@ def check_issue_3104(cfg):
 
     .. _Pulp #3104: https://pulp.plan.io/issues/3104
     """
-    return (cfg.version >= Version('2.15') and
-            selectors.bug_is_untestable(3104, cfg.version))
+    return (cfg.pulp_version >= Version('2.15') and
+            selectors.bug_is_untestable(3104, cfg.pulp_version))
 
 
 def os_is_rhel6(cfg):

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_repos.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_repos.py
@@ -56,7 +56,7 @@ class CRUDRepoTestCase(unittest.TestCase):
     @selectors.skip_if(bool, 'repo', False)
     def test_03_fully_update_name(self):
         """Update a repository's name using HTTP PUT."""
-        if selectors.bug_is_untestable(3101, self.cfg.version):
+        if selectors.bug_is_untestable(3101, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/3101')
         self.do_fully_update_attr('name')
 
@@ -84,7 +84,7 @@ class CRUDRepoTestCase(unittest.TestCase):
     @selectors.skip_if(bool, 'repo', False)
     def test_03_partially_update_name(self):
         """Update a repository's name using HTTP PATCH."""
-        if selectors.bug_is_untestable(3101, self.cfg.version):
+        if selectors.bug_is_untestable(3101, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/3101')
         self.do_partially_update_attr('name')
 

--- a/pulp_smash/tests/pulp3/utils.py
+++ b/pulp_smash/tests/pulp3/utils.py
@@ -35,10 +35,10 @@ class JWTAuth(AuthBase):  # pylint:disable=too-few-public-methods
 def set_up_module():
     """Skip tests if Pulp 3 isn't under test."""
     cfg = config.get_config()
-    if cfg.version < Version('3'):
+    if cfg.pulp_version < Version('3'):
         raise unittest.SkipTest(
             'These tests are for Pulp 3 or newer, but Pulp {} is under test.'
-            .format(cfg.version)
+            .format(cfg.pulp_version)
         )
 
 

--- a/pulp_smash/utils.py
+++ b/pulp_smash/utils.py
@@ -575,8 +575,8 @@ def os_is_f26(cfg, pulp_system=None):
 def set_up_module():
     """Skip tests if Pulp 2 isn't under test."""
     cfg = config.get_config()
-    if cfg.version >= Version('3'):
+    if cfg.pulp_version >= Version('3'):
         raise unittest.SkipTest(
             'These tests are for Pulp 2, but Pulp {} is under test.'
-            .format(cfg.version)
+            .format(cfg.pulp_version)
         )


### PR DESCRIPTION
This property was useful during a transition period some time back when
the config file format changed. It's no longer needed.