### PR TITLE
Cache JWT authentication tokens

### DIFF
--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_repos.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_repos.py
@@ -18,14 +18,13 @@ class CRUDRepoTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Create class-wide variables."""
-        cls.auth = get_auth()
         cls.cfg = config.get_config()
         cls.repo = {}
 
     def setUp(self):
         """Create an API client."""
         self.client = api.Client(self.cfg, api.code_handler)
-        self.client.request_kwargs['auth'] = self.auth
+        self.client.request_kwargs['auth'] = get_auth()
 
     def test_01_create_repo(self):
         """Create repository."""


### PR DESCRIPTION
Make the `get_auth` function return a cached JWT authentication object
when possible. This makes it possible to call `get_auth` with abandon,
without worrying about generating a huge number of tokens.

The cache used by the function can be easily cleared. This will likely
be useful in the future, when there is code that invalidates JWT tokens,
or that resets Pulp, or so on.