### PR TITLE
Update Authorization header used in JWT.

### DIFF
--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_auth.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_auth.py
@@ -54,7 +54,7 @@ class AuthTestCase(unittest.TestCase):
             'username': self.cfg.pulp_auth[0],
             'password': self.cfg.pulp_auth[1],
         })
-        client.get(BASE_PATH, auth=JWTAuth(token['token'], 'JWT'))
+        client.get(BASE_PATH, auth=JWTAuth(token['token']))
 
     def test_jwt_failure(self):
         """Perform JWT authentication with invalid credentials.

--- a/pulp_smash/tests/pulp3/utils.py
+++ b/pulp_smash/tests/pulp3/utils.py
@@ -106,5 +106,5 @@ def _get_jwt_auth(cfg):
             'username': cfg.pulp_auth[0],
             'password': cfg.pulp_auth[1],
         })
-        _JWT_AUTH = JWTAuth(token['token'], 'JWT')
+        _JWT_AUTH = JWTAuth(token['token'])
     return deepcopy(_JWT_AUTH)


### PR DESCRIPTION
The default authorization header used for JWT was update in Pulp3.
Instead of `JWT`, from now  on the `Bearer` will be standard one used in authorization header.

See: https://pulp.plan.io/issues/3107