### PR TITLE
Move constants related to Pulp2.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -20,6 +20,7 @@ developers, not a gospel.
     api/pulp_smash.selectors
     api/pulp_smash.tests
     api/pulp_smash.tests.pulp2
+    api/pulp_smash.tests.pulp2.constants
     api/pulp_smash.tests.pulp2.docker
     api/pulp_smash.tests.pulp2.docker.api_v2
     api/pulp_smash.tests.pulp2.docker.api_v2.test_copy

--- a/docs/api/pulp_smash.tests.pulp2.constants.rst
+++ b/docs/api/pulp_smash.tests.pulp2.constants.rst
@@ -1,0 +1,6 @@
+`pulp_smash.tests.pulp2.constants`
+==================================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.pulp2.constants`
+
+.. automodule:: pulp_smash.tests.pulp2.constants

--- a/pulp_smash/constants.py
+++ b/pulp_smash/constants.py
@@ -25,61 +25,6 @@ The last 32 bits (8 characters) of the key ID are what Pulp wants — in this
 example, 269D9D98.
 """
 
-CALL_REPORT_KEYS = frozenset(('error', 'result', 'spawned_tasks'))
-"""See: `Call Report`_.
-
-.. _Call Report:
-    http://docs.pulpproject.org/en/latest/dev-guide/conventions/sync-v-async.html#call-report
-"""
-
-CONSUMERS_PATH = '/pulp/api/v2/consumers/'
-"""See: `Consumer APIs`_.
-
-.. _Consumer APIs:
-    https://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/consumer/index.html
-"""
-
-CONSUMERS_ACTIONS_CONTENT_REGENERATE_APPLICABILITY_PATH = urljoin(
-    CONSUMERS_PATH,
-    'actions/content/regenerate_applicability/',
-)
-"""See: `Content Applicability`_.
-
-.. _Content Applicability:
-    http://docs.pulpproject.org/dev-guide/integration/rest-api/consumer/applicability.html
-"""
-
-CONSUMERS_CONTENT_APPLICABILITY_PATH = urljoin(
-    CONSUMERS_PATH,
-    'content/applicability/',
-)
-"""See: `Content Applicability`_.
-
-.. _Content Applicability:
-    http://docs.pulpproject.org/dev-guide/integration/rest-api/consumer/applicability.html
-"""
-
-CONTENT_SOURCES_PATH = '/etc/pulp/content/sources/conf.d'
-"""See: `Content Sources`_.
-
-.. _Content Sources:
-    https://docs.pulpproject.org/user-guide/content-sources.html
-"""
-
-CONTENT_UNITS_PATH = '/pulp/api/v2/content/units/'
-"""See: `Search for Units`_.
-
-.. _Search for Units:
-    http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/content/units.html#search-for-units
-"""
-
-CONTENT_UPLOAD_PATH = '/pulp/api/v2/content/uploads/'
-"""See: `Creating an Upload Request`_.
-
-.. _Creating an Upload Request:
-   http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/content/upload.html#creating-an-upload-request
-"""
-
 DOCKER_IMAGE_URL = urljoin(PULP_FIXTURES_BASE_URL, 'docker/busybox:latest.tar')
 """The URL to a Docker image as created by ``docker save``."""
 
@@ -180,51 +125,6 @@ FILE_MIXED_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'file-mixed/')
 FILE_URL = urljoin(FILE_FEED_URL, '1.iso')
 """The URL to an ISO file at :data:`FILE_FEED_URL`."""
 
-ERROR_KEYS = frozenset((
-    '_href',
-    'error',
-    'error_message',
-    'exception',
-    'http_status',
-    'traceback',
-))
-"""See: `Exception Handling`_.
-
-No ``href`` field should be present. See `Issue #1310`_.
-
-.. _Exception Handling:
-    https://docs.pulpproject.org/en/latest/dev-guide/conventions/exceptions.html
-.. _Issue #1310: https://pulp.plan.io/issues/1310
-"""
-
-GROUP_CALL_REPORT_KEYS = frozenset(('_href', 'group_id'))
-"""See: `Group Call Report`_.
-
-.. _Group Call Report:
-    http://docs.pulpproject.org/en/latest/dev-guide/conventions/sync-v-async.html#group-call-report
-"""
-
-LOGIN_KEYS = frozenset(('certificate', 'key'))
-"""See: `User Certificates`_.
-
-.. _User Certificates:
-    http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/authentication.html#user-certificates
-"""
-
-LOGIN_PATH = '/pulp/api/v2/actions/login/'
-"""See: `Authentication`_.
-
-.. _Authentication:
-    https://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/authentication.html
-"""
-
-ORPHANS_PATH = 'pulp/api/v2/content/orphans/'
-"""See: `Orphaned Content`_.
-
-.. _Orphaned Content:
-    http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/content/orphan.html
-"""
-
 OSTREE_BRANCHES = ['rawhide', 'stable']
 """A branch in :data:`OSTREE_FEED`. See OSTree `Importer Configuration`_.
 
@@ -237,28 +137,6 @@ OSTREE_FEED = urljoin(PULP_FIXTURES_BASE_URL, 'ostree/small/')
 
 .. _Importer Configuration:
     http://docs.pulpproject.org/plugins/pulp_ostree/tech-reference/importer.html
-"""
-
-PLUGIN_TYPES_PATH = '/pulp/api/v2/plugins/types/'
-"""See: `Retrieve All Content Unit Types`_.
-
-.. _Retrieve All Content Unit Types:
-   http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/server_plugins.html#retrieve-all-content-unit-types
-"""
-
-PULP_SERVICES = {
-    'httpd',
-    'pulp_celerybeat',
-    'pulp_resource_manager',
-    'pulp_workers',
-}
-"""Core Pulp services.
-
-There are services beyond just these that Pulp depends on in order to function
-correctly. For example, an AMQP broker such as RabbitMQ or Qpid is integral to
-Pulp's functioning. However, if resetting Pulp (such as in
-:func:`pulp_smash.utils.reset_pulp`), this is the set of services that should
-be restarted.
 """
 
 PUPPET_MODULE_1 = {
@@ -353,34 +231,6 @@ PYTHON_WHEEL_URL = urljoin(
     'bf/shelf_reader-0.1-py2-none-any.whl'
 )
 """The URL to a Python egg at :data:`PYTHON_PYPI_FEED_URL`."""
-
-REPOSITORY_EXPORT_DISTRIBUTOR = 'export_distributor'
-"""A ``distributor_type_id`` to export a repository.
-
-See: `Export Distributors
-<https://docs.pulpproject.org/plugins/pulp_rpm/tech-reference/export-distributor.html>`_.
-"""
-
-REPOSITORY_GROUP_EXPORT_DISTRIBUTOR = 'group_export_distributor'
-"""A ``distributor_type_id`` to export a repository group.
-
-See: `Export Distributors
-<https://docs.pulpproject.org/plugins/pulp_rpm/tech-reference/export-distributor.html>`_.
-"""
-
-REPOSITORY_GROUP_PATH = '/pulp/api/v2/repo_groups/'
-"""See: `Repository Group APIs`_
-
-.. _Repository Group APIs:
-    http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/repo/groups/index.html
-"""
-
-REPOSITORY_PATH = '/pulp/api/v2/repositories/'
-"""See: `Repository APIs`_.
-
-.. _Repository APIs:
-    https://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/repo/index.html
-"""
 
 RPM_DATA = MappingProxyType({
     'name': 'bear',
@@ -692,18 +542,4 @@ SRPM_UNSIGNED_URL = urljoin(SRPM_UNSIGNED_FEED_URL, SRPM)
 """The URL to an unsigned SRPM file.
 
 Built from :data:`SRPM_UNSIGNED_FEED_URL` and :data:`SRPM`.
-"""
-
-TASKS_PATH = '/pulp/api/v2/tasks/'
-"""See: `Tasks APIs`_.
-
-.. _Tasks APIs:
-    https://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/tasks.html
-"""
-
-USER_PATH = '/pulp/api/v2/users/'
-"""See: `User APIs`_.
-
-.. _User APIs:
-    https://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/user/index.html
 """

--- a/pulp_smash/tests/pulp2/constants.py
+++ b/pulp_smash/tests/pulp2/constants.py
@@ -1,0 +1,169 @@
+# coding=utf-8
+"""Constants for Pulp 2 tests."""
+
+from urllib.parse import urljoin
+
+
+CALL_REPORT_KEYS = frozenset(('error', 'result', 'spawned_tasks'))
+"""See: `Call Report`_.
+
+.. _Call Report:
+    http://docs.pulpproject.org/en/latest/dev-guide/conventions/sync-v-async.html#call-report
+"""
+
+CONSUMERS_PATH = '/pulp/api/v2/consumers/'
+"""See: `Consumer APIs`_.
+
+.. _Consumer APIs:
+    https://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/consumer/index.html
+"""
+
+CONSUMERS_ACTIONS_CONTENT_REGENERATE_APPLICABILITY_PATH = urljoin(
+    CONSUMERS_PATH,
+    'actions/content/regenerate_applicability/',
+)
+"""See: `Content Applicability`_.
+
+.. _Content Applicability:
+    http://docs.pulpproject.org/dev-guide/integration/rest-api/consumer/applicability.html
+"""
+
+CONSUMERS_CONTENT_APPLICABILITY_PATH = urljoin(
+    CONSUMERS_PATH,
+    'content/applicability/',
+)
+"""See: `Content Applicability`_.
+
+.. _Content Applicability:
+    http://docs.pulpproject.org/dev-guide/integration/rest-api/consumer/applicability.html
+"""
+
+CONTENT_SOURCES_PATH = '/etc/pulp/content/sources/conf.d'
+"""See: `Content Sources`_.
+
+.. _Content Sources:
+    https://docs.pulpproject.org/user-guide/content-sources.html
+"""
+
+CONTENT_UNITS_PATH = '/pulp/api/v2/content/units/'
+"""See: `Search for Units`_.
+
+.. _Search for Units:
+    http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/content/units.html#search-for-units
+"""
+
+CONTENT_UPLOAD_PATH = '/pulp/api/v2/content/uploads/'
+"""See: `Creating an Upload Request`_.
+
+.. _Creating an Upload Request:
+   http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/content/upload.html#creating-an-upload-request
+"""
+
+ERROR_KEYS = frozenset((
+    '_href',
+    'error',
+    'error_message',
+    'exception',
+    'http_status',
+    'traceback',
+))
+"""See: `Exception Handling`_.
+
+No ``href`` field should be present. See `Issue #1310`_.
+
+.. _Exception Handling:
+    https://docs.pulpproject.org/en/latest/dev-guide/conventions/exceptions.html
+.. _Issue #1310: https://pulp.plan.io/issues/1310
+"""
+
+GROUP_CALL_REPORT_KEYS = frozenset(('_href', 'group_id'))
+"""See: `Group Call Report`_.
+
+.. _Group Call Report:
+    http://docs.pulpproject.org/en/latest/dev-guide/conventions/sync-v-async.html#group-call-report
+"""
+
+LOGIN_KEYS = frozenset(('certificate', 'key'))
+"""See: `User Certificates`_.
+
+.. _User Certificates:
+    http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/authentication.html#user-certificates
+"""
+
+LOGIN_PATH = '/pulp/api/v2/actions/login/'
+"""See: `Authentication`_.
+
+.. _Authentication:
+    https://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/authentication.html
+"""
+
+ORPHANS_PATH = 'pulp/api/v2/content/orphans/'
+"""See: `Orphaned Content`_.
+
+.. _Orphaned Content:
+    http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/content/orphan.html
+"""
+
+PLUGIN_TYPES_PATH = '/pulp/api/v2/plugins/types/'
+"""See: `Retrieve All Content Unit Types`_.
+
+.. _Retrieve All Content Unit Types:
+   http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/server_plugins.html#retrieve-all-content-unit-types
+"""
+
+PULP_SERVICES = {
+    'httpd',
+    'pulp_celerybeat',
+    'pulp_resource_manager',
+    'pulp_workers',
+}
+"""Core Pulp services.
+
+There are services beyond just these that Pulp depends on in order to function
+correctly. For example, an AMQP broker such as RabbitMQ or Qpid is integral to
+Pulp's functioning. However, if resetting Pulp (such as in
+:func:`pulp_smash.utils.reset_pulp`), this is the set of services that should
+be restarted.
+"""
+
+REPOSITORY_EXPORT_DISTRIBUTOR = 'export_distributor'
+"""A ``distributor_type_id`` to export a repository.
+
+See: `Export Distributors
+<https://docs.pulpproject.org/plugins/pulp_rpm/tech-reference/export-distributor.html>`_.
+"""
+
+REPOSITORY_GROUP_EXPORT_DISTRIBUTOR = 'group_export_distributor'
+"""A ``distributor_type_id`` to export a repository group.
+
+See: `Export Distributors
+<https://docs.pulpproject.org/plugins/pulp_rpm/tech-reference/export-distributor.html>`_.
+"""
+
+REPOSITORY_GROUP_PATH = '/pulp/api/v2/repo_groups/'
+"""See: `Repository Group APIs`_
+
+.. _Repository Group APIs:
+    http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/repo/groups/index.html
+"""
+
+REPOSITORY_PATH = '/pulp/api/v2/repositories/'
+"""See: `Repository APIs`_.
+
+.. _Repository APIs:
+    https://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/repo/index.html
+"""
+
+TASKS_PATH = '/pulp/api/v2/tasks/'
+"""See: `Tasks APIs`_.
+
+.. _Tasks APIs:
+    https://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/tasks.html
+"""
+
+USER_PATH = '/pulp/api/v2/users/'
+"""See: `User APIs`_.
+
+.. _User APIs:
+    https://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/user/index.html
+"""

--- a/pulp_smash/tests/pulp2/docker/api_v2/test_copy.py
+++ b/pulp_smash/tests/pulp2/docker/api_v2/test_copy.py
@@ -4,11 +4,8 @@ import unittest
 from urllib.parse import urljoin
 
 from pulp_smash import api, config, selectors, utils
-from pulp_smash.constants import (
-    DOCKER_V1_FEED_URL,
-    DOCKER_V2_FEED_URL,
-    REPOSITORY_PATH,
-)
+from pulp_smash.constants import DOCKER_V1_FEED_URL, DOCKER_V2_FEED_URL
+from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.docker.api_v2.utils import gen_repo
 from pulp_smash.tests.pulp2.docker.utils import get_upstream_name
 from pulp_smash.tests.pulp2.docker.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import

--- a/pulp_smash/tests/pulp2/docker/api_v2/test_crud.py
+++ b/pulp_smash/tests/pulp2/docker/api_v2/test_crud.py
@@ -10,7 +10,7 @@ from urllib.parse import urljoin
 from packaging.version import Version
 
 from pulp_smash import api, config, utils
-from pulp_smash.constants import REPOSITORY_PATH
+from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.docker.api_v2.utils import gen_repo
 from pulp_smash.tests.pulp2.docker.utils import set_up_module
 

--- a/pulp_smash/tests/pulp2/docker/api_v2/test_duplicate_uploads.py
+++ b/pulp_smash/tests/pulp2/docker/api_v2/test_duplicate_uploads.py
@@ -15,7 +15,8 @@ The second upload should silently fail for all Pulp releases in the 2.x series.
 .. _Pulp Smash #81: https://github.com/PulpQE/pulp-smash/issues/81
 """
 from pulp_smash import api, utils
-from pulp_smash.constants import DOCKER_IMAGE_URL, REPOSITORY_PATH
+from pulp_smash.constants import DOCKER_IMAGE_URL
+from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.docker.api_v2.utils import gen_repo
 from pulp_smash.tests.pulp2.docker.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 

--- a/pulp_smash/tests/pulp2/docker/api_v2/test_sync.py
+++ b/pulp_smash/tests/pulp2/docker/api_v2/test_sync.py
@@ -6,11 +6,8 @@ from urllib.parse import urljoin
 from packaging.version import Version
 
 from pulp_smash import api, config, selectors, utils
-from pulp_smash.constants import (
-    DOCKER_V1_FEED_URL,
-    DOCKER_V2_FEED_URL,
-    REPOSITORY_PATH,
-)
+from pulp_smash.constants import DOCKER_V1_FEED_URL, DOCKER_V2_FEED_URL
+from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.docker.api_v2.utils import gen_repo
 from pulp_smash.tests.pulp2.docker.utils import (
     get_upstream_name,

--- a/pulp_smash/tests/pulp2/docker/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/pulp2/docker/api_v2/test_sync_publish.py
@@ -7,11 +7,8 @@ from jsonschema import validate
 from packaging.version import Version
 
 from pulp_smash import api, cli, config, selectors, utils
-from pulp_smash.constants import (
-    DOCKER_V1_FEED_URL,
-    DOCKER_V2_FEED_URL,
-    REPOSITORY_PATH,
-)
+from pulp_smash.constants import DOCKER_V1_FEED_URL, DOCKER_V2_FEED_URL
+from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.docker.api_v2.utils import (
     gen_distributor,
     gen_repo,

--- a/pulp_smash/tests/pulp2/docker/api_v2/test_tags.py
+++ b/pulp_smash/tests/pulp2/docker/api_v2/test_tags.py
@@ -8,10 +8,9 @@ from urllib.parse import urljoin
 from packaging.version import Version
 
 from pulp_smash import api, config, utils
-from pulp_smash.constants import (
+from pulp_smash.constants import DOCKER_V1_FEED_URL, DOCKER_V2_FEED_URL
+from pulp_smash.tests.pulp2.constants import (
     CONTENT_UPLOAD_PATH,
-    DOCKER_V1_FEED_URL,
-    DOCKER_V2_FEED_URL,
     REPOSITORY_PATH,
 )
 from pulp_smash.exceptions import TaskReportError

--- a/pulp_smash/tests/pulp2/ostree/api_v2/test_copy.py
+++ b/pulp_smash/tests/pulp2/ostree/api_v2/test_copy.py
@@ -5,7 +5,8 @@ import unittest
 from urllib.parse import urljoin
 
 from pulp_smash import api, config, utils
-from pulp_smash.constants import OSTREE_BRANCHES, OSTREE_FEED, REPOSITORY_PATH
+from pulp_smash.constants import OSTREE_BRANCHES, OSTREE_FEED
+from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.ostree.utils import gen_distributor, gen_repo
 from pulp_smash.tests.pulp2.ostree.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 

--- a/pulp_smash/tests/pulp2/ostree/api_v2/test_crud.py
+++ b/pulp_smash/tests/pulp2/ostree/api_v2/test_crud.py
@@ -12,7 +12,7 @@ from packaging.version import Version
 from requests.exceptions import HTTPError
 
 from pulp_smash import api, exceptions, selectors, utils
-from pulp_smash.constants import REPOSITORY_PATH
+from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.ostree.utils import gen_repo
 from pulp_smash.tests.pulp2.ostree.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 

--- a/pulp_smash/tests/pulp2/ostree/api_v2/test_publish.py
+++ b/pulp_smash/tests/pulp2/ostree/api_v2/test_publish.py
@@ -3,7 +3,8 @@
 import unittest
 
 from pulp_smash import api, config, utils
-from pulp_smash.constants import OSTREE_BRANCHES, OSTREE_FEED, REPOSITORY_PATH
+from pulp_smash.constants import OSTREE_BRANCHES, OSTREE_FEED
+from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.ostree.utils import gen_distributor, gen_repo
 from pulp_smash.tests.pulp2.ostree.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 

--- a/pulp_smash/tests/pulp2/ostree/api_v2/test_sync.py
+++ b/pulp_smash/tests/pulp2/ostree/api_v2/test_sync.py
@@ -10,7 +10,8 @@ import unittest
 from urllib.parse import urljoin
 
 from pulp_smash import api, selectors, utils
-from pulp_smash.constants import OSTREE_FEED, OSTREE_BRANCHES, REPOSITORY_PATH
+from pulp_smash.constants import OSTREE_FEED, OSTREE_BRANCHES
+from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.ostree.utils import gen_repo
 from pulp_smash.tests.pulp2.ostree.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 

--- a/pulp_smash/tests/pulp2/platform/api_v2/test_consumer.py
+++ b/pulp_smash/tests/pulp2/platform/api_v2/test_consumer.py
@@ -8,7 +8,7 @@ import unittest
 from urllib.parse import urljoin
 
 from pulp_smash import api, config, utils
-from pulp_smash.constants import CONSUMERS_PATH, REPOSITORY_PATH
+from pulp_smash.tests.pulp2.constants import CONSUMERS_PATH, REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_repo, gen_distributor
 from pulp_smash.tests.pulp2.platform.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 

--- a/pulp_smash/tests/pulp2/platform/api_v2/test_content_applicability.py
+++ b/pulp_smash/tests/pulp2/platform/api_v2/test_content_applicability.py
@@ -6,9 +6,10 @@ call report and starts executing tasks in series. Starting with Pulp 2.8, it is
 possible for a user to explicitly request that Pulp execute tasks in parallel
 instead. This functionality is only available for certain API calls, and when
 this is done, Pulp returns a group call report instead of a regular call
-report.  (See :data:`pulp_smash.constants.CALL_REPORT_KEYS` and
-:data:`pulp_smash.constants.GROUP_CALL_REPORT_KEYS`.) :class:`SeriesTestCase`
-and :class:`ParallelTestCase` test these two use cases, respectively.
+report.  (See :data:`pulp_smash.tests.pulp2.constants.CALL_REPORT_KEYS` and
+:data:`pulp_smash.tests.pulp2.constants.GROUP_CALL_REPORT_KEYS`.)
+:class:`SeriesTestCase` and :class:`ParallelTestCase` test these two use
+cases, respectively.
 
 .. _content applicability:
     https://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/consumer/applicability.html
@@ -19,7 +20,10 @@ import unittest
 from packaging.version import Version
 
 from pulp_smash import api, config
-from pulp_smash.constants import CALL_REPORT_KEYS, GROUP_CALL_REPORT_KEYS
+from pulp_smash.tests.pulp2.constants import (
+    CALL_REPORT_KEYS,
+    GROUP_CALL_REPORT_KEYS,
+)
 from pulp_smash.tests.pulp2.platform.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 _PATHS = {

--- a/pulp_smash/tests/pulp2/platform/api_v2/test_login.py
+++ b/pulp_smash/tests/pulp2/platform/api_v2/test_login.py
@@ -83,7 +83,11 @@
 import unittest
 
 from pulp_smash import api, config, selectors
-from pulp_smash.constants import ERROR_KEYS, LOGIN_KEYS, LOGIN_PATH
+from pulp_smash.tests.pulp2.constants import (
+    ERROR_KEYS,
+    LOGIN_KEYS,
+    LOGIN_PATH,
+)
 from pulp_smash.tests.pulp2.platform.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 

--- a/pulp_smash/tests/pulp2/platform/api_v2/test_repository.py
+++ b/pulp_smash/tests/pulp2/platform/api_v2/test_repository.py
@@ -19,7 +19,7 @@ from urllib.parse import urljoin, urlparse
 from packaging.version import Version
 
 from pulp_smash import api, utils
-from pulp_smash.constants import REPOSITORY_PATH, ERROR_KEYS
+from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH, ERROR_KEYS
 from pulp_smash.selectors import bug_is_untestable, require
 from pulp_smash.tests.pulp2.platform.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 

--- a/pulp_smash/tests/pulp2/platform/api_v2/test_search.py
+++ b/pulp_smash/tests/pulp2/platform/api_v2/test_search.py
@@ -30,7 +30,7 @@ import random
 import unittest
 
 from pulp_smash import api, config, selectors, utils
-from pulp_smash.constants import USER_PATH
+from pulp_smash.tests.pulp2.constants import USER_PATH
 from pulp_smash.tests.pulp2.platform.utils import set_up_module
 
 

--- a/pulp_smash/tests/pulp2/platform/api_v2/test_user.py
+++ b/pulp_smash/tests/pulp2/platform/api_v2/test_user.py
@@ -14,7 +14,7 @@ The assumptions explored in this module have the following dependencies::
     https://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/user/index.html
 """
 from pulp_smash import api, utils
-from pulp_smash.constants import LOGIN_PATH, USER_PATH
+from pulp_smash.tests.pulp2.constants import LOGIN_PATH, USER_PATH
 from pulp_smash.tests.pulp2.platform.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 

--- a/pulp_smash/tests/pulp2/puppet/api_v2/test_duplicate_uploads.py
+++ b/pulp_smash/tests/pulp2/puppet/api_v2/test_duplicate_uploads.py
@@ -15,7 +15,8 @@ The second upload should silently fail for all Pulp releases in the 2.x series.
 .. _Pulp Smash #81: https://github.com/PulpQE/pulp-smash/issues/81
 """
 from pulp_smash import api, utils
-from pulp_smash.constants import PUPPET_MODULE_URL_1, REPOSITORY_PATH
+from pulp_smash.constants import PUPPET_MODULE_URL_1
+from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.puppet.api_v2.utils import gen_repo
 from pulp_smash.tests.pulp2.puppet.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 

--- a/pulp_smash/tests/pulp2/puppet/api_v2/test_install_distributor.py
+++ b/pulp_smash/tests/pulp2/puppet/api_v2/test_install_distributor.py
@@ -9,11 +9,8 @@ For more information check `puppet_install_distributor`_
 from requests.exceptions import HTTPError
 
 from pulp_smash import api, cli, utils, selectors
-from pulp_smash.constants import (
-    PUPPET_MODULE_1,
-    PUPPET_MODULE_URL_1,
-    REPOSITORY_PATH,
-)
+from pulp_smash.constants import PUPPET_MODULE_1, PUPPET_MODULE_URL_1
+from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.puppet.api_v2.utils import (
     gen_install_distributor,
     gen_repo,

--- a/pulp_smash/tests/pulp2/puppet/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/pulp2/puppet/api_v2/test_sync_publish.py
@@ -12,15 +12,17 @@ from requests.exceptions import HTTPError
 
 from pulp_smash import api, config, exceptions, selectors, utils
 from pulp_smash.constants import (
-    CALL_REPORT_KEYS,
-    CONTENT_UPLOAD_PATH,
     PUPPET_FEED_2,
     PUPPET_MODULE_1,
     PUPPET_MODULE_2,
     PUPPET_MODULE_URL_1,
     PUPPET_MODULE_URL_2,
     PUPPET_QUERY_2,
-    REPOSITORY_PATH,
+)
+from pulp_smash.tests.pulp2.constants import (
+    CALL_REPORT_KEYS,
+    CONTENT_UPLOAD_PATH,
+    REPOSITORY_PATH
 )
 from pulp_smash.tests.pulp2.puppet.api_v2.utils import (
     gen_distributor,

--- a/pulp_smash/tests/pulp2/python/api_v2/test_duplicate_uploads.py
+++ b/pulp_smash/tests/pulp2/python/api_v2/test_duplicate_uploads.py
@@ -19,7 +19,8 @@ import unittest
 from packaging.version import Version
 
 from pulp_smash import api, selectors, utils
-from pulp_smash.constants import PYTHON_EGG_URL, REPOSITORY_PATH
+from pulp_smash.constants import PYTHON_EGG_URL
+from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.python.api_v2.utils import gen_repo
 from pulp_smash.tests.pulp2.python.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 

--- a/pulp_smash/tests/pulp2/python/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/pulp2/python/api_v2/test_sync_publish.py
@@ -8,6 +8,10 @@ from urllib.parse import urljoin, urlparse
 from packaging.version import Version
 
 from pulp_smash import api, config, constants, selectors, utils
+from pulp_smash.tests.pulp2.constants import (
+    REPOSITORY_PATH,
+    ORPHANS_PATH,
+)
 from pulp_smash.tests.pulp2.python.api_v2.utils import (
     gen_distributor,
     gen_repo,
@@ -43,7 +47,7 @@ class BaseTestCase(unittest.TestCase):
         client = api.Client(cls.cfg)
         for repo in cls.repos:
             client.delete(repo['_href'])
-        client.delete(constants.ORPHANS_PATH)
+        client.delete(ORPHANS_PATH)
 
     def test_01_first_repo(self):
         """Create, populate and publish a Python repository.
@@ -74,7 +78,7 @@ class BaseTestCase(unittest.TestCase):
             'feed': get_repo_path(self.cfg, self.repos[0]),
             'package_names': 'shelf-reader',
         }
-        repo = client.post(constants.REPOSITORY_PATH, body)
+        repo = client.post(REPOSITORY_PATH, body)
         self.repos.append(repo)
         call_report = utils.sync_repo(self.cfg, repo)
         with self.subTest(comment='verify the sync succeeded'):
@@ -130,7 +134,7 @@ class SyncTestCase(BaseTestCase):
             'package_names': 'shelf-reader',
         }
         body['distributors'] = [gen_distributor()]
-        repo = client.post(constants.REPOSITORY_PATH, body)
+        repo = client.post(REPOSITORY_PATH, body)
         self.repos.append(repo)
         call_report = utils.sync_repo(self.cfg, repo)
         with self.subTest(comment='verify the sync succeeded'):
@@ -159,7 +163,7 @@ class UploadTestCase(BaseTestCase):
         client = api.Client(self.cfg, api.json_handler)
         body = gen_repo()
         body['distributors'] = [gen_distributor()]
-        repo = client.post(constants.REPOSITORY_PATH, body)
+        repo = client.post(REPOSITORY_PATH, body)
         self.repos.append(repo)
 
         # A for loop is easier, but it produces hard-to-debug test failures.

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_broker.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_broker.py
@@ -31,12 +31,11 @@ from packaging.version import Version
 
 from pulp_smash import api, cli, config, selectors, utils
 from pulp_smash.constants import (
-    PULP_SERVICES,
-    REPOSITORY_PATH,
     RPM,
     RPM_SIGNED_FEED_URL,
     RPM_SIGNED_URL,
 )
+from pulp_smash.tests.pulp2.constants import PULP_SERVICES, REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import (
     gen_distributor,
     gen_repo,

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_character_encoding.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_character_encoding.py
@@ -9,10 +9,10 @@ import unittest
 
 from pulp_smash import api, config, selectors, utils
 from pulp_smash.constants import (
-    REPOSITORY_PATH,
     RPM_WITH_NON_ASCII_URL,
     RPM_WITH_NON_UTF_8_URL,
 )
+from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_repo
 from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_comps_xml.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_comps_xml.py
@@ -13,11 +13,11 @@ from xml.etree import ElementTree
 from packaging.version import Version
 
 from pulp_smash import api, config, selectors, utils
-from pulp_smash.constants import (
+from pulp_smash.constants import RPM_SIGNED_FEED_URL
+from pulp_smash.tests.pulp2.constants import (
     CONTENT_UPLOAD_PATH,
     ORPHANS_PATH,
     REPOSITORY_PATH,
-    RPM_SIGNED_FEED_URL,
 )
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import (
     gen_distributor,

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_content_applicability.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_content_applicability.py
@@ -12,13 +12,15 @@ from jsonschema import validate
 
 from pulp_smash import api, config, utils
 from pulp_smash.constants import (
+    RPM_UNSIGNED_FEED_URL,
+    RPM_DATA,
+    RPM2_DATA,
+)
+from pulp_smash.tests.pulp2.constants import (
     CONSUMERS_ACTIONS_CONTENT_REGENERATE_APPLICABILITY_PATH,
     CONSUMERS_CONTENT_APPLICABILITY_PATH,
     CONSUMERS_PATH,
     REPOSITORY_PATH,
-    RPM_UNSIGNED_FEED_URL,
-    RPM_DATA,
-    RPM2_DATA,
 )
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_distributor, gen_repo
 from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_content_sources.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_content_sources.py
@@ -10,10 +10,8 @@ from io import StringIO
 from urllib.parse import urlsplit, urlunsplit
 
 from pulp_smash import api, cli, config, selectors, utils
-from pulp_smash.constants import (
-    CONTENT_SOURCES_PATH,
-    PULP_FIXTURES_BASE_URL,
-)
+from pulp_smash.constants import PULP_FIXTURES_BASE_URL
+from pulp_smash.tests.pulp2.constants import CONTENT_SOURCES_PATH
 from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 _HEADERS = {'X-RHUI-ID', 'X-CSRF-TOKEN'}

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_copy.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_copy.py
@@ -7,11 +7,11 @@ from urllib.parse import urljoin
 
 from pulp_smash import api, cli, config, selectors, utils
 from pulp_smash.constants import (
-    REPOSITORY_PATH,
     RPM_SIGNED_URL,
     RPM_UNSIGNED_FEED_URL,
     RPM_UPDATED_INFO_FEED_URL,
 )
+from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_distributor, gen_repo
 from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_crud.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_crud.py
@@ -17,10 +17,12 @@ from requests.exceptions import HTTPError
 
 from pulp_smash import api, cli, config, selectors, utils
 from pulp_smash.constants import (
-    REPOSITORY_GROUP_PATH,
-    REPOSITORY_PATH,
     RPM_UNSIGNED_FEED_URL,
     RPM_WITH_PULP_DISTRIBUTION_FEED_URL,
+)
+from pulp_smash.tests.pulp2.constants import (
+    REPOSITORY_GROUP_PATH,
+    REPOSITORY_PATH,
 )
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import (
     gen_distributor,

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_download_policies.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_download_policies.py
@@ -13,11 +13,11 @@ from packaging.version import Version
 
 from pulp_smash import api, cli, config, selectors, utils
 from pulp_smash.constants import (
-    REPOSITORY_PATH,
     RPM,
     RPM_SIGNED_FEED_URL,
     RPM_SIGNED_URL,
 )
+from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import (
     gen_distributor,
     gen_repo,

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_duplicate_uploads.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_duplicate_uploads.py
@@ -6,7 +6,8 @@ import unittest
 from urllib.parse import urlsplit
 
 from pulp_smash import api, config, selectors, utils
-from pulp_smash.constants import FILE_URL, REPOSITORY_PATH, RPM_UNSIGNED_URL
+from pulp_smash.constants import FILE_URL, RPM_UNSIGNED_URL
+from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_repo
 from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_export.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_export.py
@@ -15,13 +15,15 @@ from packaging.version import Version
 
 from pulp_smash import api, cli, config, selectors, utils
 from pulp_smash.constants import (
+    RPM,
+    RPM_SIGNED_FEED_URL,
+    RPM_SIGNED_URL,
+)
+from pulp_smash.tests.pulp2.constants import (
     REPOSITORY_EXPORT_DISTRIBUTOR,
     REPOSITORY_GROUP_EXPORT_DISTRIBUTOR,
     REPOSITORY_GROUP_PATH,
     REPOSITORY_PATH,
-    RPM,
-    RPM_SIGNED_FEED_URL,
-    RPM_SIGNED_URL,
 )
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import (
     DisableSELinuxMixin,

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_force_full.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_force_full.py
@@ -12,7 +12,8 @@ This module tests Pulp's handling of "full" publishes.
 from packaging.version import Version
 
 from pulp_smash import api, selectors, utils
-from pulp_smash.constants import REPOSITORY_PATH, RPM_SIGNED_FEED_URL
+from pulp_smash.constants import RPM_SIGNED_FEED_URL
+from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_distributor, gen_repo
 from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_iso_crud.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_iso_crud.py
@@ -12,8 +12,8 @@ from pulp_smash import api, exceptions, selectors, utils
 from pulp_smash.constants import (
     FILE_FEED_URL,
     FILE_MIXED_FEED_URL,
-    REPOSITORY_PATH
 )
+from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 
 

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_iso_sync_publish.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_iso_sync_publish.py
@@ -10,8 +10,8 @@ from pulp_smash.constants import (
     FILE_FEED_COUNT,
     FILE_FEED_URL,
     FILE_URL,
-    REPOSITORY_PATH,
 )
+from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import (
     TemporaryUserMixin,
     get_dists_by_type_id,

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_mirrorlist.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_mirrorlist.py
@@ -19,8 +19,6 @@ from packaging.version import Version
 
 from pulp_smash import api, config, selectors, utils
 from pulp_smash.constants import (
-    ORPHANS_PATH,
-    REPOSITORY_PATH,
     RPM,
     RPM_MIRRORLIST_BAD,
     RPM_MIRRORLIST_GOOD,
@@ -28,6 +26,10 @@ from pulp_smash.constants import (
     RPM_UNSIGNED_URL,
 )
 from pulp_smash.exceptions import TaskReportError
+from pulp_smash.tests.pulp2.constants import (
+    ORPHANS_PATH,
+    REPOSITORY_PATH,
+)
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import (
     gen_distributor,
     gen_repo,

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_no_op_publish.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_no_op_publish.py
@@ -31,10 +31,10 @@ from urllib.parse import urljoin
 from packaging.version import Version
 
 from pulp_smash import api, config, exceptions, utils
-from pulp_smash.constants import (
+from pulp_smash.constants import RPM_SIGNED_FEED_URL
+from pulp_smash.tests.pulp2.constants import (
     ORPHANS_PATH,
     REPOSITORY_PATH,
-    RPM_SIGNED_FEED_URL,
 )
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_distributor, gen_repo
 from pulp_smash.tests.pulp2.rpm.utils import check_issue_2277, check_issue_3104

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_orphan_remove.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_orphan_remove.py
@@ -17,10 +17,10 @@ from urllib.parse import urljoin
 from packaging.version import Version
 
 from pulp_smash import api, config, selectors, utils
-from pulp_smash.constants import (
+from pulp_smash.constants import RPM_SIGNED_FEED_URL
+from pulp_smash.tests.pulp2.constants import (
     ORPHANS_PATH,
     REPOSITORY_PATH,
-    RPM_SIGNED_FEED_URL,
 )
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_repo
 from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
@@ -164,11 +164,11 @@ class OrphansTestCase(unittest.TestCase):
         """Ensure that a specific orphan is well and truly deleted.
 
         :param orphans_pre: The response to GET
-            :data:`pulp_smash.constants.ORPHANS_PATH` before the orphan was
-            deleted.
+            :data:`pulp_smash.tests.pulp2.constants.ORPHANS_PATH` before the
+            orphan was deleted.
         :param orphans_post: The response to GET
-            :data:`pulp_smash.constants.ORPHANS_PATH` after the orphan was
-            deleted.
+            :data:`pulp_smash.tests.pulp2.constants.ORPHANS_PATH` after the
+            orphan was deleted.
         :param orphan: A dict describing the orphan that was deleted.
         :returns: Nothing.
         """

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_package_paths.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_package_paths.py
@@ -33,11 +33,11 @@ import unittest
 
 from pulp_smash import api, config, selectors, utils
 from pulp_smash.constants import (
-    REPOSITORY_PATH,
     RPM,
     RPM_ALT_LAYOUT_FEED_URL,
     RPM_UNSIGNED_FEED_URL,
 )
+from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import (
     gen_distributor,
     gen_repo,

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_remove_unit.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_remove_unit.py
@@ -10,10 +10,12 @@ from urllib.parse import urljoin
 
 from pulp_smash import api, config, selectors, utils
 from pulp_smash.constants import (
-    ORPHANS_PATH,
-    REPOSITORY_PATH,
     RPM_SIGNED_FEED_URL,
     RPM_UNSIGNED_FEED_URL,
+)
+from pulp_smash.tests.pulp2.constants import (
+    ORPHANS_PATH,
+    REPOSITORY_PATH,
 )
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_distributor, gen_repo
 from pulp_smash.tests.pulp2.rpm.utils import (

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_repomd.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_repomd.py
@@ -9,10 +9,10 @@ from urllib.parse import urljoin
 
 from pulp_smash import api, cli, config, selectors, utils
 from pulp_smash.constants import (
-    REPOSITORY_PATH,
     RPM_NAMESPACES,
     RPM_UNSIGNED_FEED_URL,
 )
+from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import (
     gen_distributor,
     gen_repo,

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_repository_layout.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_repository_layout.py
@@ -21,10 +21,10 @@ from packaging.version import Version
 
 from pulp_smash import api, utils
 from pulp_smash.constants import (
-    REPOSITORY_PATH,
     RPM_NAMESPACES,
     RPM_SIGNED_FEED_URL,
 )
+from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import (
     gen_distributor,
     gen_repo,

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_repoview.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_repoview.py
@@ -14,6 +14,7 @@ from urllib.parse import urljoin
 from packaging.version import Version
 
 from pulp_smash import api, config, constants, selectors, utils
+from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_distributor, gen_repo
 
@@ -42,7 +43,7 @@ class RepoviewTestCase(unittest.TestCase):
         client = api.Client(cfg)
         body = gen_repo()
         body['distributors'] = [gen_distributor()]
-        repo = client.post(constants.REPOSITORY_PATH, body).json()
+        repo = client.post(REPOSITORY_PATH, body).json()
         self.addCleanup(client.delete, repo['_href'])
         rpm = utils.http_get(constants.RPM_UNSIGNED_URL)
         utils.upload_import_unit(cfg, rpm, {'unit_type_id': 'rpm'}, repo)

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_republish.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_republish.py
@@ -15,7 +15,8 @@ import unittest
 from urllib.parse import urljoin
 
 from pulp_smash import api, config, utils
-from pulp_smash.constants import REPOSITORY_PATH, RPM_SIGNED_FEED_URL
+from pulp_smash.constants import RPM_SIGNED_FEED_URL
+from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import (
     gen_distributor,
     gen_repo,

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_retain_old_count.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_retain_old_count.py
@@ -13,7 +13,8 @@ import unittest
 from urllib.parse import urljoin
 
 from pulp_smash import api, utils
-from pulp_smash.constants import REPOSITORY_PATH, RPM_UNSIGNED_FEED_URL
+from pulp_smash.constants import RPM_UNSIGNED_FEED_URL
+from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_distributor, gen_repo
 from pulp_smash.tests.pulp2.rpm.utils import check_issue_3104
 from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_rsync_distributor.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_rsync_distributor.py
@@ -60,12 +60,14 @@ from requests.exceptions import HTTPError
 
 from pulp_smash import api, cli, config, selectors, utils
 from pulp_smash.constants import (
-    ORPHANS_PATH,
-    REPOSITORY_PATH,
     RPM2_UNSIGNED_URL,
     RPM_SIGNED_FEED_COUNT,
     RPM_SIGNED_FEED_URL,
     RPM_UNSIGNED_URL,
+)
+from pulp_smash.tests.pulp2.constants import (
+    ORPHANS_PATH,
+    REPOSITORY_PATH,
 )
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import (
     DisableSELinuxMixin,

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_schedule_publish.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_schedule_publish.py
@@ -8,7 +8,8 @@ import time
 from urllib.parse import urljoin
 
 from pulp_smash import api, utils
-from pulp_smash.constants import REPOSITORY_PATH, RPM_SIGNED_FEED_URL
+from pulp_smash.constants import RPM_SIGNED_FEED_URL
+from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_repo, gen_distributor
 from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_schedule_sync.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_schedule_sync.py
@@ -10,7 +10,8 @@ from urllib.parse import urljoin
 from packaging.version import Version
 
 from pulp_smash import api, utils
-from pulp_smash.constants import REPOSITORY_PATH, RPM_SIGNED_FEED_URL
+from pulp_smash.constants import RPM_SIGNED_FEED_URL
+from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_repo
 from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_search.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_search.py
@@ -19,12 +19,14 @@ from urllib.parse import urljoin
 
 from pulp_smash import api, utils
 from pulp_smash.constants import (
-    CONTENT_UNITS_PATH,
-    REPOSITORY_PATH,
     RPM,
     RPM_SIGNED_FEED_URL,
     SRPM,
     SRPM_SIGNED_FEED_URL,
+)
+from pulp_smash.tests.pulp2.constants import (
+    CONTENT_UNITS_PATH,
+    REPOSITORY_PATH,
 )
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_repo
 from pulp_smash.tests.pulp2.rpm.utils import check_issue_2620

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_service_resiliency.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_service_resiliency.py
@@ -12,10 +12,12 @@ from requests.exceptions import HTTPError
 
 from pulp_smash import api, cli, config, selectors, utils
 from pulp_smash.constants import (
-    PULP_SERVICES,
-    REPOSITORY_PATH,
     RPM_MIRRORLIST_LARGE,
     RPM_UNSIGNED_FEED_URL,
+)
+from pulp_smash.tests.pulp2.constants import (
+    PULP_SERVICES,
+    REPOSITORY_PATH,
     TASKS_PATH,
 )
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_distributor, gen_repo

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_signatures_checked_for_copies.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_signatures_checked_for_copies.py
@@ -29,14 +29,13 @@ from pulp_smash import api, config, selectors, utils
 from pulp_smash.constants import (
     DRPM_SIGNED_URL,
     DRPM_UNSIGNED_URL,
-    ORPHANS_PATH,
     PULP_FIXTURES_KEY_ID,
-    REPOSITORY_PATH,
     RPM_SIGNED_URL,
     RPM_UNSIGNED_URL,
     SRPM_SIGNED_URL,
     SRPM_UNSIGNED_URL,
 )
+from pulp_smash.tests.pulp2.constants import ORPHANS_PATH, REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_repo
 from pulp_smash.tests.pulp2.rpm.utils import set_up_module
 

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_signatures_checked_for_syncs.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_signatures_checked_for_syncs.py
@@ -27,9 +27,7 @@ from pulp_smash.constants import (
     DRPM_SIGNED_FEED_URL,
     DRPM_UNSIGNED_FEED_COUNT,
     DRPM_UNSIGNED_FEED_URL,
-    ORPHANS_PATH,
     PULP_FIXTURES_KEY_ID,
-    REPOSITORY_PATH,
     RPM_SIGNED_FEED_COUNT,
     RPM_SIGNED_FEED_URL,
     RPM_UNSIGNED_FEED_COUNT,
@@ -39,6 +37,8 @@ from pulp_smash.constants import (
     SRPM_UNSIGNED_FEED_COUNT,
     SRPM_UNSIGNED_FEED_URL,
 )
+
+from pulp_smash.tests.pulp2.constants import ORPHANS_PATH, REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_repo
 from pulp_smash.tests.pulp2.rpm.utils import set_up_module
 

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_signatures_checked_for_uploads.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_signatures_checked_for_uploads.py
@@ -54,12 +54,12 @@ from pulp_smash.constants import (
     DRPM_SIGNED_URL,
     DRPM_UNSIGNED_URL,
     PULP_FIXTURES_KEY_ID,
-    REPOSITORY_PATH,
     RPM_SIGNED_URL,
     RPM_UNSIGNED_URL,
     SRPM_SIGNED_URL,
     SRPM_UNSIGNED_URL,
 )
+from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_repo
 from pulp_smash.tests.pulp2.rpm.utils import set_up_module
 

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_signatures_saved_for_packages.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_signatures_saved_for_packages.py
@@ -25,9 +25,7 @@ from pulp_smash.constants import (
     DRPM_SIGNED_URL,
     DRPM_UNSIGNED_FEED_URL,
     DRPM_UNSIGNED_URL,
-    ORPHANS_PATH,
     PULP_FIXTURES_KEY_ID,
-    REPOSITORY_PATH,
     RPM_SIGNED_FEED_URL,
     RPM_SIGNED_URL,
     RPM_UNSIGNED_FEED_URL,
@@ -37,6 +35,7 @@ from pulp_smash.constants import (
     SRPM_UNSIGNED_FEED_URL,
     SRPM_UNSIGNED_URL,
 )
+from pulp_smash.tests.pulp2.constants import ORPHANS_PATH, REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_repo
 from pulp_smash.tests.pulp2.rpm.utils import check_issue_2620
 from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_sync_publish.py
@@ -20,8 +20,6 @@ from requests.exceptions import HTTPError
 from pulp_smash import api, config, exceptions, selectors, utils
 from pulp_smash.constants import (
     DRPM_UNSIGNED_FEED_URL,
-    ORPHANS_PATH,
-    REPOSITORY_PATH,
     RPM,
     RPM_ERRATUM_COUNT,
     RPM_INCOMPLETE_FILELISTS_FEED_URL,
@@ -35,6 +33,7 @@ from pulp_smash.constants import (
     RPM_UNSIGNED_URL,
     SRPM_SIGNED_FEED_URL,
 )
+from pulp_smash.tests.pulp2.constants import ORPHANS_PATH, REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import (
     gen_distributor,
     gen_repo,

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_tasks.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_tasks.py
@@ -13,11 +13,8 @@ import unittest
 from urllib.parse import urljoin
 
 from pulp_smash import api, config, selectors, utils
-from pulp_smash.constants import (
-    REPOSITORY_PATH,
-    RPM_SIGNED_FEED_URL,
-    TASKS_PATH,
-)
+from pulp_smash.constants import RPM_SIGNED_FEED_URL
+from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH, TASKS_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_distributor, gen_repo
 from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_unassociate.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_unassociate.py
@@ -15,14 +15,13 @@ from packaging.version import Version
 from pulp_smash import api, config, selectors, utils
 from pulp_smash.constants import (
     DRPM_UNSIGNED_FEED_URL,
-    ORPHANS_PATH,
-    REPOSITORY_PATH,
     RPM,
     RPM_UNSIGNED_FEED_COUNT,
     RPM_UNSIGNED_FEED_URL,
     RPM_UNSIGNED_URL,
     SRPM_UNSIGNED_FEED_URL,
 )
+from pulp_smash.tests.pulp2.constants import ORPHANS_PATH, REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_distributor, gen_repo
 from pulp_smash.tests.pulp2.rpm.utils import check_issue_2620
 from pulp_smash.tests.pulp2.rpm.utils import set_up_module

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_unavailable_checksum.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_unavailable_checksum.py
@@ -5,11 +5,11 @@ import unittest
 from pulp_smash import api, config, utils
 from pulp_smash.constants import (
     DRPM_UNSIGNED_FEED_URL,
-    REPOSITORY_PATH,
     RPM_NAMESPACES,
     RPM_UNSIGNED_FEED_URL,
     SRPM_UNSIGNED_FEED_URL,
 )
+from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.exceptions import TaskReportError
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import (
     gen_distributor,

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_updateinfo.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_updateinfo.py
@@ -46,8 +46,6 @@ from requests.exceptions import HTTPError
 
 from pulp_smash import api, config, selectors, utils
 from pulp_smash.constants import (
-    ORPHANS_PATH,
-    REPOSITORY_PATH,
     RPM,
     RPM_DATA,
     RPM_ERRATUM_ID,
@@ -58,6 +56,7 @@ from pulp_smash.constants import (
     RPM_UNSIGNED_FEED_URL,
     RPM_UNSIGNED_URL,
 )
+from pulp_smash.tests.pulp2.constants import ORPHANS_PATH, REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import (
     gen_distributor,
     gen_repo,

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_upload_publish.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_upload_publish.py
@@ -16,8 +16,6 @@ from pulp_smash import api, config, selectors, utils
 from pulp_smash.constants import (
     DRPM,
     DRPM_UNSIGNED_URL,
-    ORPHANS_PATH,
-    REPOSITORY_PATH,
     RPM,
     RPM_DATA,
     RPM_UNSIGNED_URL,
@@ -27,6 +25,7 @@ from pulp_smash.constants import (
     SRPM,
     SRPM_UNSIGNED_URL,
 )
+from pulp_smash.tests.pulp2.constants import ORPHANS_PATH, REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import (
     gen_distributor,
     gen_repo,

--- a/pulp_smash/tests/pulp2/rpm/cli/test_process_recycling.py
+++ b/pulp_smash/tests/pulp2/rpm/cli/test_process_recycling.py
@@ -3,7 +3,8 @@
 import unittest
 
 from pulp_smash import cli, config, selectors, utils
-from pulp_smash.constants import PULP_SERVICES, RPM_UNSIGNED_FEED_URL
+from pulp_smash.constants import RPM_UNSIGNED_FEED_URL
+from pulp_smash.tests.pulp2.constants import PULP_SERVICES
 from pulp_smash.tests.pulp2.rpm.utils import set_up_module
 
 

--- a/pulp_smash/utils.py
+++ b/pulp_smash/utils.py
@@ -15,7 +15,7 @@ from packaging.version import Version
 
 from pulp_smash import api, cli, config, exceptions
 from pulp_smash.cli import _is_root as is_root  # for backward compatibility
-from pulp_smash.constants import (
+from pulp_smash.tests.pulp2.constants import (
     CONTENT_UPLOAD_PATH,
     ORPHANS_PATH,
     PLUGIN_TYPES_PATH,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -86,7 +86,7 @@ class BaseAPITestCase(unittest.TestCase):
 
         :meth:`pulp_smash.api.Client.delete` should be called once for each
         resource listed in ``resources``, and once for
-        :data:`pulp_smash.constants.ORPHANS_PATH`.
+        :data:`pulp_smash.tests.pulp2.constants.ORPHANS_PATH`.
         """
         with mock.patch.object(api, 'Client') as client:
             self.child.tearDownClass()


### PR DESCRIPTION
Move constants related to Pulp2 to it`s own dedicated file.

Aiming to create 2 separate namespaces for each project - Pulp2 and Pulp3, constants strong
connected to Pulp2 were moved to `pulp_smash/tests/pulp2/constants.py`.

See: #799