### PR TITLE
Remove duplicate word in docstring.

### DIFF
--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_repos.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_repos.py
@@ -43,7 +43,7 @@ class CRUDRepoTestCase(unittest.TestCase):
     def test_02_read_repos(self):
         """Search for the repository by its name.
 
-        Assert that just one search result is returned, and that that result
+        Assert that just one search result is returned, and that the result
         has a correct name.
         """
         page = self.client.get(REPO_PATH, params={


### PR DESCRIPTION
Remove the use of the word `that` twice in a row in a docstring. Besides to be grammatically correct, it can be misleading.