### PR TITLE
Fix reference for running test example.

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -168,8 +168,8 @@ All tests can be run by running the command below::
     python3 -m unittest discover pulp_smash.tests
 
 Any subset of tests may also be selected. For example, you may also run
-``python3 -m unittest pulp_smash.tests.platform.api_v2.test_login``. Consult
-the unittest documentation for test selection syntax, and consult the
+``python3 -m unittest pulp_smash.tests.pulp2.platform.api_v2.test_login``.
+Consult the unittest documentation for test selection syntax, and consult the
 :doc:`/api` to see which test modules are available, check the tests under the
 ``pulp_smash.tests.*`` namespace.
 


### PR DESCRIPTION
Pulp2 tests were moved to its own dedicated namespce.
The reference for runnnig the example was outdated.