### PR TITLE
Verify how ISO repos handlers update in content.

### DIFF
--- a/pulp_smash/constants.py
+++ b/pulp_smash/constants.py
@@ -125,6 +125,12 @@ FILE_MIXED_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'file-mixed/')
 FILE_URL = urljoin(FILE_FEED_URL, '1.iso')
 """The URL to an ISO file at :data:`FILE_FEED_URL`."""
 
+FILE2_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'file2/')
+"""The URL to a file repository."""
+
+FILE2_URL = urljoin(FILE2_FEED_URL, '1.iso')
+"""The URL to an ISO file at :data:`FILE2_FEED_URL`."""
+
 OSTREE_BRANCHES = ['rawhide', 'stable']
 """A branch in :data:`OSTREE_FEED`. See OSTree `Importer Configuration`_.
 


### PR DESCRIPTION
Verify how ISO repos handles changes in content already in Pulp.

Test:

 1. Create and sync an ISO repository.
 2. Update the repository's feed URL, and sync it. This simulates a
    change in the contents of the source ISOs.
 3. Assert that number of units remain the same, but the content has changed.

Closes: #784