### PR TITLE
Adapt task system to accept Pulp3 task system.

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -94,6 +94,14 @@ class JsonHandlerTestCase(unittest.TestCase):
             api.json_handler(**kwargs)
         self.assertEqual(handle_202.call_count, 1)
 
+    def test_204_check_run(self):
+        """Assert HTTP 204 responses are treated specially."""
+        kwargs = {key: mock.Mock() for key in ('server_config', 'response')}
+        kwargs['response'].status_code = 204
+        with mock.patch.object(api, '_handle_202'):
+            api.json_handler(**kwargs)
+        self.assertEqual(kwargs['response'].json.call_count, 0)
+
 
 class ClientTestCase(unittest.TestCase):
     """Tests for :class:`pulp_smash.api.Client`."""


### PR DESCRIPTION
Pulp3 task system still under development, but to be able to use the
current available reponse_handlers - mainly _handle_202 of API client,
few adjustments were created.

Adjusted functions: _check_tasks, _handle_202, poll_spawned_tasks and
poll_task.

Add test coverage to verify behaviour change in json_handler. Now
json_handler will treat in a different manner responses that status code
is equal to 204.

According to `HTTP/1.1 RFC 7231, Section 6.3.5`, 204 (No Content) status
code indicates that the server has sucessfully fullfiled the request and
that there is no additional content to send in response payload body.

See: #795