### PR TITLE
Fix new pylint warning

### DIFF
--- a/pulp_smash/tests/pulp2/rpm/api_v2/utils.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/utils.py
@@ -417,7 +417,7 @@ def set_pulp_manage_rsync(cfg, boolean):
         # root privileges to discover.
         client.run(sudo + ('which', 'semanage'))
     except exceptions.CalledProcessError:
-        return
+        return None
     cmd = sudo
     cmd += ('semanage', 'boolean', '--modify')
     cmd += ('--on',) if boolean else ('--off',)


### PR DESCRIPTION
Pylint 1.8 now warns about inconsistent return statements. See:
https://pylint.readthedocs.io/en/latest/whatsnew/1.8.html