### PR TITLE
Prepend "sudo" to shell commands as needed

### DIFF
--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_republish.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_republish.py
@@ -173,7 +173,8 @@ class RemoveOldRepodataTestCase(unittest.TestCase):
 
         # Upload an RPM, publish the repo, and count metadata files twice.
         cli_client = cli.Client(self.cfg)
-        find_repodata_cmd = (
+        sudo = () if utils.is_root(self.cfg) else ('sudo',)
+        find_repodata_cmd = sudo + (
             'find', os.path.join(
                 '/var/lib/pulp/published/yum/master/yum_distributor/',
                 str(repo['id'])
@@ -189,7 +190,7 @@ class RemoveOldRepodataTestCase(unittest.TestCase):
             )
             utils.publish_repo(self.cfg, repo)
             repodata_path = cli_client.run(find_repodata_cmd).stdout.strip()
-            found.append(cli_client.run((
+            found.append(cli_client.run(sudo + (
                 'find', repodata_path, '-type', 'f'
             )).stdout.splitlines())
         return found


### PR DESCRIPTION
`RemoveOldRepodataTestCase` executes several commands that require root
permissions. Prepend "sudo" to these commands when they're executed as a
non-root user.

See: fe6de191d6ea06b5f22cb96e0a07d136fb0a277c