### PR TITLE
Update Pulp3 tests to use new json_handler.

### DIFF
--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_auth.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_auth.py
@@ -5,7 +5,6 @@ For more information, see the documentation on `Authentication
 <http://docs.pulpproject.org/en/3.0/nightly/integration_guide/rest_api/authentication.html>`_.
 """
 import unittest
-from time import sleep
 from urllib.parse import urljoin
 
 from requests.auth import HTTPBasicAuth
@@ -81,14 +80,13 @@ class JWTResetTestCase(unittest.TestCase):
         # Create a user.
         self.cfg = config.get_config()
         auth = {'username': utils.uuid4(), 'password': utils.uuid4()}
-        client = api.Client(self.cfg)
-        self.addCleanup(sleep, 5)  # drop when client can wait on async tasks
-        self.user = client.post(USER_PATH, auth).json()
+        client = api.Client(self.cfg, api.json_handler)
+        self.user = client.post(USER_PATH, auth)
         self.addCleanup(client.delete, self.user['_href'])
 
         # Create tokens for that user, and verify they're valid.
         self.tokens = tuple((
-            client.post(JWT_PATH, auth).json() for _ in range(2)
+            client.post(JWT_PATH, auth) for _ in range(2)
         ))
         for token in self.tokens:
             client.get(BASE_PATH, auth=JWTAuth(token['token']))

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_repos.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_repos.py
@@ -1,7 +1,6 @@
 # coding=utf-8
 """Tests that CRUD repositories."""
 import unittest
-from time import sleep
 
 from requests.exceptions import HTTPError
 
@@ -23,12 +22,12 @@ class CRUDRepoTestCase(unittest.TestCase):
 
     def setUp(self):
         """Create an API client."""
-        self.client = api.Client(self.cfg, api.code_handler)
+        self.client = api.Client(self.cfg, api.json_handler)
         self.client.request_kwargs['auth'] = get_auth()
 
     def test_01_create_repo(self):
         """Create repository."""
-        type(self).repo = self.client.post(REPO_PATH, gen_repo()).json()
+        type(self).repo = self.client.post(REPO_PATH, gen_repo())
 
     @selectors.skip_if(bool, 'repo', False)
     def test_02_read_repo(self):
@@ -36,7 +35,7 @@ class CRUDRepoTestCase(unittest.TestCase):
 
         Assert that the response contains the correct repository name.
         """
-        repo = self.client.get(self.repo['_href']).json()
+        repo = self.client.get(self.repo['_href'])
         self.assertEqual(self.repo['name'], repo['name'])
 
     @selectors.skip_if(bool, 'repo', False)
@@ -48,7 +47,7 @@ class CRUDRepoTestCase(unittest.TestCase):
         """
         page = self.client.get(REPO_PATH, params={
             'name': self.repo['name']
-        }).json()
+        })
         self.assertEqual(len(page['results']), 1)
         self.assertEqual(page['results'][0]['name'], self.repo['name'])
 
@@ -70,14 +69,13 @@ class CRUDRepoTestCase(unittest.TestCase):
         :param attr: The name of the attribute to update. For example,
             "description." The attribute to update must be a string.
         """
-        repo = self.client.get(self.repo['_href']).json()
+        repo = self.client.get(self.repo['_href'])
         string = utils.uuid4()
         repo[attr] = string
         self.client.put(repo['_href'], repo)
-        sleep(5)
 
         # verify the update
-        repo = self.client.get(repo['_href']).json()
+        repo = self.client.get(repo['_href'])
         self.assertEqual(string, repo[attr])
 
     @selectors.skip_if(bool, 'repo', False)
@@ -100,17 +98,15 @@ class CRUDRepoTestCase(unittest.TestCase):
         """
         string = utils.uuid4()
         self.client.patch(self.repo['_href'], {attr: string})
-        sleep(5)
 
         # verify the update
-        repo = self.client.get(self.repo['_href']).json()
+        repo = self.client.get(self.repo['_href'])
         self.assertEqual(repo[attr], string)
 
     @selectors.skip_if(bool, 'repo', False)
     def test_04_delete_repo(self):
         """Delete a repository."""
         self.client.delete(self.repo['_href'])
-        sleep(5)
 
         # verify the delete
         with self.assertRaises(HTTPError):

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_users.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_users.py
@@ -1,7 +1,6 @@
 # coding=utf-8
 """Tests that CRUD users."""
 from random import choice
-from time import sleep
 import unittest
 
 from requests.exceptions import HTTPError
@@ -23,13 +22,13 @@ class UsersCRUDTestCase(unittest.TestCase):
 
     def setUp(self):
         """Create an API client."""
-        self.client = api.Client(self.cfg, api.code_handler)
+        self.client = api.Client(self.cfg, api.json_handler)
         self.client.request_kwargs['auth'] = get_auth()
 
     def test_01_create_user(self):
         """Create a user."""
         attrs = _gen_verbose_user_attrs()
-        type(self).user = self.client.post(USER_PATH, attrs).json()
+        type(self).user = self.client.post(USER_PATH, attrs)
         for key, val in attrs.items():
             with self.subTest(key=key):
                 if key == 'password':
@@ -40,7 +39,7 @@ class UsersCRUDTestCase(unittest.TestCase):
     @selectors.skip_if(bool, 'user', False)
     def test_02_read_user(self):
         """Read a user."""
-        user = self.client.get(self.user['_href']).json()
+        user = self.client.get(self.user['_href'])
         for key, val in user.items():
             with self.subTest(key=key):
                 self.assertEqual(val, self.user[key])
@@ -49,7 +48,7 @@ class UsersCRUDTestCase(unittest.TestCase):
     def test_02_read_users(self):
         """Read all users. Verify that the created user is in the results."""
         users = [
-            user for user in self.client.get(USER_PATH).json()['results']
+            user for user in self.client.get(USER_PATH)['results']
             if user['_href'] == self.user['_href']
         ]
         self.assertEqual(len(users), 1, users)
@@ -64,8 +63,7 @@ class UsersCRUDTestCase(unittest.TestCase):
         if selectors.bug_is_untestable(3125, self.cfg.pulp_version):
             attrs['username'] = self.user['username']
         self.client.put(self.user['_href'], attrs)
-        sleep(5)
-        user = self.client.get(self.user['_href']).json()
+        user = self.client.get(self.user['_href'])
         for key, val in attrs.items():
             with self.subTest(key=key):
                 if key == 'password':
@@ -80,8 +78,7 @@ class UsersCRUDTestCase(unittest.TestCase):
         if selectors.bug_is_untestable(3125, self.cfg.pulp_version):
             del attrs['username']
         self.client.patch(self.user['_href'], attrs)
-        sleep(5)
-        user = self.client.get(self.user['_href']).json()
+        user = self.client.get(self.user['_href'])
         for key, val in attrs.items():
             with self.subTest(key=key):
                 if key == 'password':
@@ -93,7 +90,6 @@ class UsersCRUDTestCase(unittest.TestCase):
     def test_04_delete_user(self):
         """Delete an user."""
         self.client.delete(self.user['_href'])
-        sleep(5)
         with self.assertRaises(HTTPError):
             self.client.get(self.user['_href'])
 


### PR DESCRIPTION
Refactor of Pulp3 tests to use the new version of `json_handler`, when
using API Client.

Remove the `sleep` function that was introduced to wait for asyncronous
calls to return.

See: #795