### PR TITLE
 Add tests for CRUD importers Pulp3.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -127,6 +127,10 @@ developers, not a gospel.
     api/pulp_smash.tests.pulp2.rpm.utils
     api/pulp_smash.tests.pulp3
     api/pulp_smash.tests.pulp3.constants
+    api/pulp_smash.tests.pulp3.file
+    api/pulp_smash.tests.pulp3.file.api_v3
+    api/pulp_smash.tests.pulp3.file.api_v3.utils
+    api/pulp_smash.tests.pulp3.file.api_v3.test_crud_importers
     api/pulp_smash.tests.pulp3.pulpcore
     api/pulp_smash.tests.pulp3.pulpcore.api_v3
     api/pulp_smash.tests.pulp3.pulpcore.api_v3.test_auth

--- a/docs/api/pulp_smash.tests.pulp3.file.api_v3.rst
+++ b/docs/api/pulp_smash.tests.pulp3.file.api_v3.rst
@@ -1,0 +1,6 @@
+`pulp_smash.tests.pulp3.file.api_v3`
+====================================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.pulp3.file.api_v3`
+
+.. automodule:: pulp_smash.tests.pulp3.file.api_v3

--- a/docs/api/pulp_smash.tests.pulp3.file.api_v3.test_crud_importers.rst
+++ b/docs/api/pulp_smash.tests.pulp3.file.api_v3.test_crud_importers.rst
@@ -1,0 +1,6 @@
+`pulp_smash.tests.pulp3.file.api_v3.test_crud_importers`
+========================================================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.pulp3.file.api_v3.test_crud_importers`
+
+.. automodule:: pulp_smash.tests.pulp3.file.api_v3.test_crud_importers

--- a/docs/api/pulp_smash.tests.pulp3.file.api_v3.utils.rst
+++ b/docs/api/pulp_smash.tests.pulp3.file.api_v3.utils.rst
@@ -1,0 +1,6 @@
+`pulp_smash.tests.pulp3.file.api_v3.utils`
+==========================================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.pulp3.file.api_v3.utils`
+
+.. automodule:: pulp_smash.tests.pulp3.file.api_v3.utils

--- a/docs/api/pulp_smash.tests.pulp3.file.rst
+++ b/docs/api/pulp_smash.tests.pulp3.file.rst
@@ -1,0 +1,6 @@
+`pulp_smash.tests.pulp3.file`
+=============================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.pulp3.file`
+
+.. automodule:: pulp_smash.tests.pulp3.file

--- a/pulp_smash/tests/pulp3/constants.py
+++ b/pulp_smash/tests/pulp3/constants.py
@@ -5,6 +5,14 @@ from urllib.parse import urljoin
 
 BASE_PATH = '/api/v3/'
 
+BASE_IMPORTER_PATH = urljoin(BASE_PATH, 'importers/')
+
+FILE_IMPORTER_PATH = urljoin(BASE_IMPORTER_PATH, 'file/')
+
+IMPORTER_DOWN_POLICY = {'background', 'immediate', 'on_demand'}
+
+IMPORTER_SYNC_MODE = {'additive', 'mirror'}
+
 JWT_PATH = urljoin(BASE_PATH, 'jwt/')
 
 REPO_PATH = urljoin(BASE_PATH, 'repositories/')

--- a/pulp_smash/tests/pulp3/file/__init__.py
+++ b/pulp_smash/tests/pulp3/file/__init__.py
@@ -1,0 +1,2 @@
+# coding=utf-8
+"""Tests for file plugin."""

--- a/pulp_smash/tests/pulp3/file/api_v3/__init__.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/__init__.py
@@ -1,0 +1,2 @@
+# coding=utf-8
+"""Tests that communicate with file plugin via the v3 API."""

--- a/pulp_smash/tests/pulp3/file/api_v3/test_crud_importers.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_crud_importers.py
@@ -1,0 +1,99 @@
+# coding=utf-8
+"""Tests that CRUD importers."""
+import unittest
+
+from requests.exceptions import HTTPError
+
+from pulp_smash import api, config, selectors
+from pulp_smash.tests.pulp3.constants import FILE_IMPORTER_PATH, REPO_PATH
+from pulp_smash.tests.pulp3.file.api_v3.utils import (
+    gen_importer,
+    modify_importer_down_policy,
+    modify_importer_sync_mode,
+)
+from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
+from pulp_smash.tests.pulp3.utils import get_auth
+
+
+class CRUDImportersTestCase(unittest.TestCase):
+    """CRUD importers."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create class-wide variables.
+
+        In order to create an importer a repository has to be created first.
+        """
+        cls.cfg = config.get_config()
+        cls.client = api.Client(cls.cfg, api.json_handler)
+        cls.client.request_kwargs['auth'] = get_auth()
+        cls.importer = {}
+        cls.repo = cls.client.post(REPO_PATH, gen_repo())
+
+    @classmethod
+    def tearDownClass(cls):
+        """Clean class-wide variable."""
+        cls.client.delete(cls.repo['_href'])
+
+    @selectors.skip_if(bool, 'repo', False)
+    def test_01_create_importer(self):
+        """Create an importer."""
+        body = gen_importer()
+        body['repository'] = self.repo['_href']
+        type(self).importer = self.client.post(FILE_IMPORTER_PATH, body)
+
+    @selectors.skip_if(bool, 'importer', False)
+    def test_02_read_importer(self):
+        """Read an importer by its href."""
+        importer = self.client.get(self.importer['_href'])
+        self.assertEqual(self.importer['name'], importer['name'])
+
+    @selectors.skip_if(bool, 'importer', False)
+    def test_02_read_importers(self):
+        """Read an importer by its name."""
+        page = self.client.get(FILE_IMPORTER_PATH, params={
+            'name': self.importer['name']
+        })
+        self.assertEqual(len(page['results']), 1)
+        self.assertEqual(page['results'][0]['name'], self.importer['name'])
+
+    @selectors.skip_if(bool, 'importer', False)
+    def test_03_partially_update(self):
+        """Update an importer using HTTP PATCH."""
+        attr = {
+            'download_policy': modify_importer_down_policy(
+                {self.importer['download_policy']}
+            ),
+            'sync_mode': modify_importer_sync_mode(
+                {self.importer['sync_mode']}
+            )
+        }
+        self.client.patch(self.importer['_href'], attr)
+        importer = self.client.get(self.importer['_href'])
+        self.assertEqual(attr['download_policy'], importer['download_policy'])
+        self.assertEqual(attr['sync_mode'], importer['sync_mode'])
+
+    @selectors.skip_if(bool, 'importer', False)
+    def test_04_fully_update(self):
+        """Update an importer using HTTP PUT."""
+        body = gen_importer()
+        body['repository'] = self.importer['repository']
+        self.client.put(self.importer['_href'], body)
+        type(self).importer = self.client.get(self.importer['_href'])
+        self.addCleanup(self.client.delete, self.importer['_href'])
+
+        self.assertEqual(body['name'], self.importer['name'])
+        self.assertEqual(
+            body['download_policy'],
+            self.importer['download_policy']
+        )
+        self.assertEqual(body['sync_mode'], self.importer['sync_mode'])
+
+    @selectors.skip_if(bool, 'importer', False)
+    def test_05_delete(self):
+        """Delete an importer."""
+        self.doCleanups()
+
+        # Verify importer was deleted.
+        with self.assertRaises(HTTPError):
+            self.client.get(self.importer['_href'])

--- a/pulp_smash/tests/pulp3/file/api_v3/utils.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/utils.py
@@ -1,0 +1,28 @@
+# coding=utf-8
+"""Utilities for file plugin tests."""
+from random import sample
+
+from pulp_smash.tests.pulp3.constants import (
+    IMPORTER_DOWN_POLICY,
+    IMPORTER_SYNC_MODE,
+)
+from pulp_smash import utils
+
+
+def gen_importer():
+    """Return a semi-random dict for use in creating an importer."""
+    return {
+        'name': utils.uuid4(),
+        'download_policy': sample(IMPORTER_DOWN_POLICY, 1)[0],
+        'sync_mode': sample(IMPORTER_SYNC_MODE, 1)[0],
+    }
+
+
+def modify_importer_down_policy(down_policy):
+    """Return a valid download policy different from the given one."""
+    return sample((IMPORTER_DOWN_POLICY - down_policy), 1)[0]
+
+
+def modify_importer_sync_mode(sync_mode):
+    """Return a valid sync mode different from the given one."""
+    return sample((IMPORTER_SYNC_MODE - sync_mode), 1)[0]


### PR DESCRIPTION
To be able to CRUD importers a plugin of any kind must be installed.
These tests require the `File Plugin` to be installed to be able to run.

See: #752