### PR TITLE
Add tests to CRUD Publishers.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -131,6 +131,7 @@ developers, not a gospel.
     api/pulp_smash.tests.pulp3.file
     api/pulp_smash.tests.pulp3.file.api_v3
     api/pulp_smash.tests.pulp3.file.api_v3.test_crud_importers
+    api/pulp_smash.tests.pulp3.file.api_v3.test_crud_publishers
     api/pulp_smash.tests.pulp3.file.api_v3.utils
     api/pulp_smash.tests.pulp3.file.utils
     api/pulp_smash.tests.pulp3.pulpcore

--- a/docs/api/pulp_smash.tests.pulp3.file.api_v3.test_crud_publishers.rst
+++ b/docs/api/pulp_smash.tests.pulp3.file.api_v3.test_crud_publishers.rst
@@ -1,0 +1,6 @@
+`pulp_smash.tests.pulp3.file.api_v3.test_crud_publishers`
+=========================================================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.pulp3.file.api_v3.test_crud_publishers`
+
+.. automodule:: pulp_smash.tests.pulp3.file.api_v3.test_crud_publishers

--- a/pulp_smash/tests/pulp3/constants.py
+++ b/pulp_smash/tests/pulp3/constants.py
@@ -7,7 +7,11 @@ BASE_PATH = '/api/v3/'
 
 BASE_IMPORTER_PATH = urljoin(BASE_PATH, 'importers/')
 
+BASE_PUBLISHER_PATH = urljoin(BASE_PATH, 'publishers/')
+
 FILE_IMPORTER_PATH = urljoin(BASE_IMPORTER_PATH, 'file/')
+
+FILE_PUBLISHER_PATH = urljoin(BASE_PUBLISHER_PATH, 'file/')
 
 IMPORTER_DOWN_POLICY = {'background', 'immediate', 'on_demand'}
 

--- a/pulp_smash/tests/pulp3/file/api_v3/test_crud_publishers.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_crud_publishers.py
@@ -1,0 +1,87 @@
+# coding=utf-8
+"""Tests that CRUD publishers."""
+import unittest
+
+from requests.exceptions import HTTPError
+
+from pulp_smash import api, config, selectors
+from pulp_smash.tests.pulp3.constants import FILE_PUBLISHER_PATH, REPO_PATH
+from pulp_smash.tests.pulp3.file.api_v3.utils import gen_publisher
+from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
+from pulp_smash.tests.pulp3.utils import get_auth
+
+
+class CRUDPublishersTestCase(unittest.TestCase):
+    """CRUD publishers."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create class-wide variables.
+
+        In order to create a publisher a repository has to be created first.
+        """
+        cls.cfg = config.get_config()
+        cls.client = api.Client(cls.cfg, api.json_handler)
+        cls.client.request_kwargs['auth'] = get_auth()
+        cls.publisher = {}
+        cls.repo = cls.client.post(REPO_PATH, gen_repo())
+
+    @classmethod
+    def tearDownClass(cls):
+        """Clean class-wide variable."""
+        cls.client.delete(cls.repo['_href'])
+
+    def test_01_create_publisher(self):
+        """Create a publisher."""
+        body = gen_publisher(self.repo)
+        type(self).publisher = self.client.post(FILE_PUBLISHER_PATH, body)
+        for key, val in body.items():
+            with self.subTest(key=key):
+                self.assertEqual(self.publisher[key], val)
+
+    @selectors.skip_if(bool, 'publisher', False)
+    def test_02_read_publisher(self):
+        """Read a publisher by its href."""
+        publisher = self.client.get(self.publisher['_href'])
+        for key, val in self.publisher.items():
+            with self.subTest(key=key):
+                self.assertEqual(publisher[key], val)
+
+    @selectors.skip_if(bool, 'publisher', False)
+    def test_02_read_publishers(self):
+        """Read a publisher by its name."""
+        page = self.client.get(FILE_PUBLISHER_PATH, params={
+            'name': self.publisher['name']
+        })
+        self.assertEqual(len(page['results']), 1)
+        for key, val in self.publisher.items():
+            with self.subTest(key=key):
+                self.assertEqual(page['results'][0][key], val)
+
+    @selectors.skip_if(bool, 'publisher', False)
+    def test_03_partially_update(self):
+        """Update a publisher using HTTP PATCH."""
+        body = gen_publisher(self.repo)
+        self.client.patch(self.publisher['_href'], body)
+        type(self).publisher = self.client.get(self.publisher['_href'])
+        for key, val in body.items():
+            with self.subTest(key=key):
+                self.assertEqual(self.publisher[key], val)
+
+    @selectors.skip_if(bool, 'publisher', False)
+    def test_04_fully_update(self):
+        """Update a publisher using HTTP PUT."""
+        body = gen_publisher(self.repo)
+        self.client.put(self.publisher['_href'], body)
+        type(self).publisher = self.client.get(self.publisher['_href'])
+        for key, val in body.items():
+            with self.subTest(key=key):
+                self.assertEqual(self.publisher[key], val)
+
+    @selectors.skip_if(bool, 'publisher', False)
+    def test_05_delete(self):
+        """Delete a publisher."""
+        self.client.delete(self.publisher['_href'])
+        with self.assertRaises(HTTPError):
+            self.client.get(self.publisher['_href'])

--- a/pulp_smash/tests/pulp3/file/api_v3/utils.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/utils.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 """Utilities for file plugin tests."""
-from random import sample
+from random import choice, sample
 
 from pulp_smash.tests.pulp3.constants import (
     IMPORTER_DOWN_POLICY,
@@ -19,4 +19,16 @@ def gen_importer(repo):
         'name': utils.uuid4(),
         'repository': repo['_href'],
         'sync_mode': sample(IMPORTER_SYNC_MODE, 1)[0],
+    }
+
+
+def gen_publisher(repo):
+    """Return a semi-random dict for use in creating a publisher.
+
+    :param repo: A dict of information about a file repository.
+    """
+    return {
+        'name': utils.uuid4(),
+        'repository': repo['_href'],
+        'auto_publish': choice((False, True))
     }


### PR DESCRIPTION
In order to CRUD publishers, a repository has to be created first.
Besides that, to run these newly added tests `file-plugin` has to be
installed.

See: #753