### PR TITLE
Skip tests affected by Pulp issue 3287

### DIFF
--- a/pulp_smash/tests/pulp2/docker/utils.py
+++ b/pulp_smash/tests/pulp2/docker/utils.py
@@ -12,7 +12,7 @@ from pulp_smash.tests.pulp2 import utils
 def set_up_module():
     """Skip tests if Pulp 2 isn't under test or if Docker isn't installed."""
     utils.require_pulp_2()
-    utils.require_issue_3159()
+    utils.require_issues()
     utils.require_unit_types({'docker_image'})
 
 

--- a/pulp_smash/tests/pulp2/ostree/utils.py
+++ b/pulp_smash/tests/pulp2/ostree/utils.py
@@ -7,7 +7,7 @@ from pulp_smash.utils import uuid4
 def set_up_module():
     """Skip tests if Pulp 2 isn't under test or if OSTree isn't installed."""
     utils.require_pulp_2()
-    utils.require_issue_3159()
+    utils.require_issues()
     utils.require_unit_types({'ostree'})
 
 

--- a/pulp_smash/tests/pulp2/platform/utils.py
+++ b/pulp_smash/tests/pulp2/platform/utils.py
@@ -6,4 +6,4 @@ from pulp_smash.tests.pulp2 import utils
 def set_up_module():
     """Skip tests if Pulp 2 isn't under test."""
     utils.require_pulp_2()
-    utils.require_issue_3159()
+    utils.require_issues()

--- a/pulp_smash/tests/pulp2/puppet/utils.py
+++ b/pulp_smash/tests/pulp2/puppet/utils.py
@@ -6,5 +6,5 @@ from pulp_smash.tests.pulp2 import utils
 def set_up_module():
     """Skip tests if Pulp 2 isn't under test or if Puppet isn't installed."""
     utils.require_pulp_2()
-    utils.require_issue_3159()
+    utils.require_issues()
     utils.require_unit_types({'puppet_module'})

--- a/pulp_smash/tests/pulp2/python/utils.py
+++ b/pulp_smash/tests/pulp2/python/utils.py
@@ -6,5 +6,5 @@ from pulp_smash.tests.pulp2 import utils
 def set_up_module():
     """Skip tests if Pulp 2 isn't under test or if Python isn't installed."""
     utils.require_pulp_2()
-    utils.require_issue_3159()
+    utils.require_issues()
     utils.require_unit_types({'python_package'})

--- a/pulp_smash/tests/pulp2/rpm/utils.py
+++ b/pulp_smash/tests/pulp2/rpm/utils.py
@@ -12,7 +12,7 @@ from pulp_smash.tests.pulp2 import utils as pulp2_utils
 def set_up_module():
     """Skip tests if Pulp 2 isn't under test or if RPM isn't installed."""
     pulp2_utils.require_pulp_2()
-    pulp2_utils.require_issue_3159()
+    pulp2_utils.require_issues()
     pulp2_utils.require_unit_types({'rpm'})
 
 

--- a/pulp_smash/tests/pulp2/utils.py
+++ b/pulp_smash/tests/pulp2/utils.py
@@ -51,6 +51,19 @@ def require_unit_types(required_unit_types):
         )
 
 
+def require_issues():
+    """Skip tests if one of several issues affects the Pulp app under test.
+
+    This function calls several ``require_issue_*`` functions, for convenience.
+    This function only checks issues that have a severe impact on the
+    functioning of an entire Pulp 2 application, regardless of which plugin is
+    under test. As a result, it's appropriate to call this function before
+    running any Pulp 2 tests.
+    """
+    require_issue_3287()
+    require_issue_3159()
+
+
 def require_issue_3159():
     """Skip tests if Fedora 27 is under test and `Pulp #3159`_ is open.
 
@@ -60,3 +73,14 @@ def require_issue_3159():
     if (selectors.bug_is_untestable(3159, cfg.pulp_version) and
             utils.os_is_f27(cfg)):
         raise unittest.SkipTest('https://pulp.plan.io/issues/3159')
+
+
+def require_issue_3287():
+    """Skip tests if Fedora 27 is under test and `Pulp #3287`_ is open.
+
+    .. _Pulp #3287: https://pulp.plan.io/issues/3287
+    """
+    cfg = config.get_config()
+    if (selectors.bug_is_untestable(3287, cfg.pulp_version) and
+            utils.os_is_f27(cfg)):
+        raise unittest.SkipTest('https://pulp.plan.io/issues/3287')


### PR DESCRIPTION
This issue is wide-ranging:

> Pulp 2.15 nightlies broken on Fedora 27 due to a pulp_streamer import
> error

See: https://pulp.plan.io/issues/3287