### PR TITLE
Cache Python wheels between Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,6 @@ install:
     - pip install .[dev]
 script:
     - make all
+cache: pip
 after_success:
     coveralls


### PR DESCRIPTION
This should have the effect of speeding up builds. See:

* https://docs.travis-ci.com/user/customizing-the-build/
* https://docs.travis-ci.com/user/caching