### PR TITLE
Skip tests affected by Pulp issue 3313

### DIFF
--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_iso_sync_publish.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_iso_sync_publish.py
@@ -52,6 +52,9 @@ class ServeHttpsFalseTestCase(TemporaryUserMixin, unittest.TestCase):
         """Publish w/an rsync distributor when ``serve_https`` is false."""
         if selectors.bug_is_untestable(2657, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2657')
+        if (selectors.bug_is_untestable(3313, self.cfg.pulp_version) and
+                utils.os_is_f27(self.cfg)):
+            self.skipTest('https://pulp.plan.io/issues/3313')
 
         # Create a user with which to rsync files
         ssh_user, priv_key = self.make_user(self.cfg)

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_rsync_distributor.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_rsync_distributor.py
@@ -95,13 +95,19 @@ def setUpModule():  # pylint:disable=invalid-name
 
     * The RPM plugin is not installed on the target Pulp server.
     * `Pulp #1759`_ is not implemented on the target Pulp server.
+    * `Pulp #3313`_ is not fixed on the target Pulp server, and the target host
+      is running Fedora 27.
 
     .. _Pulp #1759: https://pulp.plan.io/issues/1759
+    .. _Pulp #3313: https://pulp.plan.io/issues/3313
     """
     set_up_module()
     cfg = config.get_config()
     if selectors.bug_is_untestable(1759, cfg.pulp_version):
         raise unittest.SkipTest('https://pulp.plan.io/issues/1759')
+    if (selectors.bug_is_untestable(3313, cfg.pulp_version) and
+            utils.os_is_f27(cfg)):
+        raise unittest.SkipTest('https://pulp.plan.io/issues/3313')
     set_pulp_manage_rsync(cfg, True)
 
 


### PR DESCRIPTION
Issue title:

> rsync distributor broken on Fedora 27 due to SELinux denials

See: https://pulp.plan.io/issues/3313