### PR TITLE
Skip tests affected by Pulp issue 3314

### DIFF
--- a/pulp_smash/tests/pulp2/puppet/api_v2/test_install_distributor.py
+++ b/pulp_smash/tests/pulp2/puppet/api_v2/test_install_distributor.py
@@ -31,6 +31,9 @@ class InstallDistributorTestCase(utils.BaseAPITestCase):
         3. Publish the repository
         4. Check if the puppet_install_distributor config was properly used
         """
+        if (selectors.bug_is_untestable(3314, self.cfg.pulp_version) and
+                utils.os_is_f27(self.cfg)):
+            self.skipTest('https://pulp.plan.io/issues/3314')
         cli_client = cli.Client(self.cfg)
         sudo = () if utils.is_root(self.cfg) else ('sudo',)
 


### PR DESCRIPTION
Issue title:

> puppet install distributor broken on F27 due to SELinux denials

See: https://pulp.plan.io/issues/3314