### PR TITLE
Add a link to code_handlers to the API docstring.

### DIFF
--- a/pulp_smash/api.py
+++ b/pulp_smash/api.py
@@ -183,9 +183,10 @@ class Client(object):
 
     Pulp Smash ships with several response handlers. See:
 
+    * :func:`pulp_smash.api.code_handler`
     * :func:`pulp_smash.api.echo_handler`
-    * :func:`pulp_smash.api.safe_handler`
     * :func:`pulp_smash.api.json_handler`
+    * :func:`pulp_smash.api.safe_handler`
 
     As mentioned, this class has configurable request and response handling
     mechanisms. We've covered response handling mechanisms — let's move on to


### PR DESCRIPTION
Add a link to `code_handler` as one of the `response_handlers` shipped
with Pulp-Smash.