### PR TITLE
Fix description in docstring about sync mode. 

### DIFF
--- a/pulp_smash/tests/pulp3/file/api_v3/test_sync.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_sync.py
@@ -61,7 +61,7 @@ class SyncFileRepoTestCase(unittest.TestCase):
         6. Assert that repository version is different from the previous one.
 
         :param download_policy: The download policy for the importer.
-        :param sync_mode: The download policy for the importer.
+        :param sync_mode: The sync mode for the importer.
         """
         client = api.Client(self.cfg, api.json_handler)
         client.request_kwargs['auth'] = get_auth()


### PR DESCRIPTION
Update the description of docstring to sync mode, instead of download
policy in the docstring of `SyncFileRepoTestCase`.