### PR TITLE
Poll asynchronous tasks more frequently

### DIFF
--- a/pulp_smash/api.py
+++ b/pulp_smash/api.py
@@ -395,10 +395,10 @@ def poll_task(server_config, href, pulp_system=None):
     """
     if not pulp_system:
         pulp_system = server_config.get_systems('api')[0]
-    # 360 * 5s == 1800s == 30m
+    # 900 * 2s == 1800s == 30m
     # NOTE: The timeout counter is synchronous. We query Pulp, then count down,
     # then query pulp, then count down, etc. This is… dumb.
-    poll_limit = 360
+    poll_limit = 900
     poll_counter = 0
     while True:
         response = requests.get(
@@ -424,4 +424,4 @@ def poll_task(server_config, href, pulp_system=None):
             raise exceptions.TaskTimedOutError(
                 'Task {} is ongoing after {} polls.'.format(href, poll_limit)
             )
-        sleep(5)
+        sleep(2)


### PR DESCRIPTION
Poll asynchronous tasks every two seconds, instead of every five
seconds. Many of the asynchronous tasks that Pulp executes complete
within just a few polling cycles, such as five, ten or fifteen seconds.
As a result, the long (five second) polling periods mean that a
significant amount of Pulp Smash's time is spent waiting for tasks to
complete. Increasing the polling rate should reduce the amount of time
spent waiting by a significant amount.