### PR TITLE
Restrict download policies for file repo importers

### DIFF
--- a/pulp_smash/tests/pulp3/file/api_v3/test_sync.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_sync.py
@@ -4,15 +4,17 @@ import unittest
 from itertools import product
 from urllib.parse import urljoin
 
-from pulp_smash import api, config, selectors
+from pulp_smash import api, config
 from pulp_smash.constants import FILE_FEED_URL
 from pulp_smash.tests.pulp3.constants import (
     FILE_IMPORTER_PATH,
-    IMPORTER_DOWN_POLICY,
     IMPORTER_SYNC_MODE,
     REPO_PATH,
 )
-from pulp_smash.tests.pulp3.file.api_v3.utils import gen_importer
+from pulp_smash.tests.pulp3.file.api_v3.utils import (
+    gen_importer,
+    get_importer_down_policy,
+)
 from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule # noqa pylint:disable=unused-import
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
 from pulp_smash.tests.pulp3.utils import get_auth, sync_repo
@@ -37,9 +39,7 @@ class SyncFileRepoTestCase(unittest.TestCase):
 
         .. _Pulp #3320: https://pulp.plan.io/issues/3320
         """
-        importer_down_policy = IMPORTER_DOWN_POLICY
-        if selectors.bug_is_untestable(3320, self.cfg):
-            importer_down_policy -= {'background', 'on_demand'}
+        importer_down_policy = get_importer_down_policy()
         for pair in product(importer_down_policy, IMPORTER_SYNC_MODE):
             with self.subTest(pair=pair):
                 self.do_test(*pair)

--- a/pulp_smash/tests/pulp3/file/api_v3/utils.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/utils.py
@@ -6,7 +6,21 @@ from pulp_smash.tests.pulp3.constants import (
     IMPORTER_DOWN_POLICY,
     IMPORTER_SYNC_MODE,
 )
-from pulp_smash import utils
+from pulp_smash import config, selectors, utils
+
+
+def get_importer_down_policy():
+    """Return the download policies that are available to the file plugin.
+
+    See `Pulp #3320 <https://pulp.plan.io/issues/3320>`_.
+
+    :returns: A subset of
+        :data:`pulp_smash.tests.pulp3.constants.IMPORTER_DOWN_POLICY`. (The
+        constant itself might be returned.)
+    """
+    if selectors.bug_is_untestable(3320, config.get_config()):
+        return IMPORTER_DOWN_POLICY - {'background', 'on_demand'}
+    return IMPORTER_DOWN_POLICY
 
 
 def gen_importer(repo):
@@ -15,7 +29,7 @@ def gen_importer(repo):
     :param repo: A dict of information about a file repository.
     """
     return {
-        'download_policy': sample(IMPORTER_DOWN_POLICY, 1)[0],
+        'download_policy': sample(get_importer_down_policy(), 1)[0],
         'name': utils.uuid4(),
         'repository': repo['_href'],
         'sync_mode': sample(IMPORTER_SYNC_MODE, 1)[0],


### PR DESCRIPTION
The deferred download policies (background, on_demand) aren't supported
by the file plugin importers at this time. Prevent the `gen_importer`
function from returning those download policies.

See: https://pulp.plan.io/issues/3320