### PR TITLE
Change how booleans are set

### DIFF
--- a/pulp_smash/tests/pulp2/puppet/api_v2/test_install_distributor.py
+++ b/pulp_smash/tests/pulp2/puppet/api_v2/test_install_distributor.py
@@ -44,10 +44,9 @@ class InstallDistributorTestCase(utils.BaseAPITestCase):
         cli_client.run(sudo + ('chcon', '-t', 'puppet_etc_t', install_path))
 
         # Make sure the pulp_manage_puppet boolean is enabled
-        cli_client.run(sudo + (
-            'semanage', 'boolean', '--modify', '--on', 'pulp_manage_puppet'))
+        cli_client.run(sudo + ('setsebool', 'pulp_manage_puppet' 'on'))
         self.addCleanup(cli_client.run, sudo + (
-            'semanage', 'boolean', '--modify', '--off', 'pulp_manage_puppet'))
+            'setsebool', 'pulp_manage_puppet' 'off'))
 
         # Create and populate a Puppet repository.
         distributor = gen_install_distributor()

--- a/pulp_smash/tests/pulp2/rpm/api_v2/utils.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/utils.py
@@ -394,7 +394,7 @@ def get_dists_by_type_id(cfg, repo):
 def set_pulp_manage_rsync(cfg, boolean):
     """Set the ``pulp_manage_rsync`` SELinux policy.
 
-    If the ``semanage`` executable is not available, return. (This is the case
+    If the ``setsebool`` executable is not available, return. (This is the case
     if SELinux isn't installed on the system under test.) Otherwise, set the
     ``pulp_manage_rsync SELinux policy on or off, depending on the truthiness
     of ``boolean``.
@@ -413,15 +413,13 @@ def set_pulp_manage_rsync(cfg, boolean):
     sudo = () if utils.is_root(cfg) else ('sudo',)
     client = cli.Client(cfg)
     try:
-        # semanage is installed at /sbin/semanage on some distros, and requires
-        # root privileges to discover.
-        client.run(sudo + ('which', 'semanage'))
+        # setsebool is installed at /usr/sbin/setsebool on some distros, and
+        # requires root privileges to discover.
+        client.run(sudo + ('which', 'setsebool'))
     except exceptions.CalledProcessError:
         return None
-    cmd = sudo
-    cmd += ('semanage', 'boolean', '--modify')
-    cmd += ('--on',) if boolean else ('--off',)
-    cmd += ('pulp_manage_rsync',)
+    cmd = sudo + ('setsebool', 'pulp_manage_rsync')
+    cmd += ('on',) if boolean else ('off',)
     return client.run(cmd)
 
 


### PR DESCRIPTION
In Fedora 26 and earlier, and on RHEL 7:

* `semanage` sets the default and current state of an SELinux policy.
* `setsebool` sets the current state of an SELinux policy.

In Fedora 27:

* `semanage` sets the default state of an SELinux policy.
* `setsebool` sets the current state of an SELinux policy.

This change in behaviour breaks tests that use `semanage` to modify the
current state of SELinux policies. Switch to using `setsebool`.

See: https://pulp.plan.io/issues/3347