### PR TITLE
Fix tests Pulp3 repo field importers, publishers and sync. 

### DIFF
--- a/pulp_smash/tests/pulp3/file/api_v3/test_crud_importers.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_crud_importers.py
@@ -36,7 +36,7 @@ class CRUDImportersTestCase(unittest.TestCase):
 
     def test_01_create_importer(self):
         """Create an importer."""
-        body = _gen_verbose_importer(self.repo)
+        body = _gen_verbose_importer()
         type(self).importer = self.client.post(FILE_IMPORTER_PATH, body)
         for key in ('username', 'password'):
             del body[key]
@@ -66,7 +66,7 @@ class CRUDImportersTestCase(unittest.TestCase):
     @selectors.skip_if(bool, 'importer', False)
     def test_03_partially_update(self):
         """Update an importer using HTTP PATCH."""
-        body = _gen_verbose_importer(self.repo)
+        body = _gen_verbose_importer()
         self.client.patch(self.importer['_href'], body)
         for key in ('username', 'password'):
             del body[key]
@@ -78,7 +78,7 @@ class CRUDImportersTestCase(unittest.TestCase):
     @selectors.skip_if(bool, 'importer', False)
     def test_04_fully_update(self):
         """Update an importer using HTTP PUT."""
-        body = _gen_verbose_importer(self.repo)
+        body = _gen_verbose_importer()
         self.client.put(self.importer['_href'], body)
         for key in ('username', 'password'):
             del body[key]
@@ -95,7 +95,7 @@ class CRUDImportersTestCase(unittest.TestCase):
             self.client.get(self.importer['_href'])
 
 
-def _gen_verbose_importer(repo):
+def _gen_verbose_importer():
     """Return a semi-random dict for use in defining an importer.
 
     For most tests, it's desirable to create importers with as few attributes
@@ -104,10 +104,8 @@ def _gen_verbose_importer(repo):
     sense to provide as many attributes as possible.
 
     Note that 'username' and 'password' are write-only attributes.
-
-    :param repo: A dict of information about a file repository.
     """
-    attrs = gen_importer(repo)
+    attrs = gen_importer()
     attrs.update({
         'feed_url': random.choice((FILE_FEED_URL, FILE2_FEED_URL)),
         'password': utils.uuid4(),

--- a/pulp_smash/tests/pulp3/file/api_v3/test_crud_publishers.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_crud_publishers.py
@@ -34,7 +34,7 @@ class CRUDPublishersTestCase(unittest.TestCase):
 
     def test_01_create_publisher(self):
         """Create a publisher."""
-        body = gen_publisher(self.repo)
+        body = gen_publisher()
         type(self).publisher = self.client.post(FILE_PUBLISHER_PATH, body)
         for key, val in body.items():
             with self.subTest(key=key):
@@ -62,7 +62,7 @@ class CRUDPublishersTestCase(unittest.TestCase):
     @selectors.skip_if(bool, 'publisher', False)
     def test_03_partially_update(self):
         """Update a publisher using HTTP PATCH."""
-        body = gen_publisher(self.repo)
+        body = gen_publisher()
         self.client.patch(self.publisher['_href'], body)
         type(self).publisher = self.client.get(self.publisher['_href'])
         for key, val in body.items():
@@ -72,7 +72,7 @@ class CRUDPublishersTestCase(unittest.TestCase):
     @selectors.skip_if(bool, 'publisher', False)
     def test_04_fully_update(self):
         """Update a publisher using HTTP PUT."""
-        body = gen_publisher(self.repo)
+        body = gen_publisher()
         self.client.put(self.publisher['_href'], body)
         type(self).publisher = self.client.get(self.publisher['_href'])
         for key, val in body.items():

--- a/pulp_smash/tests/pulp3/file/api_v3/test_sync.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_sync.py
@@ -68,7 +68,7 @@ class SyncFileRepoTestCase(unittest.TestCase):
         client.request_kwargs['auth'] = get_auth()
         repo = client.post(REPO_PATH, gen_repo())
         self.addCleanup(client.delete, repo['_href'])
-        body = gen_importer(repo)
+        body = gen_importer()
         body['download_policy'] = download_policy
         body['feed_url'] = urljoin(FILE_FEED_URL, 'PULP_MANIFEST')
         body['sync_mode'] = sync_mode
@@ -77,13 +77,13 @@ class SyncFileRepoTestCase(unittest.TestCase):
 
         # Sync the repository.
         self.assertIsNone(repo['_latest_version_href'])
-        sync_repo(self.cfg, importer)
+        sync_repo(self.cfg, importer, repo)
         repo = client.get(repo['_href'])
         self.assertIsNotNone(repo['_latest_version_href'])
 
         # Sync the repository again.
         latest_version_href = repo['_latest_version_href']
-        sync_repo(self.cfg, importer)
+        sync_repo(self.cfg, importer, repo)
         repo = client.get(repo['_href'])
         self.assertNotEqual(latest_version_href, repo['_latest_version_href'])
 
@@ -113,14 +113,14 @@ class SyncChangeRepoVersionTestCase(unittest.TestCase):
         client.request_kwargs['auth'] = get_auth()
         repo = client.post(REPO_PATH, gen_repo())
         self.addCleanup(client.delete, repo['_href'])
-        body = gen_importer(repo)
+        body = gen_importer()
         body['feed_url'] = urljoin(FILE_FEED_URL, 'PULP_MANIFEST')
         importer = client.post(FILE_IMPORTER_PATH, body)
         self.addCleanup(client.delete, importer['_href'])
 
         number_of_syncs = randint(1, 10)
         for _ in range(number_of_syncs):
-            sync_repo(cfg, importer)
+            sync_repo(cfg, importer, repo)
 
         repo = client.get(repo['_href'])
         path = urlsplit(repo['_latest_version_href']).path

--- a/pulp_smash/tests/pulp3/file/api_v3/utils.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/utils.py
@@ -23,26 +23,18 @@ def get_importer_down_policy():
     return IMPORTER_DOWN_POLICY
 
 
-def gen_importer(repo):
-    """Return a semi-random dict for use in creating an importer.
-
-    :param repo: A dict of information about a file repository.
-    """
+def gen_importer():
+    """Return a semi-random dict for use in creating an importer."""
     return {
         'download_policy': sample(get_importer_down_policy(), 1)[0],
         'name': utils.uuid4(),
-        'repository': repo['_href'],
         'sync_mode': sample(IMPORTER_SYNC_MODE, 1)[0],
     }
 
 
-def gen_publisher(repo):
-    """Return a semi-random dict for use in creating a publisher.
-
-    :param repo: A dict of information about a file repository.
-    """
+def gen_publisher():
+    """Return a semi-random dict for use in creating a publisher."""
     return {
         'name': utils.uuid4(),
-        'repository': repo['_href'],
         'auto_publish': choice((False, True))
     }

--- a/pulp_smash/tests/pulp3/utils.py
+++ b/pulp_smash/tests/pulp3/utils.py
@@ -160,16 +160,17 @@ def get_plugins(cfg=None):
     return plugins
 
 
-def sync_repo(cfg, importer):
+def sync_repo(cfg, importer, repo):
     """Sync a repository.
 
     :param pulp_smash.config.PulpSmashConfig cfg: Information about the Pulp
         host.
     :param importer: A dict of detailed information about the importer of
         the repository to be synced.
+    :param repo: A dict of detailed information about the repository.
     :returns: The server's response. Call ``.json()`` on the response to get
         a call report.
     """
     return api.Client(cfg, api.json_handler).post(
-        urljoin(importer['_href'], 'sync/')
+        urljoin(importer['_href'], 'sync/'), {'repository': repo['_href']}
     )


### PR DESCRIPTION
Pulp3 is under active development, and many changes were added to
endpoints, and mandatory fields.

FK `repository` was removed from importers and publishers.

See: https://pulp.plan.io/issues/3341

Besides that, an importer can be associate with multiples repositories.
At the moment of sync the `href` to repository to be synced has to
informed.

See: https://pulp.plan.io/issues/3351