### PR TITLE
Add tests to CRUD distributions.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -138,6 +138,7 @@ developers, not a gospel.
     api/pulp_smash.tests.pulp3.pulpcore
     api/pulp_smash.tests.pulp3.pulpcore.api_v3
     api/pulp_smash.tests.pulp3.pulpcore.api_v3.test_auth
+    api/pulp_smash.tests.pulp3.pulpcore.api_v3.test_crud_distributions
     api/pulp_smash.tests.pulp3.pulpcore.api_v3.test_crud_repos
     api/pulp_smash.tests.pulp3.pulpcore.api_v3.test_crud_users
     api/pulp_smash.tests.pulp3.pulpcore.utils

--- a/docs/api/pulp_smash.tests.pulp3.pulpcore.api_v3.test_crud_distributions.rst
+++ b/docs/api/pulp_smash.tests.pulp3.pulpcore.api_v3.test_crud_distributions.rst
@@ -1,0 +1,6 @@
+`pulp_smash.tests.pulp3.pulpcore.api_v3.test_crud_distributions`
+================================================================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.pulp3.pulpcore.api_v3.test_crud_distributions`
+
+.. automodule:: pulp_smash.tests.pulp3.pulpcore.api_v3.test_crud_distributions

--- a/pulp_smash/tests/pulp3/constants.py
+++ b/pulp_smash/tests/pulp3/constants.py
@@ -9,6 +9,8 @@ BASE_IMPORTER_PATH = urljoin(BASE_PATH, 'importers/')
 
 BASE_PUBLISHER_PATH = urljoin(BASE_PATH, 'publishers/')
 
+DISTRIBUTION_PATH = urljoin(BASE_PATH, 'distributions/')
+
 FILE_IMPORTER_PATH = urljoin(BASE_IMPORTER_PATH, 'file/')
 
 FILE_PUBLISHER_PATH = urljoin(BASE_PUBLISHER_PATH, 'file/')

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_distributions.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_distributions.py
@@ -1,0 +1,79 @@
+# coding=utf-8
+"""Tests that CRUD distributions."""
+import unittest
+
+from requests.exceptions import HTTPError
+
+from pulp_smash import api, config, selectors
+from pulp_smash.tests.pulp3.constants import DISTRIBUTION_PATH
+from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp3.pulpcore.utils import gen_distribution
+from pulp_smash.tests.pulp3.utils import get_auth
+
+
+class CRUDDistributionsTestCase(unittest.TestCase):
+    """CRUD distributions."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create class wide-variables."""
+        cls.cfg = config.get_config()
+        cls.client = api.Client(cls.cfg, api.json_handler)
+        cls.client.request_kwargs['auth'] = get_auth()
+        cls.distribution = {}
+
+    def test_01_create_distribution(self):
+        """Create a distribution."""
+        body = gen_distribution()
+        type(self).distribution = self.client.post(DISTRIBUTION_PATH, body)
+        for key, val in body.items():
+            with self.subTest(key=key):
+                self.assertEqual(self.distribution[key], val)
+
+    @selectors.skip_if(bool, 'distribution', False)
+    def test_02_read_distribution(self):
+        """Read a distribution by its _href."""
+        distribution = self.client.get(self.distribution['_href'])
+        for key, val in self.distribution.items():
+            with self.subTest(key=key):
+                self.assertEqual(distribution[key], val)
+
+    @selectors.skip_if(bool, 'distribution', False)
+    def test_02_read_distributions(self):
+        """Read a distribution by its name."""
+        if selectors.bug_is_untestable(3082, self.cfg.pulp_version):
+            self.skipTest('https://pulp.plan.io/issues/3082')
+        page = self.client.get(DISTRIBUTION_PATH, params={
+            'name': self.distribution['name']
+        })
+        self.assertEqual(len(page['results']), 1)
+        for key, val in self.distribution.items():
+            with self.subTest(key=key):
+                self.assertEqual(page['results'][0][key], val)
+
+    @selectors.skip_if(bool, 'distribution', False)
+    def test_03_partially_update(self):
+        """Update a distribution using HTTP PATCH."""
+        body = gen_distribution()
+        self.client.patch(self.distribution['_href'], body)
+        type(self).distribution = self.client.get(self.distribution['_href'])
+        for key, val in body.items():
+            with self.subTest(key=key):
+                self.assertEqual(self.distribution[key], val)
+
+    @selectors.skip_if(bool, 'distribution', False)
+    def test_04_fully_update(self):
+        """Update a distribution using HTTP PUT."""
+        body = gen_distribution()
+        self.client.put(self.distribution['_href'], body)
+        type(self).distribution = self.client.get(self.distribution['_href'])
+        for key, val in body.items():
+            with self.subTest(key=key):
+                self.assertEqual(self.distribution[key], val)
+
+    @selectors.skip_if(bool, 'distribution', False)
+    def test_05_delete(self):
+        """Delete a distribution."""
+        self.client.delete(self.distribution['_href'])
+        with self.assertRaises(HTTPError):
+            self.client.get(self.distribution['_href'])

--- a/pulp_smash/tests/pulp3/pulpcore/utils.py
+++ b/pulp_smash/tests/pulp3/pulpcore/utils.py
@@ -1,5 +1,7 @@
 # coding=utf-8
 """Utilities for Pulpcore tests."""
+from random import choice
+
 from pulp_smash import utils
 from pulp_smash.tests.pulp3 import utils as pulp3_utils
 
@@ -13,3 +15,13 @@ def set_up_module():
     """Skip tests Pulp 3 isn't under test or if pulpcore isn't installed."""
     pulp3_utils.require_pulp_3()
     pulp3_utils.require_pulp_plugins({'pulpcore'})
+
+
+def gen_distribution():
+    """Return a semi-random dict for use in creating a distribution."""
+    return {
+        'base_path': utils.uuid4(),
+        'http': choice((False, True)),
+        'https': choice((False, True)),
+        'name': utils.uuid4()
+    }


### PR DESCRIPTION
Add tests to CRUD distributions. A distribution is not associated within
a plugin, then the related tests were added as part of `pulp_core`.

See: #776