### PR TITLE
Verify publisher and importers are unliked to repo.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -133,6 +133,7 @@ developers, not a gospel.
     api/pulp_smash.tests.pulp3.file.api_v3.test_crud_importers
     api/pulp_smash.tests.pulp3.file.api_v3.test_crud_publishers
     api/pulp_smash.tests.pulp3.file.api_v3.test_sync
+    api/pulp_smash.tests.pulp3.file.api_v3.test_unlinking_repo
     api/pulp_smash.tests.pulp3.file.api_v3.utils
     api/pulp_smash.tests.pulp3.file.utils
     api/pulp_smash.tests.pulp3.pulpcore

--- a/docs/api/pulp_smash.tests.pulp3.file.api_v3.test_unlinking_repo.rst
+++ b/docs/api/pulp_smash.tests.pulp3.file.api_v3.test_unlinking_repo.rst
@@ -1,0 +1,6 @@
+`pulp_smash.tests.pulp3.file.api_v3.test_unlinking_repo`
+========================================================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.pulp3.file.api_v3.test_unlinking_repo`
+
+.. automodule:: pulp_smash.tests.pulp3.file.api_v3.test_unlinking_repo

--- a/pulp_smash/tests/pulp3/file/api_v3/test_unlinking_repo.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_unlinking_repo.py
@@ -1,0 +1,85 @@
+# coding=utf-8
+"""Tests that perform action over importers and publishers."""
+
+import unittest
+from urllib.parse import urljoin
+
+from pulp_smash import api, config
+from pulp_smash.constants import FILE_FEED_URL
+from pulp_smash.tests.pulp3.constants import (
+    FILE_IMPORTER_PATH,
+    FILE_PUBLISHER_PATH,
+    REPO_PATH,
+)
+from pulp_smash.tests.pulp3.file.api_v3.utils import (
+    gen_importer,
+    gen_publisher,
+)
+from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
+from pulp_smash.tests.pulp3.utils import (
+    get_auth,
+    publish_repo,
+    read_repo_content,
+    sync_repo,
+)
+
+
+class ImportersPublishersTestCase(unittest.TestCase):
+    """Verify publisher and importer can be used with different repos."""
+
+    def test_all(self):
+        """Verify publisher and importer can be used with different repos.
+
+        This test explores the design choice stated in `Pulp #3341`_ that
+        remove the FK from publishers and importers to repository.
+        Allowing importers and publishers to be used with different
+        repositories.
+
+        .. _Pulp #3341: https://pulp.plan.io/issues/3341
+
+        Do the following:
+
+        1. Create an importer, and a publisher.
+        2. Create 2 repositories.
+        3. Sync both repositories using the same importer.
+        4. Assert that the number of units present in both repositories are the
+           same.
+        5. Publish both repositories using the same publisher.
+        6. Assert that each generated publication has the same publisher, but
+           are associated with different repositories.
+        """
+        cfg = config.get_config()
+        repos = []
+        client = api.Client(cfg, api.json_handler)
+        client.request_kwargs['auth'] = get_auth()
+        body = gen_importer()
+        body['feed_url'] = urljoin(FILE_FEED_URL, 'PULP_MANIFEST')
+        importer = client.post(FILE_IMPORTER_PATH, body)
+        self.addCleanup(client.delete, importer['_href'])
+        publisher = client.post(FILE_PUBLISHER_PATH, gen_publisher())
+        self.addCleanup(client.delete, publisher['_href'])
+        for _ in range(2):
+            repo = client.post(REPO_PATH, gen_repo())
+            self.addCleanup(client.delete, repo['_href'])
+            repos.append(repo)
+            sync_repo(cfg, importer, repo)
+
+        contents = []
+        contents.append(len(read_repo_content(repos[0])['results']))
+        contents.append(len(read_repo_content(repos[1])['results']))
+
+        self.assertEqual(contents[0], contents[1])
+
+        publications = []
+        for repo in repos:
+            publications.append(publish_repo(cfg, publisher, repo))
+
+        self.assertEqual(
+            publications[0]['publisher'],
+            publications[1]['publisher']
+        )
+        self.assertNotEqual(
+            publications[0]['repository_version'],
+            publications[1]['repository_version']
+        )

--- a/pulp_smash/tests/pulp3/utils.py
+++ b/pulp_smash/tests/pulp3/utils.py
@@ -174,3 +174,43 @@ def sync_repo(cfg, importer, repo):
     return api.Client(cfg, api.json_handler).post(
         urljoin(importer['_href'], 'sync/'), {'repository': repo['_href']}
     )
+
+
+def publish_repo(cfg, publisher, repo):
+    """Publish a repository.
+
+    :param pulp_smash.config.PulpSmashConfig cfg: Information about the Pulp
+        host.
+    :param publisher: A dict of detailed information about the publisher of
+        the repository to be published.
+    :param repo: A dict of detailed information about the repository.
+    :returns: A publication. A dict of detailed information about the just
+        create publication.
+    """
+    client = api.Client(cfg, api.json_handler)
+    call_report = client.post(
+        urljoin(publisher['_href'], 'publish/'), {'repository': repo['_href']}
+    )
+    last_task = next(api.poll_spawned_tasks(cfg, call_report))
+    return client.get(last_task['created_resources'][0])
+
+
+def get_latest_repo_version(repo):
+    """Get the latest version of a given repository.
+
+    :param repo: A dict of detailed information about the repository.
+    :returns: A _href to the latest version of a given repository.
+    """
+    client = api.Client(config.get_config(), api.json_handler)
+    return client.get(repo['_href'])['_latest_version_href']
+
+
+def read_repo_content(repo):
+    """Read the content units of a given repository.
+
+    :param repo: A dict of detailed information about the repository.
+    :returns: A dict of detailed information about the contents units present
+        in a given repository.
+    """
+    client = api.Client(config.get_config(), api.json_handler)
+    return client.get(urljoin(get_latest_repo_version(repo), 'content/'))


### PR DESCRIPTION
Do the following:

 1. Create an importer, and a publisher.
 2. Create 2 repositories.
 3. Sync both repositories using the same importer.
 4. Assert that the number of units present in both repositories are the same.
 5. Publish both repositories using the same publisher.
 6. Assert that each generated publication has the same publisher, but
    are associated with different repositories.

Besides that, introduce 3 new functions to Pulp3 - utils.

 1. publish_repo - Used to a publish a repo.
 2. get_latest_repo_version - Used to get the _href to latest repo
 version.
 3. read_repo_content - Used to read the content units present on a
 repo.

Closes: #865