### PR TITLE
Update constant sync modes for importers. 

### DIFF
--- a/pulp_smash/tests/pulp3/constants.py
+++ b/pulp_smash/tests/pulp3/constants.py
@@ -22,7 +22,7 @@ See `pulpcore.app.models.Importer
 <https://docs.pulpproject.org/en/3.0/nightly/contributing/platform_api/app/models.html#pulpcore.app.models.Importer>`_.
 """
 
-IMPORTER_SYNC_MODE = {'additive', 'mirror'}
+IMPORTER_SYNC_MODE = {'mirror'}
 """Sync modes for an importer.
 
 See `pulpcore.app.models.Importer


### PR DESCRIPTION
According to the issue https://pulp.plan.io/issues/3336 an exception
will be raised if a user tries to create/update an importer with
`additive` sync policy.

Then the `additive` mode was removed from the constant
`IMPORTER_SYNC_MODE`.