### PR TITLE
Add `pulp-smash smoke-tests` CLI command

### DIFF
--- a/pulp_smash/tests/pulp3/file/api_v3/test_crd_publications.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_crd_publications.py
@@ -5,7 +5,7 @@ from urllib.parse import urljoin
 
 from requests.exceptions import HTTPError
 
-from pulp_smash import api, config, selectors
+from pulp_smash import api, config, selectors, utils
 from pulp_smash.constants import FILE_FEED_URL
 from pulp_smash.tests.pulp3.constants import (
     FILE_PUBLISHER_PATH,
@@ -22,7 +22,7 @@ from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
 from pulp_smash.tests.pulp3.utils import get_auth, sync_repo
 
 
-class PublicationsTestCase(unittest.TestCase):
+class PublicationsTestCase(unittest.TestCase, utils.SmokeTest):
     """Perform actions over publications."""
 
     @classmethod

--- a/pulp_smash/tests/pulp3/file/api_v3/test_crud_importers.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_crud_importers.py
@@ -14,7 +14,7 @@ from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
 from pulp_smash.tests.pulp3.utils import get_auth
 
 
-class CRUDImportersTestCase(unittest.TestCase):
+class CRUDImportersTestCase(unittest.TestCase, utils.SmokeTest):
     """CRUD importers."""
 
     @classmethod

--- a/pulp_smash/tests/pulp3/file/api_v3/test_crud_publishers.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_crud_publishers.py
@@ -4,7 +4,7 @@ import unittest
 
 from requests.exceptions import HTTPError
 
-from pulp_smash import api, config, selectors
+from pulp_smash import api, config, selectors, utils
 from pulp_smash.tests.pulp3.constants import FILE_PUBLISHER_PATH, REPO_PATH
 from pulp_smash.tests.pulp3.file.api_v3.utils import gen_publisher
 from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
@@ -12,7 +12,7 @@ from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
 from pulp_smash.tests.pulp3.utils import get_auth
 
 
-class CRUDPublishersTestCase(unittest.TestCase):
+class CRUDPublishersTestCase(unittest.TestCase, utils.SmokeTest):
     """CRUD publishers."""
 
     @classmethod

--- a/pulp_smash/tests/pulp3/file/api_v3/test_sync.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_sync.py
@@ -5,7 +5,7 @@ from itertools import product
 from random import randint
 from urllib.parse import urljoin, urlsplit
 
-from pulp_smash import api, config
+from pulp_smash import api, config, utils
 from pulp_smash.constants import FILE_FEED_URL
 from pulp_smash.tests.pulp3.constants import (
     FILE_IMPORTER_PATH,
@@ -21,7 +21,7 @@ from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
 from pulp_smash.tests.pulp3.utils import get_auth, sync_repo
 
 
-class SyncFileRepoTestCase(unittest.TestCase):
+class SyncFileRepoTestCase(unittest.TestCase, utils.SmokeTest):
     """Sync repositories with the file plugin."""
 
     @classmethod

--- a/pulp_smash/tests/pulp3/file/api_v3/test_unlinking_repo.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_unlinking_repo.py
@@ -4,7 +4,7 @@
 import unittest
 from urllib.parse import urljoin
 
-from pulp_smash import api, config, selectors
+from pulp_smash import api, config, selectors, utils
 from pulp_smash.constants import FILE_FEED_URL
 from pulp_smash.tests.pulp3.constants import (
     FILE_IMPORTER_PATH,
@@ -25,7 +25,7 @@ from pulp_smash.tests.pulp3.utils import (
 )
 
 
-class ImportersPublishersTestCase(unittest.TestCase):
+class ImportersPublishersTestCase(unittest.TestCase, utils.SmokeTest):
     """Verify publisher and importer can be used with different repos."""
 
     def test_all(self):

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_auth.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_auth.py
@@ -16,7 +16,7 @@ from pulp_smash.tests.pulp3.pulpcore.utils import set_up_module as setUpModule  
 from pulp_smash.tests.pulp3.utils import JWTAuth
 
 
-class AuthTestCase(unittest.TestCase):
+class AuthTestCase(unittest.TestCase, utils.SmokeTest):
     """Test Pulp3 Authentication."""
 
     @classmethod

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_distributions.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_distributions.py
@@ -4,14 +4,14 @@ import unittest
 
 from requests.exceptions import HTTPError
 
-from pulp_smash import api, config, selectors
+from pulp_smash import api, config, selectors, utils
 from pulp_smash.tests.pulp3.constants import DISTRIBUTION_PATH
 from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_distribution
 from pulp_smash.tests.pulp3.utils import get_auth
 
 
-class CRUDDistributionsTestCase(unittest.TestCase):
+class CRUDDistributionsTestCase(unittest.TestCase, utils.SmokeTest):
     """CRUD distributions."""
 
     @classmethod

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_repos.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_repos.py
@@ -11,7 +11,7 @@ from pulp_smash.tests.pulp3.pulpcore.utils import set_up_module as setUpModule  
 from pulp_smash.tests.pulp3.utils import get_auth
 
 
-class CRUDRepoTestCase(unittest.TestCase):
+class CRUDRepoTestCase(unittest.TestCase, utils.SmokeTest):
     """CRUD repositories."""
 
     @classmethod

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_users.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_users.py
@@ -11,7 +11,7 @@ from pulp_smash.tests.pulp3.pulpcore.utils import set_up_module as setUpModule  
 from pulp_smash.tests.pulp3.utils import get_auth
 
 
-class UsersCRUDTestCase(unittest.TestCase):
+class UsersCRUDTestCase(unittest.TestCase, utils.SmokeTest):
     """CRUD users."""
 
     @classmethod

--- a/pulp_smash/utils.py
+++ b/pulp_smash/utils.py
@@ -546,3 +546,16 @@ def os_is_f27(cfg, pulp_system=None):
         '/etc/redhat-release',
     ))
     return response.returncode == 0
+
+
+class SmokeTest():  # pylint:disable=too-few-public-methods
+    """A class for identifying smoke tests.
+
+    Classes that inherit from this class are considered smoke tests, and may be
+    returned by Pulp Smash's CLI. (See :mod:`pulp_smash.pulp_smash_cli`.)
+    """
+    # Which test cases should be marked as smoke tests? For Pulp 3, a sane
+    # solution is to include test cases that belong to the Pulp 3 smoke tests
+    # milestone. [1] For Pulp 2, no similar milestone exists.
+    #
+    # [1] https://github.com/PulpQE/pulp-smash/milestone/22


### PR DESCRIPTION
This command prints the dotted name of each smoke test in Pulp Smash.
Sample usage:

    python -m unittest $(pulp-smash smoke-tests)