### PR TITLE
Add a template for Pulp-Smash issues.

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,12 @@
+
+1. Describe what you expected to happen.
+
+2. Describe what actually happened.
+
+3. Describe what version of Pulp and what OS is affected by the issue.
+
+4. State steps to re-create the issue.
+
+5. If there is a related pulp.plan.io issue, link to it, and set the "smash test" field.
+
+6. Choose proper labels. See: [Smash Labels](https://pulp-smash.readthedocs.io/en/latest/about.html#labels)


### PR DESCRIPTION
In order to create a standard, and make easy to a new contributor file
an issue it was included a template with the the basics steps in how to
file a pulp-smash issue.

It was added a dir `.github` to the root system of the project, thus
avoiding to add extra files to the root system of smash.

Futures templates can be added to the same dir as well.