### PR TITLE
Add tests for CRD artifacts.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -130,6 +130,7 @@ developers, not a gospel.
     api/pulp_smash.tests.pulp3.constants
     api/pulp_smash.tests.pulp3.file
     api/pulp_smash.tests.pulp3.file.api_v3
+    api/pulp_smash.tests.pulp3.file.api_v3.test_crd_artifacts
     api/pulp_smash.tests.pulp3.file.api_v3.test_crd_publications
     api/pulp_smash.tests.pulp3.file.api_v3.test_crud_importers
     api/pulp_smash.tests.pulp3.file.api_v3.test_crud_publishers

--- a/docs/api/pulp_smash.tests.pulp3.file.api_v3.test_crd_artifacts.rst
+++ b/docs/api/pulp_smash.tests.pulp3.file.api_v3.test_crd_artifacts.rst
@@ -1,0 +1,6 @@
+`pulp_smash.tests.pulp3.file.api_v3.test_crd_artifacts`
+=======================================================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.pulp3.file.api_v3.test_crd_artifacts`
+
+.. automodule:: pulp_smash.tests.pulp3.file.api_v3.test_crd_artifacts

--- a/pulp_smash/tests/pulp3/constants.py
+++ b/pulp_smash/tests/pulp3/constants.py
@@ -5,6 +5,8 @@ from urllib.parse import urljoin
 
 BASE_PATH = '/api/v3/'
 
+ARTIFACTS_PATH = urljoin(BASE_PATH, 'artifacts/')
+
 BASE_IMPORTER_PATH = urljoin(BASE_PATH, 'importers/')
 
 BASE_PUBLISHER_PATH = urljoin(BASE_PATH, 'publishers/')

--- a/pulp_smash/tests/pulp3/file/api_v3/test_crd_artifacts.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_crd_artifacts.py
@@ -1,0 +1,71 @@
+# coding=utf-8
+"""Tests that perform actions over artifacts."""
+import hashlib
+import unittest
+
+from requests.exceptions import HTTPError
+
+from pulp_smash import api, config, selectors, utils
+from pulp_smash.constants import FILE_URL
+from pulp_smash.tests.pulp3.constants import ARTIFACTS_PATH
+from pulp_smash.tests.pulp3.pulpcore.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp3.utils import clean_artifacts, get_auth
+
+
+class ArtifactTestCase(unittest.TestCase, utils.SmokeTest):
+    """Perform actions over an artifact."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create class-wide variable."""
+        cls.artifact = {}
+        cls.cfg = config.get_config()
+        cls.client = api.Client(cls.cfg, api.json_handler)
+        cls.client.request_kwargs['auth'] = get_auth()
+
+    def test_01_create(self):
+        """Create an artifact by uploading a file.
+
+        This test explores the design choice stated in `Pulp #2843`_ that an
+        artifact can be created using HTTP POST with a body of request that
+        contains a multipart form data.
+
+        This test targets the following issues:
+
+        * `Pulp #2843 <https://pulp.plan.io/issues/2843>`_
+        * `Pulp Smash #726 <https://github.com/PulpQE/pulp-smash/issues/726>`_
+
+        Do the following:
+
+        1. Download a file in memory.
+        2. Upload the just downloaded file to pulp.
+        3. Verify that the checksum of the just created artifact is equal to
+           the checksum of the file that was uploaded.
+        """
+        files = {'file': utils.http_get(FILE_URL)}
+
+        # To avoid upload of duplicates in pulp. This function call may be
+        # removed after pulp3 is able to handle duplicates, and how to delete
+        # artifacts that are content units as well.
+        clean_artifacts(self.cfg)
+
+        type(self).artifact = self.client.post(ARTIFACTS_PATH, files=files)
+        self.assertEqual(
+            self.artifact['sha256'],
+            hashlib.sha256(files['file']).hexdigest()
+        )
+
+    @selectors.skip_if(bool, 'artifact', False)
+    def test_02_read(self):
+        """Read an artifact by its href."""
+        artifact = self.client.get(self.artifact['_href'])
+        for key, val in self.artifact.items():
+            with self.subTest(key=key):
+                self.assertEqual(artifact[key], val)
+
+    @selectors.skip_if(bool, 'artifact', False)
+    def test_03_delete(self):
+        """Delete an artifact."""
+        self.client.delete(self.artifact['_href'])
+        with self.assertRaises(HTTPError):
+            self.client.get(self.artifact['_href'])

--- a/pulp_smash/tests/pulp3/utils.py
+++ b/pulp_smash/tests/pulp3/utils.py
@@ -11,6 +11,8 @@ from requests.exceptions import HTTPError
 
 from pulp_smash import api, config, selectors
 from pulp_smash.tests.pulp3.constants import (
+    ARTIFACTS_PATH,
+    FILE_CONTENT_PATH,
     FILE_IMPORTER_PATH,
     JWT_PATH,
     STATUS_PATH,
@@ -230,3 +232,30 @@ def get_content_unit_names(repo):
         content_unit['path']  # A misnomer. Think "name," not "path."
         for content_unit in read_repo_content(repo)['results']
     ]
+
+
+def clean_artifacts(cfg=None):
+    """Clean all artifacts present in pulp.
+
+    :param pulp_smash.config.PulpSmashConfig cfg: Information about the Pulp
+        host.
+    """
+    if cfg is None:
+        cfg = config.get_config()
+    clean_content_units(cfg)
+    client = api.Client(cfg, api.json_handler)
+    for artifact in client.get(ARTIFACTS_PATH)['results']:
+        client.delete(artifact['_href'])
+
+
+def clean_content_units(cfg=None):
+    """Clean all content units present in pulp.
+
+    :param pulp_smash.config.PulpSmashConfig cfg: Information about the Pulp
+     host.
+    """
+    if cfg is None:
+        cfg = config.get_config()
+    client = api.Client(cfg, api.json_handler)
+    for content_unit in client.get(FILE_CONTENT_PATH)['results']:
+        client.delete(content_unit['_href'])


### PR DESCRIPTION
As of this writing, pulp3 does not handle upload of duplicate files.
Due that, there is a need to clean the artifacts present in pulp3, before
attempt to upload a new file to pulp3.
However, if a file exists as content unit and as artifact, the file has
to be deleted first as a content unit then as an artifact.
To solve this issue, 2 new functions were added to pulp3/utils.

- `clean_content_units()`
- `clean_artifacts()`

Add tests to CRD artifacts.

1. Create an artifact by uploading a file to pulp3.
2. Reads an artifact by its href.
3. Delete an artifact.

Closes: #726