### PR TITLE
Revert Modify function gen_distribution for Pulp3.

### DIFF
--- a/pulp_smash/tests/pulp3/pulpcore/utils.py
+++ b/pulp_smash/tests/pulp3/pulpcore/utils.py
@@ -20,7 +20,7 @@ def set_up_module():
 def gen_distribution():
     """Return a semi-random dict for use in creating a distribution."""
     return {
-        'base_path': utils.uuid4() + '/',
+        'base_path': utils.uuid4(),
         'http': choice((False, True)),
         'https': choice((False, True)),
         'name': utils.uuid4()


### PR DESCRIPTION
This reverts commit 9bc6e8e7a3d01fee2ba68f8ecc5f35389197ec1a.

When a distribution has a trailing slash on its base path, files can't
be downloaded. This may be a bug.