### PR TITLE
Test upload of a manifest list V2 without a sync.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -29,6 +29,7 @@ developers, not a gospel.
     api/pulp_smash.tests.pulp2.docker.api_v2.test_sync
     api/pulp_smash.tests.pulp2.docker.api_v2.test_sync_publish
     api/pulp_smash.tests.pulp2.docker.api_v2.test_tags
+    api/pulp_smash.tests.pulp2.docker.api_v2.test_upload
     api/pulp_smash.tests.pulp2.docker.api_v2.utils
     api/pulp_smash.tests.pulp2.docker.cli
     api/pulp_smash.tests.pulp2.docker.cli.test_crud

--- a/docs/api/pulp_smash.tests.pulp2.docker.api_v2.test_upload.rst
+++ b/docs/api/pulp_smash.tests.pulp2.docker.api_v2.test_upload.rst
@@ -1,0 +1,6 @@
+`pulp_smash.tests.pulp2.docker.api_v2.test_upload`
+==================================================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.pulp2.docker.api_v2.test_upload`
+
+.. automodule:: pulp_smash.tests.pulp2.docker.api_v2.test_upload

--- a/pulp_smash/tests/pulp2/docker/api_v2/test_upload.py
+++ b/pulp_smash/tests/pulp2/docker/api_v2/test_upload.py
@@ -1,0 +1,92 @@
+# coding=utf-8
+"""Tests for uploading content to docker repositories."""
+import unittest
+
+from pulp_smash import api, cli, config, selectors, utils
+from pulp_smash.constants import DOCKER_V2_FEED_URL
+from pulp_smash.tests.pulp2.docker.api_v2.utils import SyncPublishMixin
+from pulp_smash.tests.pulp2.docker.utils import (
+    set_up_module,
+    write_manifest_list,
+)
+
+
+def setUpModule():  # pylint:disable=invalid-name
+    """Execute ``pulp-admin login``."""
+    set_up_module()
+    utils.pulp_admin_login(config.get_config())
+
+
+class UploadManifestListV2TestCase(SyncPublishMixin, unittest.TestCase):
+    """Test upload of manifest list V2 without perform a sync."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create class-wide variables."""
+        super().setUpClass()
+        cls.cfg = config.get_config()
+        if (utils.os_is_f26(cls.cfg) and
+                selectors.bug_is_untestable(3036, cls.cfg.pulp_version)):
+            raise unittest.SkipTest('https://pulp.plan.io/issues/3036')
+        for issue_id in (2287, 2384, 2993):
+            if selectors.bug_is_untestable(issue_id, cls.cfg.pulp_version):
+                raise unittest.SkipTest(
+                    'https://pulp.plan.io/issues/{}'.format(issue_id)
+                )
+
+    def setUp(self):
+        """Create a docker repository."""
+        self.repo = self.create_repo(self.cfg, False, True, DOCKER_V2_FEED_URL)
+
+    @selectors.skip_if(bool, 'repo', False)
+    def test_01_upload_manifest_list(self):
+        """Test upload of manifest list V2 without perform a sync.
+
+        This test targets the following issues:
+
+        * `Pulp Smash #829 <https://github.com/PulpQE/pulp-smash/issues/829>`_
+        * `Pulp #2993 <https://pulp.plan.io/issues/2993>`_
+
+        Do the following:
+
+        1. Create, sync and publish a repository.
+        2. Read the manifest list, and remove one of the existent
+           architectures from it.
+        3. From the modified manifest list create a new JSON valid on a
+           temporary dir on disk.
+        4. Upload the just created JSON file to the repository.
+        5. Assert that the number of ``docker_manifest_list`` present on the
+           repository has increased.
+        """
+        content_type = (
+            'application/vnd.docker.distribution.manifest.list.v2+json'
+        )
+        client = api.Client(
+            self.cfg,
+            request_kwargs={'headers': {'accept': content_type}}
+        )
+        client.request_kwargs['url'] = self.adjust_url(
+            client.request_kwargs['url']
+        )
+        response = client.get(
+            '/v2/{}/manifests/latest'.format(self.repo['id'])
+        )
+        manifest_list = response.json()
+        # In order to modify the current manifest list, one unwanted
+        # architecture is removed.
+        manifest_list['manifests'].pop()
+        manifest_path, dir_path = write_manifest_list(self.cfg, manifest_list)
+        repos = []
+        api_client = api.Client(self.cfg, api.json_handler)
+        repos.append(api_client.get(self.repo['_href']))
+        cli_client = cli.Client(self.cfg)
+        self.addCleanup(cli_client.run, ('rm', '-rf', dir_path))
+        cli_client.machine.session().run(
+            'pulp-admin docker repo uploads upload --repo-id {} -f {}'
+            .format(self.repo['id'], manifest_path)
+        )
+        repos.append(api_client.get(self.repo['_href']))
+        self.assertGreater(
+            repos[1]['content_unit_counts']['docker_manifest_list'],
+            repos[0]['content_unit_counts']['docker_manifest_list']
+        )

--- a/pulp_smash/tests/pulp2/docker/api_v2/utils.py
+++ b/pulp_smash/tests/pulp2/docker/api_v2/utils.py
@@ -1,6 +1,10 @@
 # coding=utf-8
 """Utility functions for Docker API tests."""
-from pulp_smash import utils
+from urllib.parse import urlsplit, urlunsplit
+
+from pulp_smash import api, cli, utils
+from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
+from pulp_smash.tests.pulp2.docker.utils import get_upstream_name
 
 
 def gen_repo():
@@ -21,3 +25,94 @@ def gen_distributor():
         'distributor_id': utils.uuid4(),
         'distributor_type_id': 'docker_distributor_web',
     }
+
+
+class SyncPublishMixin():
+    """Tools for test cases that sync and publish Docker repositories.
+
+    This class must be mixed in to a class that inherits from
+    ``unittest.TestCase``.
+    """
+
+    @staticmethod
+    def adjust_url(url):
+        """Return a URL that can be used for talking with Crane.
+
+        The URL returned is the same as ``url``, except that the scheme is set
+        to HTTP, and the port is set to (or replaced by) 5000.
+
+        :param url: A string, such as ``https://pulp.example.com/foo``.
+        :returns: A string, such as ``http://pulp.example.com:5000/foo``.
+        """
+        parse_result = urlsplit(url)
+        netloc = parse_result[1].partition(':')[0] + ':5000'
+        return urlunsplit(('http', netloc) + parse_result[2:])
+
+    @staticmethod
+    def make_crane_client(cfg):
+        """Make an API client for talking with Crane.
+
+        Create an API client for talking to Crane. The client returned by this
+        method is similar to the following ``client``:
+
+        >>> client = api.Client(cfg, api.json_handler)
+
+        However:
+
+        * The client's base URL is adjusted as described by :meth:`adjust_url`.
+        * The client will send an ``accept:application/json`` header with each
+          request.
+
+        :param pulp_smash.config.PulpSmashConfig cfg: Information about a Pulp
+            deployment.
+        :returns: An API client for talking with Crane.
+        :rtype: pulp_smash.api.Client
+        """
+        client = api.Client(
+            cfg,
+            api.json_handler,
+            {'headers': {'accept': 'application/json'}},
+        )
+        client.request_kwargs['url'] = SyncPublishMixin.adjust_url(
+            client.request_kwargs['url']
+        )
+        return client
+
+    def create_repo(self, cfg, enable_v1, enable_v2, feed):
+        """Create, sync and publish a repository.
+
+        Specifically do the following:
+
+        1. Create, sync and publish a Docker repository.
+        2. Make Crane immediately re-read the metadata files published by
+           Pulp.(Restart Apache)
+
+        :param pulp_smash.config.PulpSmashConfig cfg: Information about a Pulp
+            deployment.
+        :param enable_v1: A boolean. Either ``True`` or ``False``.
+        :param enable_v2: A boolean. Either ``True`` or ``False``.
+        :param feed: A value for the docker importer's ``feed`` option.
+        :returns: A detailed dict of information about the repository.
+        """
+        client = api.Client(cfg, api.json_handler)
+        body = gen_repo()
+        body['importer_config'].update({
+            'enable_v1': enable_v1,
+            'enable_v2': enable_v2,
+            'feed': feed,
+            'upstream_name': get_upstream_name(cfg),
+        })
+        body['distributors'] = [gen_distributor()]
+        repo = client.post(REPOSITORY_PATH, body)
+        self.addCleanup(client.delete, repo['_href'])
+        repo = client.get(
+            repo['_href'],
+            params={'details': True}
+        )
+        utils.sync_repo(cfg, repo)
+        utils.publish_repo(cfg, repo)
+
+        # Make Crane re-read metadata. (Now!)
+        cli.GlobalServiceManager(cfg).restart(('httpd',))
+
+        return repo

--- a/pulp_smash/tests/pulp2/docker/utils.py
+++ b/pulp_smash/tests/pulp2/docker/utils.py
@@ -1,19 +1,23 @@
 # coding=utf-8
 """Utilities for Docker tests."""
+import os
+import json
+
 from packaging.version import Version
 
+from pulp_smash import cli, utils
 from pulp_smash.constants import (
     DOCKER_UPSTREAM_NAME,
     DOCKER_UPSTREAM_NAME_NOLIST,
 )
-from pulp_smash.tests.pulp2 import utils
+from pulp_smash.tests.pulp2 import utils as pulp2_utils
 
 
 def set_up_module():
     """Skip tests if Pulp 2 isn't under test or if Docker isn't installed."""
-    utils.require_pulp_2()
-    utils.require_issue_3159()
-    utils.require_unit_types({'docker_image'})
+    pulp2_utils.require_pulp_2()
+    pulp2_utils.require_issue_3159()
+    pulp2_utils.require_unit_types({'docker_image'})
 
 
 def get_upstream_name(cfg):
@@ -27,3 +31,28 @@ def get_upstream_name(cfg):
     if cfg.pulp_version < Version('2.14'):
         return DOCKER_UPSTREAM_NAME_NOLIST
     return DOCKER_UPSTREAM_NAME
+
+
+def write_manifest_list(cfg, manifest_list):
+    """Write out a content source to JSON file.
+
+    :param pulp_smash.config.PulpSmashConfig cfg: The Pulp deployment on
+        which to create a repository.
+    :param manifest_list: A detailed dict of information about the manifest
+        list.
+    :return: The path to created file, and the path to dir that stores the
+        file.
+    """
+    sudo = '' if utils.is_root(cfg) else 'sudo'
+    client = cli.Client(cfg)
+    dir_path = client.run('mktemp --directory'.split()).stdout.strip()
+    file_path = os.path.join(dir_path, utils.uuid4() + '.json')
+    manifest_list_json = json.dumps(manifest_list)
+    client.machine.session().run(
+        "{} echo '{}' > {}".format(
+            sudo,
+            manifest_list_json,
+            file_path
+        )
+    )
+    return file_path, dir_path


### PR DESCRIPTION
Move `SyncPublishMixin` to docker/api_v2/utils. This class will be used
as a helper to existent tests, and for new ones. This change is
necessary to avoid DRY.

Refactor and rename existent tests to reflect the previous change.

Create a helper function `write_manifest_list` on docker/utils.

Do the following:

 1. Create, sync and publish a repository.
 2. Read the manifest list,and remove one of the existent architectures
  from it.
 3. From the modified manifest list create a new JSON valid on a
  temporary dir on disk.
 4. Upload the just created JSON file to the repository.
 5. Assert that the number of `docker_manifest_list` present on the
  repository has increased.

Closes: #829