### PR TITLE
Re-factor read_repo_content.

### DIFF
--- a/pulp_smash/tests/pulp3/utils.py
+++ b/pulp_smash/tests/pulp3/utils.py
@@ -210,16 +210,25 @@ def get_latest_repo_version(repo):
             .get(repo['_href'])['_latest_version_href'])
 
 
-def read_repo_content(repo):
+def read_repo_content(repo, version=None):
     """Read the content units of a given repository.
 
+    In case the repository version is not provided, the content of latest
+    repository version will be read.
+
     :param repo: A dict of information about the repository.
-    :returns: A dict of information about the contents units present in a given
-        repository.
+    :param version: An integer specifying what repository version should be
+        read.
+    :returns: A dict of information about the content units present in a given
+        repository version.
     """
+    if version is None:
+        version_href = get_latest_repo_version(repo)
+    else:
+        version_href = urljoin(repo['_versions_href'], str(version) + '/')
     return (api
             .Client(config.get_config(), api.json_handler)
-            .get(urljoin(get_latest_repo_version(repo), 'content/')))
+            .get(urljoin(version_href, 'content/')))
 
 
 def get_content_unit_paths(repo):


### PR DESCRIPTION
Pulp3 allows mutliple repository versions. Adjust function
`read_repo_content` to reflect this.
Add the paramter `version` to the function `read_repo_content` thus
allowing read the content of a specific repository version. If `version`
is None, the latest repo version will be read.
This change will help future tests that require read content from the
same repo, but from different versions.