### PR TITLE
Add tests to view content for a repository version.

### DIFF
--- a/pulp_smash/tests/pulp3/file/api_v3/test_repo_version.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_repo_version.py
@@ -5,23 +5,21 @@ from random import choice
 from urllib.parse import urljoin
 
 from pulp_smash import api, config, utils
-from pulp_smash.constants import FILE_FEED_URL
+from pulp_smash.constants import FILE_FEED_COUNT, FILE_FEED_URL
 from pulp_smash.tests.pulp3.constants import (
     FILE_CONTENT_PATH,
     FILE_IMPORTER_PATH,
-    FILE_PUBLISHER_PATH,
     REPO_PATH,
 )
-from pulp_smash.tests.pulp3.file.api_v3.utils import (
-    gen_importer,
-    gen_publisher,
-)
+from pulp_smash.tests.pulp3.file.api_v3.utils import gen_importer
 from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
 from pulp_smash.tests.pulp3.utils import (
     get_auth,
     get_latest_repo_version,
+    read_repo_added_content,
     read_repo_content,
+    read_repo_removed_content,
     sync_repo,
 )
 
@@ -29,7 +27,28 @@ from pulp_smash.tests.pulp3.utils import (
 class AddingRemovingUnitsTestCase(unittest.TestCase, utils.SmokeTest):
     """Create new repo version adding or removing content."""
 
-    def test_all(self):
+    @classmethod
+    def setUpClass(cls):
+        """Create class-wide variables.
+
+        Sync a repository.
+        """
+        cls.cfg = config.get_config()
+        cls.client = api.Client(cls.cfg, api.json_handler)
+        cls.client.request_kwargs['auth'] = get_auth()
+        body = gen_importer()
+        body['feed_url'] = urljoin(FILE_FEED_URL, 'PULP_MANIFEST')
+        cls.importer = cls.client.post(FILE_IMPORTER_PATH, body)
+        cls.repo = cls.client.post(REPO_PATH, gen_repo())
+        sync_repo(cls.cfg, cls.importer, cls.repo)
+
+    @classmethod
+    def tearDownClass(cls):
+        """Clean class-wide variables."""
+        cls.client.delete(cls.importer['_href'])
+        cls.client.delete(cls.repo['_href'])
+
+    def test_01_create_repo_version(self):
         """Create a new repo version adding or removing content.
 
         This test explores the design choice stated in `Pulp #3234`_ that
@@ -40,43 +59,26 @@ class AddingRemovingUnitsTestCase(unittest.TestCase, utils.SmokeTest):
 
         Do the following:
 
-        1. Create and sync a repository.
-        2. Create a second repository.
-        3. Use ``add_content_units`` to pass an url for a unit to be added
-           to second repository.
-        4. Assert that the repository version has changed for the second
-           repository.
-        5. Assert that there is just one content unit in the second repository.
-        6. Remove the just added unit from the second repository using the
-           ``remove_content_units``, and assert that the repository version has
-           changed.
-        7. Assert that there are no content units present in the second
-           repository.
+        1. Create a repository.
+        2. Use ``add_content_units`` to pass an url for a unit to be added
+           to the repository.
+        3. Assert that the repository version has changed.
+        4. Assert that there is just one content unit in the repository.
+        5. Remove the just added unit from the repository using the
+           ``remove_content_units``, and assert that the repository version
+           has changed.
+        6. Assert that there are no content units present in the repository.
         """
-        # Add content to Pulp.
-        cfg = config.get_config()
-        client = api.Client(cfg, api.json_handler)
-        client.request_kwargs['auth'] = get_auth()
-        body = gen_importer()
-        body['feed_url'] = urljoin(FILE_FEED_URL, 'PULP_MANIFEST')
-        importer = client.post(FILE_IMPORTER_PATH, body)
-        self.addCleanup(client.delete, importer['_href'])
-        publisher = client.post(FILE_PUBLISHER_PATH, gen_publisher())
-        self.addCleanup(client.delete, publisher['_href'])
-        repo = client.post(REPO_PATH, gen_repo())
-        self.addCleanup(client.delete, repo['_href'])
-        sync_repo(cfg, importer, repo)
-
-        # Create second repository.
-        repo = client.post(REPO_PATH, gen_repo())
-        self.addCleanup(client.delete, repo['_href'])
+        # Create repository.
+        repo = self.client.post(REPO_PATH, gen_repo())
+        self.addCleanup(self.client.delete, repo['_href'])
         repo_versions = []
         repo_versions.append(get_latest_repo_version(repo))
 
         # Add content unit to the second repository.
-        file_content = client.get(FILE_CONTENT_PATH)['results']
+        file_content = self.client.get(FILE_CONTENT_PATH)['results']
         content_href = choice(file_content)['_href']
-        client.post(
+        self.client.post(
             repo['_versions_href'],
             {'add_content_units': [content_href]}
         )
@@ -89,10 +91,47 @@ class AddingRemovingUnitsTestCase(unittest.TestCase, utils.SmokeTest):
         )
 
         # Remove content unit from the second repository.
-        client.post(
+        self.client.post(
             repo['_versions_href'],
             {'remove_content_units': [content_href]}
         )
         repo_versions.append(get_latest_repo_version(repo))
         self.assertNotEqual(repo_versions[1], repo_versions[2])
         self.assertEqual(len(read_repo_content(repo)['results']), 0)
+
+    def test_02_view_content(self):
+        """Test whether a user can view content for a repository version.
+
+        This test targets the following issues:
+
+        * `Pulp #3059 <https://pulp.plan.io/issues/3059>`_
+        * `Pulp Smash #878 <https://github.com/PulpQE/pulp-smash/issues/878>`_
+
+        Do the following:
+
+        1. Assert that ``content_summary`` has the correct number of files
+           according to the sync ``feed_url``.
+        2. Assert that the content present on the last version of repository
+           is equal to the content that was added to the the last version.
+           Inspect ``/added_content/`` and ``/content/`` endpoints to
+           achieve this.
+        3. Remove a content unit from the repository, and assert that endpoint
+           ``removed_content`` represents this change.
+        """
+        versions_href = self.client.get(self.repo['_href'])['_versions_href']
+        detail_view = self.client.get(versions_href)
+        content_summary = detail_view['results'][0]['content_summary']
+        self.assertEqual(int(content_summary['file']), FILE_FEED_COUNT)
+        repo_content = read_repo_content(self.repo)
+        added_content = read_repo_added_content(self.repo)
+        self.assertListEqual(
+            repo_content['results'],
+            added_content['results']
+        )
+        content_href = choice(repo_content['results'])['_href']
+        self.client.post(
+            self.repo['_versions_href'],
+            {'remove_content_units': [content_href]}
+        )
+        removed_content = read_repo_removed_content(self.repo)
+        self.assertEqual(content_href, removed_content['results'][0]['_href'])

--- a/pulp_smash/tests/pulp3/utils.py
+++ b/pulp_smash/tests/pulp3/utils.py
@@ -236,6 +236,42 @@ def read_repo_content(repo, version=None):
             .get(urljoin(version_href, 'content/')))
 
 
+def read_repo_added_content(repo, version=None):
+    """Read the added content of a given repository version.
+
+    :param repo: A dict of information about the repository.
+    :param version: An integer specifying what repository version should be
+     read.
+    :returns: A dict of information about the content added since the
+     previous repository version.
+    """
+    if version is None:
+        version_href = get_latest_repo_version(repo)
+    else:
+        version_href = urljoin(repo['_versions_href'], str(version) + '/')
+    return (api
+            .Client(config.get_config(), api.json_handler)
+            .get(urljoin(version_href, 'added_content/')))
+
+
+def read_repo_removed_content(repo, version=None):
+    """Read the removed content of a given repository version.
+
+    :param repo: A dict of information about the repository.
+    :param version: An integer specifying what repository version should be
+     read.
+    :returns: A dict of information about the content removed since the
+     previous repository version.
+    """
+    if version is None:
+        version_href = get_latest_repo_version(repo)
+    else:
+        version_href = urljoin(repo['_versions_href'], str(version) + '/')
+    return (api
+            .Client(config.get_config(), api.json_handler)
+            .get(urljoin(version_href, 'removed_content/')))
+
+
 def get_content_unit_paths(repo):
     """Return the relative path of content units present in a given repository.
 


### PR DESCRIPTION
Refactor the `AddingRemovingUnitsTestCase` to add the tests related to
the view content for a repository version. Move commom code to
`setUpClass`.

Add 2 helper functions to `pulp3/utils`.

* read_repo_added_content
* read_repo_removed_content

To the test the issue - view content for a repository version. Do the following:

 1. Assert that `content_summary` has the correct number of files according to the sync `feed_url`.
 2. Assert that the content present on the last version of repository is equal to the content that was added to the the last version.Inspect `/added_content/` and `/content/` endpoints to achieve this.
 3. Remove a content unit from the repository, and assert that endpoint `removed_content` represents this change.

Closes: #878