### PR TITLE
Add test to delete content unit used by a repo version.

### DIFF
--- a/pulp_smash/tests/pulp3/file/api_v3/test_crud_content_unit.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_crud_content_unit.py
@@ -1,14 +1,28 @@
 # coding=utf-8
 """Tests that perform actions over content unit."""
 import unittest
+from random import choice
+from urllib.parse import urljoin
 
 from requests.exceptions import HTTPError
 
 from pulp_smash import api, config, selectors, utils
-from pulp_smash.constants import FILE_URL
-from pulp_smash.tests.pulp3.constants import ARTIFACTS_PATH, FILE_CONTENT_PATH
+from pulp_smash.constants import FILE_FEED_URL, FILE_URL
+from pulp_smash.tests.pulp3.constants import (
+    ARTIFACTS_PATH,
+    FILE_CONTENT_PATH,
+    FILE_IMPORTER_PATH,
+    REPO_PATH,
+)
+from pulp_smash.tests.pulp3.file.api_v3.utils import gen_importer
 from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
-from pulp_smash.tests.pulp3.utils import clean_artifacts, get_auth
+from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
+from pulp_smash.tests.pulp3.utils import (
+    clean_artifacts,
+    get_auth,
+    get_content,
+    sync_repo,
+)
 
 
 class ContentUnitTestCase(unittest.TestCase, utils.SmokeTest):
@@ -87,3 +101,43 @@ def _gen_content_unit_attrs(artifact):
     :returns: A semi-random dict for use in creating a content unit.
     """
     return {'artifact': artifact['_href'], 'relative_path': utils.uuid4()}
+
+
+class DeleteContentUnitRepoVersionTestCase(unittest.TestCase, utils.SmokeTest):
+    """Test whether content unit used by a repo version can be deleted.
+
+    This test targets the following issues:
+
+    * `Pulp #3418 <https://pulp.plan.io/issues/3418>`_
+    * `Pulp Smash #900 <https://github.com/PulpQE/pulp-smash/issues/900>`_
+    """
+
+    def test_all(self):
+        """Test whether content unit used by a repo version can be deleted.
+
+        Do the following:
+
+        1. Sync content to a repository.
+        2. Attempt to delete a content unit present in a repository version.
+           Assert that a HTTP exception was raised.
+        3. Assert that number of content units present on the repository
+           does not change after the attempt to delete one content unit.
+        """
+        cfg = config.get_config()
+        client = api.Client(cfg, api.json_handler)
+        client.request_kwargs['auth'] = get_auth()
+        body = gen_importer()
+        body['feed_url'] = urljoin(FILE_FEED_URL, 'PULP_MANIFEST')
+        importer = client.post(FILE_IMPORTER_PATH, body)
+        self.addCleanup(client.delete, importer['_href'])
+        repo = client.post(REPO_PATH, gen_repo())
+        self.addCleanup(client.delete, repo['_href'])
+        sync_repo(cfg, importer, repo)
+        repo = client.get(repo['_href'])
+        content = get_content(repo)['results']
+        with self.assertRaises(HTTPError):
+            client.delete(choice(content)['_href'])
+        self.assertEqual(
+            len(content),
+            len(get_content(repo)['results'])
+        )


### PR DESCRIPTION
Test whether content unit used by a repo version can be deleted.

Do the following:

 1. Sync content to a repository.
 2. Attempt to delete a content unit present in a repository version. Assert that a HTTP exception was raised.
 3. Assert that number of content units present on the repository does not change after the attempt to delete one content unit.

Closes: #900