### PR TITLE
Update get_plugins function.

### DIFF
--- a/pulp_smash/tests/pulp3/file/utils.py
+++ b/pulp_smash/tests/pulp3/file/utils.py
@@ -6,4 +6,4 @@ from pulp_smash.tests.pulp3 import utils
 def set_up_module():
     """Skip tests Pulp 3 isn't under test or if pulp-file isn't installed."""
     utils.require_pulp_3()
-    utils.require_pulp_plugins({'pulp-file'})
+    utils.require_pulp_plugins({'pulp_file'})

--- a/pulp_smash/tests/pulp3/utils.py
+++ b/pulp_smash/tests/pulp3/utils.py
@@ -7,13 +7,11 @@ from urllib.parse import urljoin, urlsplit
 
 from packaging.version import Version
 from requests.auth import AuthBase, HTTPBasicAuth
-from requests.exceptions import HTTPError
 
 from pulp_smash import api, config, selectors
 from pulp_smash.tests.pulp3.constants import (
     ARTIFACTS_PATH,
     FILE_CONTENT_PATH,
-    FILE_IMPORTER_PATH,
     JWT_PATH,
     STATUS_PATH,
 )
@@ -143,23 +141,14 @@ def get_plugins(cfg=None):
 
     :param pulp_smash.config.PulpSmashConfig cfg: Information about the Pulp
         application under test.
-    :returns: A set of plugin names, e.g. ``{'pulpcore', 'pulp-file'}``.
+    :returns: A set of plugin names, e.g. ``{'pulpcore', 'pulp_file'}``.
     """
     if not cfg:
         cfg = config.get_config()
     client = api.Client(cfg, api.json_handler)
-    plugins = {
+    return {
         version['component'] for version in client.get(STATUS_PATH)['versions']
     }
-
-    # As of this writing, only the pulpcore plugin reports its existence.
-    try:
-        client.get(FILE_IMPORTER_PATH)
-        plugins.add('pulp-file')  # Name of PyPI package.
-    except HTTPError:
-        pass
-
-    return plugins
 
 
 def sync_repo(cfg, importer, repo):


### PR DESCRIPTION
The current version of Pulp 3 status page /api/v3/status is returning the plugins
installed.

For example:

```json
"versions": [
        {
            "component": "pulpcore",
            "version": "3.0.0a1"
        },
        {
            "component": "pulp_file",
            "version": "0.0.1a1"
        }
    ]

```

Adjust the get_plugins function to make use of this feature.