### PR TITLE
Add tests to status page.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -149,6 +149,7 @@ developers, not a gospel.
     api/pulp_smash.tests.pulp3.pulpcore.api_v3.test_crud_distributions
     api/pulp_smash.tests.pulp3.pulpcore.api_v3.test_crud_repos
     api/pulp_smash.tests.pulp3.pulpcore.api_v3.test_crud_users
+    api/pulp_smash.tests.pulp3.pulpcore.api_v3.test_status
     api/pulp_smash.tests.pulp3.pulpcore.utils
     api/pulp_smash.tests.pulp3.utils
     api/pulp_smash.utils

--- a/docs/api/pulp_smash.tests.pulp3.pulpcore.api_v3.test_status.rst
+++ b/docs/api/pulp_smash.tests.pulp3.pulpcore.api_v3.test_status.rst
@@ -1,0 +1,6 @@
+`pulp_smash.tests.pulp3.pulpcore.api_v3.test_status`
+====================================================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.pulp3.pulpcore.api_v3.test_status`
+
+.. automodule:: pulp_smash.tests.pulp3.pulpcore.api_v3.test_status

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_status.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_status.py
@@ -1,0 +1,47 @@
+# coding=utf-8
+"""Test the status page."""
+import unittest
+
+from requests.exceptions import HTTPError
+
+from pulp_smash import api, config, selectors, utils
+from pulp_smash.tests.pulp3.constants import STATUS_PATH
+from pulp_smash.tests.pulp3.pulpcore.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+
+
+class StatusTestCase(unittest.TestCase, utils.SmokeTest):
+    """Tests related to the status page.
+
+    This test explores the following issues:
+
+    * `Pulp #2804 <https://pulp.plan.io/issues/2804>`_
+    * `Pulp #2867 <https://pulp.plan.io/issues/2867>`_
+    * `Pulp Smash #755 <https://github.com/PulpQE/pulp-smash/issues/755>`_
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Create class-wide variables."""
+        cls.cfg = config.get_config()
+        cls.client = api.Client(cls.cfg, api.json_handler)
+        cls.status = {}
+
+    def test_01_access_status(self):
+        """Verify whether an un-authenticated user can view status page."""
+        self.status.update(self.client.get(STATUS_PATH))
+
+    @selectors.skip_if(bool, 'status', False)
+    def test_02_data_content(self):
+        """Verify whether few parameters are present on status page."""
+        self.assertTrue(self.status['database_connection'])
+        self.assertTrue(self.status['messaging_connection'])
+        self.assertTrue(self.status['known_workers'])
+        self.assertTrue(self.status['versions'])
+
+    def test_03_http_method(self):
+        """Verify whether an HTTP exception is raised.
+
+        When using a not allowed HTTP method.
+        """
+        with self.assertRaises(HTTPError):
+            self.client.post(STATUS_PATH)


### PR DESCRIPTION
Add basic test coverage to ``api/v3/status``.

Verify whether un-authenitcated user can view the status page.
Verify whether few parameters are present on the status page.
Verify whether an HTTP exception is raised. When using a not allowed
method.

Closes: #755