### PR TITLE
Remove delete content units.

### DIFF
--- a/pulp_smash/tests/pulp3/constants.py
+++ b/pulp_smash/tests/pulp3/constants.py
@@ -37,6 +37,8 @@ See `pulpcore.app.models.Importer
 
 JWT_PATH = urljoin(BASE_PATH, 'jwt/')
 
+ORPHANS_PATH = urljoin(BASE_PATH, 'orphans/')
+
 PUBLICATIONS_PATH = urljoin(BASE_PATH, 'publications/')
 
 REPO_PATH = urljoin(BASE_PATH, 'repositories/')

--- a/pulp_smash/tests/pulp3/file/api_v3/test_crd_artifacts.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_crd_artifacts.py
@@ -9,7 +9,7 @@ from pulp_smash import api, config, selectors, utils
 from pulp_smash.constants import FILE_URL
 from pulp_smash.tests.pulp3.constants import ARTIFACTS_PATH
 from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
-from pulp_smash.tests.pulp3.utils import clean_artifacts, get_auth
+from pulp_smash.tests.pulp3.utils import delete_orphans, get_auth
 
 
 class ArtifactTestCase(unittest.TestCase, utils.SmokeTest):
@@ -20,6 +20,7 @@ class ArtifactTestCase(unittest.TestCase, utils.SmokeTest):
         """Create class-wide variable."""
         cls.artifact = {}
         cls.cfg = config.get_config()
+        delete_orphans(cls.cfg)
         cls.client = api.Client(cls.cfg, api.json_handler)
         cls.client.request_kwargs['auth'] = get_auth()
 
@@ -43,12 +44,6 @@ class ArtifactTestCase(unittest.TestCase, utils.SmokeTest):
            the checksum of the file that was uploaded.
         """
         files = {'file': utils.http_get(FILE_URL)}
-
-        # To avoid upload of duplicates in pulp. This function call may be
-        # removed after pulp3 is able to handle duplicates, and how to delete
-        # artifacts that are content units as well.
-        clean_artifacts(self.cfg)
-
         type(self).artifact = self.client.post(ARTIFACTS_PATH, files=files)
         self.assertEqual(
             self.artifact['sha256'],

--- a/pulp_smash/tests/pulp3/file/api_v3/test_crud_content_unit.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_crud_content_unit.py
@@ -18,7 +18,7 @@ from pulp_smash.tests.pulp3.file.api_v3.utils import gen_importer
 from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
 from pulp_smash.tests.pulp3.utils import (
-    clean_artifacts,
+    delete_orphans,
     get_auth,
     get_content,
     sync_repo,
@@ -38,7 +38,7 @@ class ContentUnitTestCase(unittest.TestCase, utils.SmokeTest):
     def setUpClass(cls):
         """Create class-wide variable."""
         cls.cfg = config.get_config()
-        clean_artifacts(cls.cfg)
+        delete_orphans(cls.cfg)
         cls.content_unit = {}
         cls.client = api.Client(cls.cfg, api.json_handler)
         cls.client.request_kwargs['auth'] = get_auth()
@@ -48,7 +48,7 @@ class ContentUnitTestCase(unittest.TestCase, utils.SmokeTest):
     @classmethod
     def tearDownClass(cls):
         """Clean class-wide variable."""
-        cls.client.delete(cls.artifact['_href'])
+        delete_orphans(cls.cfg)
 
     def test_01_create_content_unit(self):
         """Create content unit."""
@@ -85,13 +85,6 @@ class ContentUnitTestCase(unittest.TestCase, utils.SmokeTest):
         attrs = _gen_content_unit_attrs(self.artifact)
         with self.assertRaises(HTTPError):
             self.client.put(self.content_unit['_href'], attrs)
-
-    @selectors.skip_if(bool, 'content_unit', False)
-    def test_04_delete_content_unit(self):
-        """Delete a content unit."""
-        self.client.delete(self.content_unit['_href'])
-        with self.assertRaises(HTTPError):
-            self.client.get(self.content_unit['_href'])
 
 
 def _gen_content_unit_attrs(artifact):

--- a/pulp_smash/tests/pulp3/utils.py
+++ b/pulp_smash/tests/pulp3/utils.py
@@ -10,9 +10,8 @@ from requests.auth import AuthBase, HTTPBasicAuth
 
 from pulp_smash import api, config, selectors
 from pulp_smash.tests.pulp3.constants import (
-    ARTIFACTS_PATH,
-    FILE_CONTENT_PATH,
     JWT_PATH,
+    ORPHANS_PATH,
     STATUS_PATH,
 )
 
@@ -251,31 +250,19 @@ def get_content_unit_paths(repo):
     ]
 
 
-def clean_artifacts(cfg=None):
-    """Clean all artifacts present in pulp.
-
-    :param pulp_smash.config.PulpSmashConfig cfg: Information about the Pulp
-        host.
-    """
-    if cfg is None:
-        cfg = config.get_config()
-    clean_content_units(cfg)
-    client = api.Client(cfg, api.json_handler)
-    for artifact in client.get(ARTIFACTS_PATH)['results']:
-        client.delete(artifact['_href'])
-
-
-def clean_content_units(cfg=None):
+def delete_orphans(cfg=None):
     """Clean all content units present in pulp.
+
+    An orphaned artifact is an artifact that is not in any content units.
+    An orphaned content unit is a content unit that is not in any repository
+    version.
 
     :param pulp_smash.config.PulpSmashConfig cfg: Information about the Pulp
      host.
     """
     if cfg is None:
         cfg = config.get_config()
-    client = api.Client(cfg, api.json_handler)
-    for content_unit in client.get(FILE_CONTENT_PATH)['results']:
-        client.delete(content_unit['_href'])
+    api.Client(cfg, api.safe_handler).delete(ORPHANS_PATH)
 
 
 def get_repo_versions(repo):


### PR DESCRIPTION
In order to avoid a race condition it was removed the feature to remove
content units.

See: https://pulp.plan.io/issues/3445

A new endpoint was added `/api/v3/orphans/` and using the
DELETE method and this endpoint all orphan content units will be
removed. This endpoint also removes orphan artifact units.

Adjust pulp-smash to this new scenario.

Remove:
 * clean_content_units
 * clean_artifacts

Add:
 * delete_orphan_units

Closes:#926

Related:#914