### PR TITLE
Remove documentation related to importers.

### DIFF
--- a/docs/api/pulp_smash.tests.pulp3.file.api_v3.test_crud_importers.rst
+++ b/docs/api/pulp_smash.tests.pulp3.file.api_v3.test_crud_importers.rst
@@ -1,6 +1,0 @@
-`pulp_smash.tests.pulp3.file.api_v3.test_crud_importers`
-========================================================
-
-Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.pulp3.file.api_v3.test_crud_importers`
-
-.. automodule:: pulp_smash.tests.pulp3.file.api_v3.test_crud_importers

--- a/docs/api/pulp_smash.tests.pulp3.file.api_v3.test_crud_remotes.rst
+++ b/docs/api/pulp_smash.tests.pulp3.file.api_v3.test_crud_remotes.rst
@@ -1,0 +1,6 @@
+`pulp_smash.tests.pulp3.file.api_v3.test_crud_remotes`
+======================================================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.pulp3.file.api_v3.test_crud_remotes`
+
+.. automodule:: pulp_smash.tests.pulp3.file.api_v3.test_crud_remotes


### PR DESCRIPTION
Importers were renamed to remotes.

Adjust documentation to this change.

See: f93f19a2106d22292639ddabfe191c265cb259bd