### PR TITLE
Move test_crd_artifacts to pulpcore

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -131,11 +131,10 @@ developers, not a gospel.
     api/pulp_smash.tests.pulp3.constants
     api/pulp_smash.tests.pulp3.file
     api/pulp_smash.tests.pulp3.file.api_v3
-    api/pulp_smash.tests.pulp3.file.api_v3.test_crd_artifacts
     api/pulp_smash.tests.pulp3.file.api_v3.test_crd_publications
     api/pulp_smash.tests.pulp3.file.api_v3.test_crud_content_unit
-    api/pulp_smash.tests.pulp3.file.api_v3.test_crud_remotes
     api/pulp_smash.tests.pulp3.file.api_v3.test_crud_publishers
+    api/pulp_smash.tests.pulp3.file.api_v3.test_crud_remotes
     api/pulp_smash.tests.pulp3.file.api_v3.test_download_content
     api/pulp_smash.tests.pulp3.file.api_v3.test_publish
     api/pulp_smash.tests.pulp3.file.api_v3.test_repo_version
@@ -146,6 +145,7 @@ developers, not a gospel.
     api/pulp_smash.tests.pulp3.pulpcore
     api/pulp_smash.tests.pulp3.pulpcore.api_v3
     api/pulp_smash.tests.pulp3.pulpcore.api_v3.test_auth
+    api/pulp_smash.tests.pulp3.pulpcore.api_v3.test_crd_artifacts
     api/pulp_smash.tests.pulp3.pulpcore.api_v3.test_crud_distributions
     api/pulp_smash.tests.pulp3.pulpcore.api_v3.test_crud_repos
     api/pulp_smash.tests.pulp3.pulpcore.api_v3.test_crud_users

--- a/docs/api/pulp_smash.tests.pulp3.file.api_v3.test_crd_artifacts.rst
+++ b/docs/api/pulp_smash.tests.pulp3.file.api_v3.test_crd_artifacts.rst
@@ -1,6 +1,0 @@
-`pulp_smash.tests.pulp3.file.api_v3.test_crd_artifacts`
-=======================================================
-
-Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.pulp3.file.api_v3.test_crd_artifacts`
-
-.. automodule:: pulp_smash.tests.pulp3.file.api_v3.test_crd_artifacts

--- a/docs/api/pulp_smash.tests.pulp3.pulpcore.api_v3.test_crd_artifacts.rst
+++ b/docs/api/pulp_smash.tests.pulp3.pulpcore.api_v3.test_crd_artifacts.rst
@@ -1,0 +1,6 @@
+`pulp_smash.tests.pulp3.pulpcore.api_v3.test_crd_artifacts`
+===========================================================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.pulp3.pulpcore.api_v3.test_crd_artifacts`
+
+.. automodule:: pulp_smash.tests.pulp3.pulpcore.api_v3.test_crd_artifacts

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crd_artifacts.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crd_artifacts.py
@@ -9,7 +9,7 @@ from pulp_smash import api, cli, config, selectors, utils
 from pulp_smash.constants import FILE_URL
 from pulp_smash.exceptions import CalledProcessError
 from pulp_smash.tests.pulp3.constants import ARTIFACTS_PATH
-from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp3.pulpcore.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 from pulp_smash.tests.pulp3.utils import delete_orphans, get_auth
 
 


### PR DESCRIPTION
Artifacts are a pulpcore feature. Move `test_crd_artifacts` from
`pulp_smash.tests.pulp3.file.api_v3` to
`pulp_smash.tests.pulp3.pulpcore.api_v3`.

Fix: https://github.com/PulpQE/pulp-smash/issues/934