### PR TITLE
Add tests to clean up orphan files.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -136,6 +136,7 @@ developers, not a gospel.
     api/pulp_smash.tests.pulp3.file.api_v3.test_crud_publishers
     api/pulp_smash.tests.pulp3.file.api_v3.test_crud_remotes
     api/pulp_smash.tests.pulp3.file.api_v3.test_download_content
+    api/pulp_smash.tests.pulp3.file.api_v3.test_orphans
     api/pulp_smash.tests.pulp3.file.api_v3.test_publish
     api/pulp_smash.tests.pulp3.file.api_v3.test_repo_version
     api/pulp_smash.tests.pulp3.file.api_v3.test_sync

--- a/docs/api/pulp_smash.tests.pulp3.file.api_v3.test_orphans.rst
+++ b/docs/api/pulp_smash.tests.pulp3.file.api_v3.test_orphans.rst
@@ -1,0 +1,6 @@
+`pulp_smash.tests.pulp3.file.api_v3.test_orphans`
+=================================================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.pulp3.file.api_v3.test_orphans`
+
+.. automodule:: pulp_smash.tests.pulp3.file.api_v3.test_orphans

--- a/pulp_smash/tests/pulp3/file/api_v3/test_orphans.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_orphans.py
@@ -1,0 +1,113 @@
+# coding=utf-8:
+"""Tests that perform actions over orphan files."""
+import unittest
+from random import choice
+from urllib.parse import urljoin
+
+from pulp_smash import api, cli, config, utils
+from pulp_smash.constants import (
+    FILE2_URL,
+    FILE_FEED_URL,
+)
+from pulp_smash.exceptions import CalledProcessError
+from pulp_smash.tests.pulp3.constants import (
+    ARTIFACTS_PATH,
+    FILE_CONTENT_PATH,
+    FILE_REMOTE_PATH,
+    REPO_PATH,
+)
+
+from pulp_smash.tests.pulp3.file.api_v3.utils import gen_remote
+from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
+from pulp_smash.tests.pulp3.utils import (
+    delete_orphans,
+    delete_repo_version,
+    get_auth,
+    get_content,
+    get_repo_versions,
+    sync_repo,
+)
+
+
+class DeleteOrphansTestCase(unittest.TestCase, utils.SmokeTest):
+    """Test whether orphans files can be clean up.
+
+    An orphan artifact is an artifact that is not in any content units.
+    An orphan content unit is a content unit that is not in any repository
+    version.
+
+    This test targets the following issues:
+
+    * `Pulp #3442 <https://pulp.plan.io/issues/3442>`_
+    * `Pulp Smash #914 <https://github.com/PulpQE/pulp-smash/issues/914>`_
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Create class-wide variables."""
+        cls.cfg = config.get_config()
+        cls.api_client = api.Client(cls.cfg, api.json_handler)
+        cls.api_client.request_kwargs['auth'] = get_auth()
+        cls.cli_client = cli.Client(cls.cfg)
+        cls.sudo = () if utils.is_root(cls.cfg) else ('sudo',)
+
+    def test_clean_orphan_content_unit(self):
+        """Test whether orphan content units can be clean up.
+
+        Do the following:
+
+        1. Create, and sync a repo.
+        2. Remove a content unit from the repo. This will create a second
+           repository version, and create an orphan content unit.
+        3. Assert that content unit that was removed from the repo and its
+           artifact are present on disk.
+        4. Delete orphans.
+        5. Assert that the orphan content unit was cleaned up, and its artifact
+           is not present on disk.
+        """
+        repo = self.api_client.post(REPO_PATH, gen_repo())
+        self.addCleanup(self.api_client.delete, repo['_href'])
+        body = gen_remote()
+        body['url'] = urljoin(FILE_FEED_URL, 'PULP_MANIFEST')
+        remote = self.api_client.post(FILE_REMOTE_PATH, body)
+        self.addCleanup(self.api_client.delete, remote['_href'])
+        sync_repo(self.cfg, remote, repo)
+        repo = self.api_client.get(repo['_href'])
+        content = choice(get_content(repo)['results'])
+
+        # Create an orphan content unit.
+        self.api_client.post(
+            repo['_versions_href'],
+            {'remove_content_units': [content['_href']]}
+        )
+
+        # Verify that the artifact is present on disk.
+        artifact_path = self.api_client.get(content['artifact'])['file']
+        cmd = self.sudo + ('ls', artifact_path)
+        self.cli_client.run(cmd)
+
+        # Delete first repo version. The previous removed content unit will be
+        # an orphan.
+        delete_repo_version(repo, get_repo_versions(repo)[0])
+        content_units = self.api_client.get(FILE_CONTENT_PATH)['results']
+        self.assertIn(content, content_units)
+        delete_orphans()
+        content_units = self.api_client.get(FILE_CONTENT_PATH)['results']
+        self.assertNotIn(content, content_units)
+
+        # Verify that the artifact was removed from disk.
+        with self.assertRaises(CalledProcessError):
+            self.cli_client.run(cmd)
+
+    def test_clean_orphan_artifact(self):
+        """Test whether orphan artifacts units can be clean up."""
+        repo = self.api_client.post(REPO_PATH, gen_repo())
+        self.addCleanup(self.api_client.delete, repo['_href'])
+        files = {'file': utils.http_get(FILE2_URL)}
+        artifact = self.api_client.post(ARTIFACTS_PATH, files=files)
+        cmd = self.sudo + ('ls', artifact['file'])
+        self.cli_client.run(cmd)
+        delete_orphans()
+        with self.assertRaises(CalledProcessError):
+            self.cli_client.run(cmd)


### PR DESCRIPTION
Add tests to verify whether orphan files can be clean up.

Add new tests.

First:

 1. Create, and sync a repo.
 2. Remove a content unit from the repo. This will create a second
    repository version, and create an orphan content unit.
 3. Assert that content unit that was removed from the repo and its
    artifact are present on disk.
 4. Delete orphans.
 5. Assert that the orphan content unit was cleaned up, and its artifact
    is not present on disk.

Second:

 1. Test whether orphan content units can be clean up. Verify whether
    the file is present on disk, after orphans clean up.

See: https://pulp.plan.io/issues/3442

Closes:#914