### PR TITLE
Add pycodestyle to makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ help:
 	@echo "  docs-clean     to remove documentation"
 	@echo "  lint           to run all linters"
 	@echo "  lint-flake8    to run the flake8 linter"
+	@echo "  lint-pycode    to run the pycodestyle linter"
 	@echo "  lint-pylint    to run the pylint linter"
 	@echo "  publish        to upload dist/* to PyPi"
 	@echo "  test           to run unit tests"
@@ -38,6 +39,9 @@ docs-clean:
 lint-flake8:
 	flake8 . --ignore D203 --exclude docs/_build
 
+lint-pycode:
+	pycodestyle . --ignore=E501 --exclude docs/_build
+
 lint-pylint:
 	pylint -j $(CPU_COUNT) --reports=n --disable=I \
 		docs/conf.py \
@@ -46,7 +50,7 @@ lint-pylint:
 		setup.py \
 		tests
 
-lint: lint-flake8 lint-pylint
+lint: lint-flake8 lint-pylint lint-pycode
 
 publish: dist
 	twine upload dist/*
@@ -58,5 +62,5 @@ test-coverage:
 	coverage run --source pulp_smash.api,pulp_smash.cli,pulp_smash.config,pulp_smash.exceptions,pulp_smash.pulp_smash_cli,pulp_smash.selectors,pulp_smash.utils \
 	$(TEST_OPTIONS)
 
-.PHONY: help all docs-html docs-clean lint-flake8 lint-pylint lint test \
+.PHONY: help all docs-html docs-clean lint-flake8 lint-pylint lint-pycode lint test \
     test-coverage dist-clean publish

--- a/pulp_smash/tests/pulp3/file/api_v3/test_publish.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_publish.py
@@ -18,7 +18,7 @@ from pulp_smash.tests.pulp3.file.api_v3.utils import (
     gen_remote,
     gen_publisher,
 )
-from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
 from pulp_smash.tests.pulp3.utils import (
     get_auth,

--- a/pulp_smash/tests/pulp3/file/api_v3/test_sync.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_sync.py
@@ -16,7 +16,7 @@ from pulp_smash.tests.pulp3.file.api_v3.utils import (
     gen_remote,
     get_remote_down_policy,
 )
-from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
 from pulp_smash.tests.pulp3.utils import get_auth, sync_repo
 


### PR DESCRIPTION
pycodestyle is listed as one of the dev requirements. But it is not being used.

Add pycodestyle to makefile, and as part of `make all`.

Add flag to `-ignore=E501` to pycodestyle, let pylint handles `line
too long error`.

Fix two minor issues found using pycodestyle.