### PR TITLE
Add test to verify multi-resource locking.

### DIFF
--- a/pulp_smash/tests/pulp3/file/api_v3/test_sync.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_sync.py
@@ -6,7 +6,11 @@ from random import randint
 from urllib.parse import urljoin, urlsplit
 
 from pulp_smash import api, config, utils
-from pulp_smash.constants import FILE_FEED_URL
+from pulp_smash.constants import (
+    FILE_FEED_COUNT,
+    FILE_FEED_URL,
+    FILE_LARGE_FEED_URL,
+)
 from pulp_smash.tests.pulp3.constants import (
     FILE_REMOTE_PATH,
     REMOTE_SYNC_MODE,
@@ -18,7 +22,7 @@ from pulp_smash.tests.pulp3.file.api_v3.utils import (
 )
 from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule # noqa pylint:disable=unused-import
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
-from pulp_smash.tests.pulp3.utils import get_auth, sync_repo
+from pulp_smash.tests.pulp3.utils import get_auth, get_content, sync_repo
 
 
 class SyncFileRepoTestCase(unittest.TestCase, utils.SmokeTest):
@@ -126,3 +130,43 @@ class SyncChangeRepoVersionTestCase(unittest.TestCase):
         path = urlsplit(repo['_latest_version_href']).path
         latest_repo_version = int(path.split('/')[-2])
         self.assertEqual(latest_repo_version, number_of_syncs)
+
+
+class MultiResourceLockingTestCase(unittest.TestCase, utils.SmokeTest):
+    """Verify multi-resourcing locking.
+
+    This test targets the following issues:
+
+    * `Pulp #3186 <https://pulp.plan.io/issues/3186>`_
+    * `Pulp Smash #879 <https://github.com/PulpQE/pulp-smash/issues/879>`_
+    """
+
+    def test_all(self):
+        """Verify multi-resourcing locking.
+
+        Do the following:
+
+        1. Create a repository, and a remote.
+        2. Update the remote to point to a different url.
+        3. Immediately run a sync. The sync should fire after the update and
+           sync from the second url.
+        4. Assert that remote url was updated.
+        5. Assert that the number of units present in the repository is
+           according to the updated url.
+        """
+        cfg = config.get_config()
+        client = api.Client(cfg, api.json_handler)
+        client.request_kwargs['auth'] = get_auth()
+        repo = client.post(REPO_PATH, gen_repo())
+        self.addCleanup(client.delete, repo['_href'])
+        body = gen_remote()
+        body['url'] = urljoin(FILE_LARGE_FEED_URL, 'PULP_MANIFEST')
+        remote = client.post(FILE_REMOTE_PATH, body)
+        self.addCleanup(client.delete, remote['_href'])
+        url = {'url': urljoin(FILE_FEED_URL, 'PULP_MANIFEST')}
+        client.patch(remote['_href'], url)
+        sync_repo(cfg, remote, repo)
+        repo = client.get(repo['_href'])
+        remote = client.get(remote['_href'])
+        self.assertEqual(remote['url'], url['url'])
+        self.assertEqual(len(get_content(repo)['results']), FILE_FEED_COUNT)


### PR DESCRIPTION
Do the following:

 1. Create a repository, and a remote.
 2. Update the remote to point to a different url.
 3. Immediately run a sync. The sync should fire after the update and
     sync from the second url.
 4. Assert that remote url was updated.
 5. Assert that the number of units present in the repository is
    according to the updated url.

Closes:#879