### PR TITLE
Update linters and remove noqa from codebase.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,9 @@ docs-html:
 docs-clean:
 	@cd docs; $(MAKE) clean
 
+# E501 and F401 are ignored because Pylint performs similar checks.
 lint-flake8:
-	flake8 . --ignore D203 --exclude docs/_build
+	flake8 . --ignore D203,E501,F401 --exclude docs/_build
 
 lint-pylint:
 	pylint -j $(CPU_COUNT) --reports=n --disable=I \

--- a/pulp_smash/config.py
+++ b/pulp_smash/config.py
@@ -365,7 +365,8 @@ class PulpSmashConfig(object):
         )
         self._xdg_config_dir = 'pulp_smash'
 
-    def __repr__(self):  # noqa
+    def __repr__(self):
+        """Create string representation of the object."""
         attrs = _public_attrs(self)
         attrs['pulp_version'] = type('')(attrs['pulp_version'])
         str_kwargs = ', '.join(

--- a/pulp_smash/tests/__init__.py
+++ b/pulp_smash/tests/__init__.py
@@ -1,5 +1,4 @@
 # coding=utf-8
-# flake8:noqa
 """Tests for Pulp.
 
 This package contain functional tests for Pulp. These tests should be run

--- a/pulp_smash/tests/pulp2/docker/api_v2/test_copy.py
+++ b/pulp_smash/tests/pulp2/docker/api_v2/test_copy.py
@@ -8,7 +8,7 @@ from pulp_smash.constants import DOCKER_V1_FEED_URL, DOCKER_V2_FEED_URL
 from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.docker.api_v2.utils import gen_repo
 from pulp_smash.tests.pulp2.docker.utils import get_upstream_name
-from pulp_smash.tests.pulp2.docker.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.docker.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
 class CopyV1ContentTestCase(unittest.TestCase):

--- a/pulp_smash/tests/pulp2/docker/api_v2/test_duplicate_uploads.py
+++ b/pulp_smash/tests/pulp2/docker/api_v2/test_duplicate_uploads.py
@@ -18,7 +18,7 @@ from pulp_smash import api, utils
 from pulp_smash.constants import DOCKER_IMAGE_URL
 from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.docker.api_v2.utils import gen_repo
-from pulp_smash.tests.pulp2.docker.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.docker.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
 class DuplicateUploadsTestCase(

--- a/pulp_smash/tests/pulp2/docker/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/pulp2/docker/api_v2/test_sync_publish.py
@@ -14,7 +14,7 @@ from pulp_smash.tests.pulp2.docker.api_v2.utils import (
     gen_repo,
 )
 from pulp_smash.tests.pulp2.docker.utils import get_upstream_name
-from pulp_smash.tests.pulp2.docker.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.docker.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 # Variable name derived from HTTP content-type.
 MANIFEST_V1 = {

--- a/pulp_smash/tests/pulp2/docker/cli/test_crud.py
+++ b/pulp_smash/tests/pulp2/docker/cli/test_crud.py
@@ -11,7 +11,7 @@ from packaging import version
 
 from pulp_smash import api, cli, config, selectors, utils
 from pulp_smash.tests.pulp2.docker.cli import utils as docker_utils
-from pulp_smash.tests.pulp2.docker.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.docker.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 _FEED = 'https://example.com'
 _UPSTREAM_NAME = 'foo/bar'

--- a/pulp_smash/tests/pulp2/docker/cli/utils.py
+++ b/pulp_smash/tests/pulp2/docker/cli/utils.py
@@ -105,7 +105,7 @@ def repo_update(  # pylint:disable=too-many-arguments
     return cli.Client(server_config).run(cmd)
 
 
-def repo_publish(server_config, repo_id, bg=None, force_full=None):  # noqa pylint:disable=invalid-name
+def repo_publish(server_config, repo_id, bg=None, force_full=None):  # pylint:disable=invalid-name
     """Execute ``pulp-admin docker repo publish run``."""
     cmd = (
         'pulp-admin', 'docker', 'repo', 'publish', 'run', '--repo-id', repo_id

--- a/pulp_smash/tests/pulp2/ostree/api_v2/test_copy.py
+++ b/pulp_smash/tests/pulp2/ostree/api_v2/test_copy.py
@@ -8,7 +8,7 @@ from pulp_smash import api, config, utils
 from pulp_smash.constants import OSTREE_BRANCHES, OSTREE_FEED
 from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.ostree.utils import gen_distributor, gen_repo
-from pulp_smash.tests.pulp2.ostree.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.ostree.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
 class FilterTestCase(unittest.TestCase):

--- a/pulp_smash/tests/pulp2/ostree/api_v2/test_crud.py
+++ b/pulp_smash/tests/pulp2/ostree/api_v2/test_crud.py
@@ -17,7 +17,7 @@ from pulp_smash import api, config, exceptions, selectors, utils
 from pulp_smash.constants import OSTREE_FEED, OSTREE_BRANCHES
 from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.ostree.utils import gen_repo
-from pulp_smash.tests.pulp2.ostree.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.ostree.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
 def _gen_distributor(relative_path):

--- a/pulp_smash/tests/pulp2/ostree/api_v2/test_publish.py
+++ b/pulp_smash/tests/pulp2/ostree/api_v2/test_publish.py
@@ -6,7 +6,7 @@ from pulp_smash import api, config, utils
 from pulp_smash.constants import OSTREE_BRANCHES, OSTREE_FEED
 from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.ostree.utils import gen_distributor, gen_repo
-from pulp_smash.tests.pulp2.ostree.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.ostree.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
 class PublishTestCase(unittest.TestCase):

--- a/pulp_smash/tests/pulp2/ostree/api_v2/test_sync.py
+++ b/pulp_smash/tests/pulp2/ostree/api_v2/test_sync.py
@@ -13,7 +13,7 @@ from pulp_smash import api, selectors, utils
 from pulp_smash.constants import OSTREE_FEED, OSTREE_BRANCHES
 from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.ostree.utils import gen_repo
-from pulp_smash.tests.pulp2.ostree.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.ostree.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
 def _sync_repo(server_config, href):

--- a/pulp_smash/tests/pulp2/platform/api_v2/test_consumer.py
+++ b/pulp_smash/tests/pulp2/platform/api_v2/test_consumer.py
@@ -10,7 +10,7 @@ from urllib.parse import urljoin
 from pulp_smash import api, config, utils
 from pulp_smash.tests.pulp2.constants import CONSUMERS_PATH, REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_repo, gen_distributor
-from pulp_smash.tests.pulp2.platform.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.platform.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
 class BindConsumerTestCase(unittest.TestCase):

--- a/pulp_smash/tests/pulp2/platform/api_v2/test_content_applicability.py
+++ b/pulp_smash/tests/pulp2/platform/api_v2/test_content_applicability.py
@@ -24,11 +24,11 @@ from pulp_smash.tests.pulp2.constants import (
     CALL_REPORT_KEYS,
     GROUP_CALL_REPORT_KEYS,
 )
-from pulp_smash.tests.pulp2.platform.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.platform.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 _PATHS = {
-    'consumer': '/pulp/api/v2/consumers/actions/content/regenerate_applicability/',  # noqa
-    'repo': '/pulp/api/v2/repositories/actions/content/regenerate_applicability/',  # noqa
+    'consumer': '/pulp/api/v2/consumers/actions/content/regenerate_applicability/',
+    'repo': '/pulp/api/v2/repositories/actions/content/regenerate_applicability/',
 }
 
 

--- a/pulp_smash/tests/pulp2/platform/api_v2/test_login.py
+++ b/pulp_smash/tests/pulp2/platform/api_v2/test_login.py
@@ -88,7 +88,7 @@ from pulp_smash.tests.pulp2.constants import (
     LOGIN_KEYS,
     LOGIN_PATH,
 )
-from pulp_smash.tests.pulp2.platform.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.platform.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
 class LoginTestCase(unittest.TestCase):

--- a/pulp_smash/tests/pulp2/platform/api_v2/test_repository.py
+++ b/pulp_smash/tests/pulp2/platform/api_v2/test_repository.py
@@ -21,7 +21,7 @@ from packaging.version import Version
 from pulp_smash import api, utils
 from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH, ERROR_KEYS
 from pulp_smash.selectors import bug_is_untestable, require
-from pulp_smash.tests.pulp2.platform.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.platform.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
 class CreateSuccessTestCase(utils.BaseAPITestCase):

--- a/pulp_smash/tests/pulp2/platform/api_v2/test_search.py
+++ b/pulp_smash/tests/pulp2/platform/api_v2/test_search.py
@@ -241,7 +241,7 @@ class FiltersIdsTestCase(_BaseTestCase):
     def setUpClass(cls):
         """Search for exactly two users."""
         super(FiltersIdsTestCase, cls).setUpClass()
-        cls.user_ids = [user['id'] for user in random.sample(_USERS, 2)]  # noqa pylint:disable=unsubscriptable-object
+        cls.user_ids = [user['id'] for user in random.sample(_USERS, 2)]  # pylint:disable=unsubscriptable-object
         cls.searches['post'] = api.Client(cls.cfg).post(
             _SEARCH_PATH,
             {'criteria': {'filters': {'id': {'$in': cls.user_ids}}}},
@@ -272,7 +272,7 @@ class LimitSkipTestCase(_BaseTestCase):
     def setUpClass(cls):
         """Create two users. Execute searches."""
         super(LimitSkipTestCase, cls).setUpClass()
-        cls.user_ids = [user['id'] for user in random.sample(_USERS, 2)]  # noqa pylint:disable=unsubscriptable-object
+        cls.user_ids = [user['id'] for user in random.sample(_USERS, 2)]  # pylint:disable=unsubscriptable-object
         client = api.Client(cls.cfg)
         for criterion in {'limit', 'skip'}:
             key = 'post_' + criterion

--- a/pulp_smash/tests/pulp2/platform/api_v2/test_user.py
+++ b/pulp_smash/tests/pulp2/platform/api_v2/test_user.py
@@ -15,7 +15,7 @@ The assumptions explored in this module have the following dependencies::
 """
 from pulp_smash import api, utils
 from pulp_smash.tests.pulp2.constants import LOGIN_PATH, USER_PATH
-from pulp_smash.tests.pulp2.platform.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.platform.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
 def _logins(search_response):

--- a/pulp_smash/tests/pulp2/platform/cli/test_selinux.py
+++ b/pulp_smash/tests/pulp2/platform/cli/test_selinux.py
@@ -5,7 +5,7 @@ import unittest
 from collections import namedtuple
 
 from pulp_smash import cli, config, selectors, utils
-from pulp_smash.tests.pulp2.platform.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.platform.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
 CELERY_LABEL = ':system_r:celery_t:s0'

--- a/pulp_smash/tests/pulp2/puppet/api_v2/test_crud.py
+++ b/pulp_smash/tests/pulp2/puppet/api_v2/test_crud.py
@@ -2,7 +2,7 @@
 """Tests that CRUD Puppet repositories."""
 from pulp_smash import utils
 from pulp_smash.tests.pulp2.puppet.api_v2.utils import gen_repo
-from pulp_smash.tests.pulp2.puppet.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.puppet.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
 class CRUDTestCase(utils.BaseAPICrudTestCase):

--- a/pulp_smash/tests/pulp2/puppet/api_v2/test_duplicate_uploads.py
+++ b/pulp_smash/tests/pulp2/puppet/api_v2/test_duplicate_uploads.py
@@ -18,7 +18,7 @@ from pulp_smash import api, utils
 from pulp_smash.constants import PUPPET_MODULE_URL_1
 from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.puppet.api_v2.utils import gen_repo
-from pulp_smash.tests.pulp2.puppet.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.puppet.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
 class DuplicateUploadsTestCase(

--- a/pulp_smash/tests/pulp2/puppet/api_v2/test_install_distributor.py
+++ b/pulp_smash/tests/pulp2/puppet/api_v2/test_install_distributor.py
@@ -15,7 +15,7 @@ from pulp_smash.tests.pulp2.puppet.api_v2.utils import (
     gen_install_distributor,
     gen_repo,
 )
-from pulp_smash.tests.pulp2.puppet.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.puppet.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
 class InstallDistributorTestCase(utils.BaseAPITestCase):

--- a/pulp_smash/tests/pulp2/puppet/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/pulp2/puppet/api_v2/test_sync_publish.py
@@ -28,7 +28,7 @@ from pulp_smash.tests.pulp2.puppet.api_v2.utils import (
     gen_distributor,
     gen_repo,
 )
-from pulp_smash.tests.pulp2.puppet.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.puppet.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
 class CreateTestCase(utils.BaseAPITestCase):
@@ -169,7 +169,7 @@ class SyncValidFeedTestCase(utils.BaseAPITestCase):
         report = utils.sync_repo(self.cfg, repo).json()
         for task in api.poll_spawned_tasks(self.cfg, report):
             self.assertIsNone(
-                task['progress_report']['puppet_importer']['metadata']['error_message']  # noqa pylint:disable=line-too-long
+                task['progress_report']['puppet_importer']['metadata']['error_message']  # pylint:disable=line-too-long
             )
 
 
@@ -208,7 +208,7 @@ class SyncInvalidFeedTestCase(utils.BaseAPITestCase):
     def test_error_details(self):
         """Assert each task's progress report contains error details."""
         self.assertIsNotNone(
-            self.tasks[0]['progress_report']['puppet_importer']['metadata']['error']  # noqa pylint:disable=line-too-long
+            self.tasks[0]['progress_report']['puppet_importer']['metadata']['error']  # pylint:disable=line-too-long
         )
 
 
@@ -258,7 +258,7 @@ class SyncValidManifestFeedTestCase(utils.BaseAPITestCase):
         client = api.Client(cls.cfg)
         body = gen_repo()
         body['importer_config'] = {
-            'feed': 'http://repos.fedorapeople.org/repos/pulp/pulp/demo_repos/puppet_manifest/modules/'  # noqa pylint:disable=line-too-long
+            'feed': 'http://repos.fedorapeople.org/repos/pulp/pulp/demo_repos/puppet_manifest/modules/'  # pylint:disable=line-too-long
         }
         repo = client.post(REPOSITORY_PATH, body).json()
         cls.resources.add(repo['_href'])
@@ -280,7 +280,7 @@ class SyncValidManifestFeedTestCase(utils.BaseAPITestCase):
         for i, task in enumerate(self.tasks):
             with self.subTest(i=i):
                 self.assertIsNone(
-                    task['progress_report']['puppet_importer']['metadata']['error_message']  # noqa pylint:disable=line-too-long
+                    task['progress_report']['puppet_importer']['metadata']['error_message']  # pylint:disable=line-too-long
                 )
 
 

--- a/pulp_smash/tests/pulp2/python/api_v2/test_crud.py
+++ b/pulp_smash/tests/pulp2/python/api_v2/test_crud.py
@@ -2,7 +2,7 @@
 """Tests that CRUD Python repositories."""
 from pulp_smash import utils
 from pulp_smash.tests.pulp2.python.api_v2.utils import gen_repo
-from pulp_smash.tests.pulp2.python.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.python.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
 class CRUDTestCase(utils.BaseAPICrudTestCase):

--- a/pulp_smash/tests/pulp2/python/api_v2/test_duplicate_uploads.py
+++ b/pulp_smash/tests/pulp2/python/api_v2/test_duplicate_uploads.py
@@ -22,7 +22,7 @@ from pulp_smash import api, selectors, utils
 from pulp_smash.constants import PYTHON_EGG_URL
 from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.python.api_v2.utils import gen_repo
-from pulp_smash.tests.pulp2.python.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.python.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
 class DuplicateUploadsTestCase(

--- a/pulp_smash/tests/pulp2/python/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/pulp2/python/api_v2/test_sync_publish.py
@@ -16,7 +16,7 @@ from pulp_smash.tests.pulp2.python.api_v2.utils import (
     gen_distributor,
     gen_repo,
 )
-from pulp_smash.tests.pulp2.python.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.python.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
 class BaseTestCase(unittest.TestCase):

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_broker.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_broker.py
@@ -46,7 +46,7 @@ from pulp_smash.tests.pulp2.rpm.utils import (
     check_issue_2387,
     check_issue_3104,
 )
-from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
 class BrokerTestCase(unittest.TestCase):

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_character_encoding.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_character_encoding.py
@@ -14,7 +14,7 @@ from pulp_smash.constants import (
 )
 from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_repo
-from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
 class UploadNonAsciiTestCase(unittest.TestCase):

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_content_applicability.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_content_applicability.py
@@ -23,7 +23,7 @@ from pulp_smash.tests.pulp2.constants import (
     REPOSITORY_PATH,
 )
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_distributor, gen_repo
-from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 # MappingProxyType is used to make an immutable dict.
 RPM_WITH_ERRATUM_METADATA = MappingProxyType({

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_content_sources.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_content_sources.py
@@ -12,7 +12,7 @@ from urllib.parse import urlsplit, urlunsplit
 from pulp_smash import api, cli, config, selectors, utils
 from pulp_smash.constants import PULP_FIXTURES_BASE_URL
 from pulp_smash.tests.pulp2.constants import CONTENT_SOURCES_PATH
-from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 _HEADERS = {'X-RHUI-ID', 'X-CSRF-TOKEN'}
 

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_copy.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_copy.py
@@ -13,7 +13,7 @@ from pulp_smash.constants import (
 )
 from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_distributor, gen_repo
-from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 _PATH = '/var/lib/pulp/published/yum/https/repos/'
 

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_crud.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_crud.py
@@ -29,7 +29,7 @@ from pulp_smash.tests.pulp2.rpm.api_v2.utils import (
     gen_repo,
     gen_repo_group
 )
-from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
 class CrudTestCase(utils.BaseAPICrudTestCase):

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_duplicate_uploads.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_duplicate_uploads.py
@@ -9,7 +9,7 @@ from pulp_smash import api, config, selectors, utils
 from pulp_smash.constants import FILE_URL, RPM_UNSIGNED_URL
 from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_repo
-from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
 class DuplicateUploadsTestCase(unittest.TestCase):

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_errata.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_errata.py
@@ -11,7 +11,7 @@ from pulp_smash.tests.pulp2.rpm.api_v2.utils import (
     get_rpm_names_versions,
 )
 from pulp_smash.tests.pulp2.rpm.utils import gen_yum_config_file
-from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
 class ApplyErratumTestCase(unittest.TestCase):
@@ -97,7 +97,7 @@ class ApplyErratumTestCase(unittest.TestCase):
         # methods like PackageManager.upgrade. But sometimes, we need to peek
         # under the hood, and this is a good example of that. Maybe
         # _get_package_manager() could be made into a public function.
-        yum_or_dnf = cli.PackageManager._get_package_manager(cfg)  # noqa pylint:disable=protected-access
+        yum_or_dnf = cli.PackageManager._get_package_manager(cfg)  # pylint:disable=protected-access
         self.assertIn(yum_or_dnf, ('yum', 'dnf'))
         if yum_or_dnf == 'yum':
             return ('--advisory', erratum)
@@ -145,5 +145,5 @@ class LargePackageListTestCase(unittest.TestCase):
             tasks = tuple(api.poll_spawned_tasks(cfg, report.json()))
             for i, task in enumerate(tasks):
                 with self.subTest(i=i):
-                    error_details = task['progress_report']['yum_importer']['content']['error_details']  # noqa pylint:disable=line-too-long
+                    error_details = task['progress_report']['yum_importer']['content']['error_details']  # pylint:disable=line-too-long
                     self.assertEqual(error_details, [], task)

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_force_full.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_force_full.py
@@ -15,7 +15,7 @@ from pulp_smash import api, selectors, utils
 from pulp_smash.constants import RPM_SIGNED_FEED_URL
 from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_distributor, gen_repo
-from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
 class ForceFullTestCase(utils.BaseAPITestCase):

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_iso_crud.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_iso_crud.py
@@ -16,7 +16,7 @@ from pulp_smash.constants import (
     FILE2_FEED_URL,
 )
 from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
-from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
 _DISTRIBUTOR = {

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_iso_sync_publish.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_iso_sync_publish.py
@@ -17,7 +17,7 @@ from pulp_smash.tests.pulp2.rpm.api_v2.utils import (
     get_dists_by_type_id,
     set_pulp_manage_rsync,
 )
-from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
 class ServeHttpsFalseTestCase(TemporaryUserMixin, unittest.TestCase):

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_orphan_remove.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_orphan_remove.py
@@ -23,7 +23,7 @@ from pulp_smash.tests.pulp2.constants import (
     REPOSITORY_PATH,
 )
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_repo
-from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
 def _count_orphans(orphans):

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_package_paths.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_package_paths.py
@@ -48,7 +48,7 @@ from pulp_smash.tests.pulp2.rpm.utils import (
     check_issue_2798,
     check_issue_3104,
 )
-from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
 class ReuseContentTestCase(unittest.TestCase):

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_remove_unit.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_remove_unit.py
@@ -23,7 +23,7 @@ from pulp_smash.tests.pulp2.rpm.utils import (
     check_issue_2620,
     check_issue_3104,
 )
-from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 _PUBLISH_DIR = 'pulp/repos/'
 

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_repomd.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_repomd.py
@@ -19,7 +19,7 @@ from pulp_smash.tests.pulp2.rpm.api_v2.utils import (
     xml_handler,
 )
 from pulp_smash.tests.pulp2.rpm.utils import check_issue_2277, check_issue_3104
-from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
 class RepoMDTestCase(utils.BaseAPITestCase):

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_repository_layout.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_repository_layout.py
@@ -31,7 +31,7 @@ from pulp_smash.tests.pulp2.rpm.api_v2.utils import (
     xml_handler,
 )
 from pulp_smash.tests.pulp2.rpm.utils import check_issue_2277, check_issue_3104
-from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
 def get_parse_repodata_xml(server_config, distributor, file_path):

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_repoview.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_repoview.py
@@ -15,7 +15,7 @@ from packaging.version import Version
 
 from pulp_smash import api, config, constants, selectors, utils
 from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
-from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_distributor, gen_repo
 
 

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_republish.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_republish.py
@@ -22,7 +22,7 @@ from pulp_smash.tests.pulp2.rpm.utils import (
     check_issue_2620,
     check_issue_3104,
 )
-from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
 class UnassociateTestCase(unittest.TestCase):

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_retain_old_count.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_retain_old_count.py
@@ -17,7 +17,7 @@ from pulp_smash.constants import RPM_UNSIGNED_FEED_URL
 from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_distributor, gen_repo
 from pulp_smash.tests.pulp2.rpm.utils import check_issue_3104
-from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
 class RetainOldCountTestCase(utils.BaseAPITestCase):

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_schedule_publish.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_schedule_publish.py
@@ -11,7 +11,7 @@ from pulp_smash import api, utils
 from pulp_smash.constants import RPM_SIGNED_FEED_URL
 from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_repo, gen_distributor
-from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
 class CreateSuccessTestCase(utils.BaseAPITestCase):

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_schedule_sync.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_schedule_sync.py
@@ -13,7 +13,7 @@ from pulp_smash import api, utils
 from pulp_smash.constants import RPM_SIGNED_FEED_URL
 from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_repo
-from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 _MUTABLE_ATTRS = {
     'consecutive_failures',

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_search.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_search.py
@@ -30,7 +30,7 @@ from pulp_smash.tests.pulp2.constants import (
 )
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_repo
 from pulp_smash.tests.pulp2.rpm.utils import check_issue_2620
-from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
 class BaseSearchTestCase(utils.BaseAPITestCase):

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_service_resiliency.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_service_resiliency.py
@@ -21,7 +21,7 @@ from pulp_smash.tests.pulp2.constants import (
     TASKS_PATH,
 )
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_distributor, gen_repo
-from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 _PULP_WORKERS_CFG = '/etc/default/pulp_workers'
 

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_signatures_saved_for_packages.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_signatures_saved_for_packages.py
@@ -38,7 +38,7 @@ from pulp_smash.constants import (
 from pulp_smash.tests.pulp2.constants import ORPHANS_PATH, REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_repo
 from pulp_smash.tests.pulp2.rpm.utils import check_issue_2620
-from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
 def _get_pkg_filename(pkg_url):

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_sync_publish.py
@@ -40,7 +40,7 @@ from pulp_smash.tests.pulp2.rpm.api_v2.utils import (
     get_unit,
 )
 from pulp_smash.tests.pulp2.rpm.utils import check_issue_3104
-from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
 # This class is left public for documentation purposes.
@@ -86,7 +86,7 @@ class SyncRepoBaseTestCase(utils.BaseAPITestCase):
         tasks = tuple(api.poll_spawned_tasks(self.cfg, self.report.json()))
         for i, task in enumerate(tasks):
             with self.subTest(i=i):
-                error_details = task['progress_report']['yum_importer']['content']['error_details']  # noqa pylint:disable=line-too-long
+                error_details = task['progress_report']['yum_importer']['content']['error_details']  # pylint:disable=line-too-long
                 self.assertEqual(error_details, [], task)
 
 

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_tasks.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_tasks.py
@@ -16,7 +16,7 @@ from pulp_smash import api, config, selectors, utils
 from pulp_smash.constants import RPM_SIGNED_FEED_URL
 from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH, TASKS_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_distributor, gen_repo
-from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
 class TasksOperationsTestCase(unittest.TestCase):

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_unavailable_checksum.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_unavailable_checksum.py
@@ -17,7 +17,7 @@ from pulp_smash.tests.pulp2.rpm.api_v2.utils import (
     get_repodata,
 )
 from pulp_smash.tests.pulp2.rpm.utils import check_issue_3104
-from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
 class UnavailableChecksumTestCase(unittest.TestCase):

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_upload_publish.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_upload_publish.py
@@ -33,7 +33,7 @@ from pulp_smash.tests.pulp2.rpm.api_v2.utils import (
     get_unit,
 )
 from pulp_smash.tests.pulp2.rpm.utils import check_issue_2620, check_issue_3104
-from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
 class UploadDrpmTestCase(unittest.TestCase):

--- a/pulp_smash/tests/pulp2/rpm/cli/test_environments.py
+++ b/pulp_smash/tests/pulp2/rpm/cli/test_environments.py
@@ -7,7 +7,7 @@ from packaging.version import Version
 
 from pulp_smash import cli, config, utils
 from pulp_smash.constants import RPM_SIGNED_FEED_URL
-from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
 class UploadPackageEnvTestCase(unittest.TestCase):

--- a/pulp_smash/tests/pulp2/rpm/cli/test_langpacks.py
+++ b/pulp_smash/tests/pulp2/rpm/cli/test_langpacks.py
@@ -5,7 +5,7 @@ import unittest
 from packaging.version import Version
 
 from pulp_smash import cli, config, utils
-from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_smash.tests.pulp2.rpm.cli.utils import count_langpacks
 
 

--- a/pulp_smash/tests/pulp2/rpm/cli/test_retain_old_count.py
+++ b/pulp_smash/tests/pulp2/rpm/cli/test_retain_old_count.py
@@ -16,7 +16,7 @@ from urllib.parse import urljoin
 from pulp_smash import cli, config, utils
 from pulp_smash.constants import RPM_UNSIGNED_FEED_URL
 from pulp_smash.tests.pulp2.rpm.utils import check_issue_3104
-from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
 class RetainOldCountTestCase(unittest.TestCase):

--- a/pulp_smash/tests/pulp2/rpm/cli/test_search.py
+++ b/pulp_smash/tests/pulp2/rpm/cli/test_search.py
@@ -3,7 +3,7 @@
 import unittest
 
 from pulp_smash import cli, config, utils
-from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
 class SearchReposWithFiltersTestCase(unittest.TestCase):

--- a/pulp_smash/tests/pulp3/file/api_v3/test_crd_publications.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_crd_publications.py
@@ -17,7 +17,7 @@ from pulp_smash.tests.pulp3.file.api_v3.utils import (
     gen_remote,
     gen_publisher,
 )
-from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
 from pulp_smash.tests.pulp3.utils import (
     get_auth,

--- a/pulp_smash/tests/pulp3/file/api_v3/test_crud_content_unit.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_crud_content_unit.py
@@ -15,7 +15,7 @@ from pulp_smash.tests.pulp3.constants import (
     REPO_PATH,
 )
 from pulp_smash.tests.pulp3.file.api_v3.utils import gen_remote
-from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
 from pulp_smash.tests.pulp3.utils import (
     delete_orphans,

--- a/pulp_smash/tests/pulp3/file/api_v3/test_crud_publishers.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_crud_publishers.py
@@ -7,7 +7,7 @@ from requests.exceptions import HTTPError
 from pulp_smash import api, config, selectors, utils
 from pulp_smash.tests.pulp3.constants import FILE_PUBLISHER_PATH, REPO_PATH
 from pulp_smash.tests.pulp3.file.api_v3.utils import gen_publisher
-from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
 from pulp_smash.tests.pulp3.utils import get_auth
 

--- a/pulp_smash/tests/pulp3/file/api_v3/test_crud_remotes.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_crud_remotes.py
@@ -9,7 +9,7 @@ from pulp_smash import api, config, selectors, utils
 from pulp_smash.constants import FILE_FEED_URL, FILE2_FEED_URL
 from pulp_smash.tests.pulp3.constants import FILE_REMOTE_PATH, REPO_PATH
 from pulp_smash.tests.pulp3.file.api_v3.utils import gen_remote
-from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
 from pulp_smash.tests.pulp3.utils import get_auth
 

--- a/pulp_smash/tests/pulp3/file/api_v3/test_download_content.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_download_content.py
@@ -17,7 +17,7 @@ from pulp_smash.tests.pulp3.file.api_v3.utils import (
     gen_remote,
     gen_publisher,
 )
-from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_distribution, gen_repo
 from pulp_smash.tests.pulp3.utils import (
     get_auth,

--- a/pulp_smash/tests/pulp3/file/api_v3/test_publish.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_publish.py
@@ -18,7 +18,7 @@ from pulp_smash.tests.pulp3.file.api_v3.utils import (
     gen_remote,
     gen_publisher,
 )
-from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
 from pulp_smash.tests.pulp3.utils import (
     get_auth,

--- a/pulp_smash/tests/pulp3/file/api_v3/test_repo_version.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_repo_version.py
@@ -20,7 +20,7 @@ from pulp_smash.tests.pulp3.constants import (
     REPO_PATH,
 )
 from pulp_smash.tests.pulp3.file.api_v3.utils import gen_publisher, gen_remote
-from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
 from pulp_smash.tests.pulp3.utils import (
     delete_repo_version,

--- a/pulp_smash/tests/pulp3/file/api_v3/test_sync.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_sync.py
@@ -20,7 +20,7 @@ from pulp_smash.tests.pulp3.file.api_v3.utils import (
     gen_remote,
     get_remote_down_policy,
 )
-from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
 from pulp_smash.tests.pulp3.utils import get_auth, get_content, sync_repo
 

--- a/pulp_smash/tests/pulp3/file/api_v3/test_unlinking_repo.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_unlinking_repo.py
@@ -15,7 +15,7 @@ from pulp_smash.tests.pulp3.file.api_v3.utils import (
     gen_remote,
     gen_publisher,
 )
-from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
 from pulp_smash.tests.pulp3.utils import (
     get_auth,

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_api_docs.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_api_docs.py
@@ -6,7 +6,7 @@ from requests.exceptions import HTTPError
 
 from pulp_smash import api, config, selectors, utils
 from pulp_smash.tests.pulp3.constants import API_DOCS_PATH
-from pulp_smash.tests.pulp3.pulpcore.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp3.pulpcore.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
 class ApiDocsTestCase(unittest.TestCase, utils.SmokeTest):

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_auth.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_auth.py
@@ -12,7 +12,7 @@ from requests.exceptions import HTTPError
 
 from pulp_smash import api, config, selectors, utils
 from pulp_smash.tests.pulp3.constants import BASE_PATH, JWT_PATH, USER_PATH
-from pulp_smash.tests.pulp3.pulpcore.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp3.pulpcore.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_smash.tests.pulp3.utils import JWTAuth
 
 

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crd_artifacts.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crd_artifacts.py
@@ -9,7 +9,7 @@ from pulp_smash import api, cli, config, selectors, utils
 from pulp_smash.constants import FILE_URL
 from pulp_smash.exceptions import CalledProcessError
 from pulp_smash.tests.pulp3.constants import ARTIFACTS_PATH
-from pulp_smash.tests.pulp3.pulpcore.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp3.pulpcore.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_smash.tests.pulp3.utils import delete_orphans, get_auth
 
 

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_distributions.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_distributions.py
@@ -7,7 +7,7 @@ from requests.exceptions import HTTPError
 from pulp_smash import api, config, selectors, utils
 from pulp_smash.tests.pulp3.constants import DISTRIBUTION_PATH
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_distribution
-from pulp_smash.tests.pulp3.pulpcore.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp3.pulpcore.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_smash.tests.pulp3.utils import get_auth
 
 

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_repos.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_repos.py
@@ -7,7 +7,7 @@ from requests.exceptions import HTTPError
 from pulp_smash import api, config, selectors, utils
 from pulp_smash.tests.pulp3.constants import REPO_PATH
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
-from pulp_smash.tests.pulp3.pulpcore.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp3.pulpcore.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_smash.tests.pulp3.utils import get_auth
 
 

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_users.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_users.py
@@ -6,7 +6,7 @@ from requests.exceptions import HTTPError
 
 from pulp_smash import api, config, selectors, utils
 from pulp_smash.tests.pulp3.constants import USER_PATH
-from pulp_smash.tests.pulp3.pulpcore.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp3.pulpcore.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_smash.tests.pulp3.utils import get_auth
 
 

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_status.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_status.py
@@ -6,7 +6,7 @@ from requests.exceptions import HTTPError
 
 from pulp_smash import api, config, selectors, utils
 from pulp_smash.tests.pulp3.constants import STATUS_PATH
-from pulp_smash.tests.pulp3.pulpcore.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp3.pulpcore.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
 class StatusTestCase(unittest.TestCase, utils.SmokeTest):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -79,7 +79,7 @@ class CompletedProcessTestCase(unittest.TestCase):
     def test_can_eval(self):
         """Assert ``__repr__()`` can be parsed by ``eval()``."""
         string = repr(cli.CompletedProcess(**self.kwargs))
-        from pulp_smash.cli import CompletedProcess  # noqa pylint:disable=unused-variable
+        from pulp_smash.cli import CompletedProcess  # pylint:disable=unused-variable
         # pylint:disable=eval-used
         self.assertEqual(string, repr(eval(string)))
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -432,7 +432,7 @@ class ReprTestCase(unittest.TestCase):
 
     def test_can_eval(self):
         """Assert that the result can be parsed by ``eval``."""
-        from pulp_smash.config import PulpSmashConfig, PulpSystem  # noqa pylint:disable=unused-variable
+        from pulp_smash.config import PulpSmashConfig, PulpSystem  # pylint:disable=unused-variable
         # pylint:disable=eval-used
         cfg = eval(self.result)
         with self.subTest('check pulp_version'):


### PR DESCRIPTION
Update errors ignored by flake8. Add E501, and F401.

flake8 calls pycodestyle, but errors found by pycodestyle were ignored
due to the use of `noqa`.

Remove the majority of `noqa`  from the codebase. Remains nine `noqa` in
the whole codebase, all realted to same issue  `# noqa:E722`.