### PR TITLE
Don't ignore flake8 warning D203

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ docs-clean:
 
 # E501 and F401 are ignored because Pylint performs similar checks.
 lint-flake8:
-	flake8 . --ignore D203,E501,F401 --exclude docs/_build
+	flake8 . --ignore E501,F401 --exclude docs/_build
 
 lint-pylint:
 	pylint -j $(CPU_COUNT) --reports=n --disable=I \


### PR DESCRIPTION
This ignore was added some time back to work around an issue with
flake8-docstrings, and it has subsequently been fixed.

See: 76dfc72a0ef0dbfc2b6c55507614b2c3bb3e3c29