### PR TITLE
Add tests to workers.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -152,6 +152,7 @@ developers, not a gospel.
     api/pulp_smash.tests.pulp3.pulpcore.api_v3.test_crud_repos
     api/pulp_smash.tests.pulp3.pulpcore.api_v3.test_crud_users
     api/pulp_smash.tests.pulp3.pulpcore.api_v3.test_status
+    api/pulp_smash.tests.pulp3.pulpcore.api_v3.test_workers
     api/pulp_smash.tests.pulp3.pulpcore.utils
     api/pulp_smash.tests.pulp3.utils
     api/pulp_smash.utils

--- a/docs/api/pulp_smash.tests.pulp3.pulpcore.api_v3.test_workers.rst
+++ b/docs/api/pulp_smash.tests.pulp3.pulpcore.api_v3.test_workers.rst
@@ -1,0 +1,6 @@
+`pulp_smash.tests.pulp3.pulpcore.api_v3.test_workers`
+=====================================================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.pulp3.pulpcore.api_v3.test_workers`
+
+.. automodule:: pulp_smash.tests.pulp3.pulpcore.api_v3.test_workers

--- a/pulp_smash/tests/pulp3/constants.py
+++ b/pulp_smash/tests/pulp3/constants.py
@@ -48,3 +48,5 @@ REPO_PATH = urljoin(BASE_PATH, 'repositories/')
 STATUS_PATH = urljoin(BASE_PATH, 'status/')
 
 USER_PATH = urljoin(BASE_PATH, 'users/')
+
+WORKER_PATH = urljoin(BASE_PATH, 'workers/')

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_workers.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_workers.py
@@ -1,0 +1,94 @@
+# coding=utf-8
+"""Tests related to the workers."""
+import unittest
+from random import choice
+
+from requests.exceptions import HTTPError
+
+from pulp_smash import api, config, selectors, utils
+from pulp_smash.tests.pulp3.constants import WORKER_PATH
+from pulp_smash.tests.pulp3.pulpcore.utils import set_up_module as setUpModule  # pylint:disable=unused-import
+from pulp_smash.tests.pulp3.utils import get_auth
+
+
+class WorkersTestCase(unittest.TestCase, utils.SmokeTest):
+    """Test actions over workers.
+
+    This test targets the following issues:
+
+    * `Pulp #3143 <https://pulp.plan.io/issues/3143>`_
+    * `Pulp Smash #945 <https://github.com/PulpQE/pulp-smash/issues/945>`_
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Create an API Client."""
+        cfg = config.get_config()
+        cls.client = api.Client(cfg, api.json_handler)
+        cls.client.request_kwargs['auth'] = get_auth()
+        cls.worker = {}
+
+    def test_01_read_all_workers(self):
+        """Read all workers.
+
+        Pick a random worker to be used for the next assertions.
+        """
+        workers = self.client.get(WORKER_PATH)['results']
+        for worker in workers:
+            for key, val in worker.items():
+                with self.subTest(key=key):
+                    self.assertIsNotNone(val)
+        self.worker.update(choice(workers))
+
+    @selectors.skip_if(bool, 'worker', False)
+    def test_02_read_worker(self):
+        """Read a worker by its _href."""
+        worker = self.client.get(self.worker['_href'])
+        for key, val in self.worker.items():
+            with self.subTest(key=key):
+                self.assertEqual(worker[key], val)
+
+    @selectors.skip_if(bool, 'worker', False)
+    def test_02_read_workers(self):
+        """Read a worker by its name."""
+        page = self.client.get(WORKER_PATH, params={
+            'name': self.worker['name']
+        })
+        self.assertEqual(len(page['results']), 1)
+        for key, val in self.worker.items():
+            with self.subTest(key=key):
+                self.assertEqual(page['results'][0][key], val)
+
+    @selectors.skip_if(bool, 'worker', False)
+    def test_03_positive_filters(self):
+        """Read a worker using a set of query parameters."""
+        page = self.client.get(WORKER_PATH, params={
+            'last_updated__gte': self.worker['last_heartbeat'],
+            'name': self.worker['name'],
+            'online': self.worker['online'],
+            'missing': self.worker['missing'],
+        })
+        self.assertEqual(len(page['results']), 1)
+        for key, val in self.worker.items():
+            with self.subTest(key=key):
+                self.assertEqual(page['results'][0][key], val)
+
+    @selectors.skip_if(bool, 'worker', False)
+    def test_04_negative_filters(self):
+        """Read a worker with a query that does not match any worker."""
+        page = self.client.get(WORKER_PATH, params={
+            'last_heartbeat': utils.uuid4(),
+            'name': self.worker['name'],
+            'online': self.worker['online'],
+            'missing': self.worker['missing'],
+        })
+        self.assertEqual(len(page['results']), 0)
+
+    @selectors.skip_if(bool, 'worker', False)
+    def test_05_http_method(self):
+        """Use an HTTP method different than GET.
+
+        Assert an error is raised.
+        """
+        with self.assertRaises(HTTPError):
+            self.client.delete(self.worker['_href'])


### PR DESCRIPTION
Add basic test coverage to the `workers` endpoint.

Add tests to verify filters, and invalid HTTP method.

Closes:#945