### PR TITLE
Switch status API to RQ

### DIFF
--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_status.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_status.py
@@ -21,7 +21,7 @@ STATUS = {
             'type': 'object',
             'properties': {'connected': {'type': 'boolean'}},
         },
-        'messaging_connection': {
+        'redis_connection': {
             'type': 'object',
             'properties': {'connected': {'type': 'boolean'}},
         },
@@ -92,7 +92,7 @@ class StatusTestCase(unittest.TestCase, utils.SmokeTest):
         """
         validate(status, STATUS)
         self.assertTrue(status['database_connection']['connected'])
-        self.assertTrue(status['messaging_connection']['connected'])
+        self.assertTrue(status['redis_connection']['connected'])
         self.assertEqual(status['missing_workers'], [])
         self.assertNotEqual(status['online_workers'], [])
         self.assertNotEqual(status['versions'], [])


### PR DESCRIPTION
The attribute name in the status API changed when RQ with Redis replaced
AMQP brokers like RabbitMQ.

This PR is meant to be used with these core and pulp_file PRs:

https://github.com/pulp/pulp/pull/3454
https://github.com/pulp/pulp_file/pull/72