### PR TITLE
Remove sync_mode and download_policy from Remote

### DIFF
--- a/pulp_smash/tests/pulp3/file/api_v3/test_sync.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_sync.py
@@ -1,7 +1,6 @@
 # coding=utf-8
 """Tests that sync file plugin repositories."""
 import unittest
-from itertools import product
 from random import randint
 from urllib.parse import urljoin, urlsplit
 
@@ -13,12 +12,10 @@ from pulp_smash.constants import (
 )
 from pulp_smash.tests.pulp3.constants import (
     FILE_REMOTE_PATH,
-    REMOTE_SYNC_MODE,
     REPO_PATH,
 )
 from pulp_smash.tests.pulp3.file.api_v3.utils import (
     gen_remote,
-    get_remote_down_policy,
 )
 from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
@@ -33,23 +30,7 @@ class SyncFileRepoTestCase(unittest.TestCase, utils.SmokeTest):
         """Create class-wide variables."""
         cls.cfg = config.get_config()
 
-    def test_all(self):
-        """Call :meth:`do_test` with varying arguments.
-
-        Call :meth:`do_test` with each possible pairing of
-        :data:`pulp_smash.tests.pulp3.constants.REMOTE_DOWN_POLICY` and
-        :data:`pulp_smash.tests.pulp3.constants.REMOTE_SYNC_MODE`. If `Pulp
-        #3320`_ affects Pulp, then the ``background`` and ``on_demand``
-        download policies are omitted from the test matrix.
-
-        .. _Pulp #3320: https://pulp.plan.io/issues/3320
-        """
-        remote_down_policy = get_remote_down_policy()
-        for pair in product(remote_down_policy, REMOTE_SYNC_MODE):
-            with self.subTest(pair=pair):
-                self.do_test(*pair)
-
-    def do_test(self, download_policy, sync_mode):
+    def test_sync(self):
         """Sync repositories with the file plugin.
 
         In order to sync a repository an remote has to be associated within
@@ -64,18 +45,13 @@ class SyncFileRepoTestCase(unittest.TestCase, utils.SmokeTest):
         4. Assert that repository version is not None.
         5. Sync the remote one more time.
         6. Assert that repository version is different from the previous one.
-
-        :param download_policy: The download policy for the remote.
-        :param sync_mode: The sync mode for the remote.
         """
         client = api.Client(self.cfg, api.json_handler)
         client.request_kwargs['auth'] = get_auth()
         repo = client.post(REPO_PATH, gen_repo())
         self.addCleanup(client.delete, repo['_href'])
         body = gen_remote()
-        body['download_policy'] = download_policy
         body['url'] = urljoin(FILE_FEED_URL, 'PULP_MANIFEST')
-        body['sync_mode'] = sync_mode
         remote = client.post(FILE_REMOTE_PATH, body)
         self.addCleanup(client.delete, remote['_href'])
 

--- a/pulp_smash/tests/pulp3/file/api_v3/utils.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/utils.py
@@ -1,34 +1,12 @@
 # coding=utf-8
 """Utilities for file plugin tests."""
-from random import sample
-
-from pulp_smash.tests.pulp3.constants import (
-    REMOTE_DOWN_POLICY,
-    REMOTE_SYNC_MODE,
-)
-from pulp_smash import config, selectors, utils
-
-
-def get_remote_down_policy():
-    """Return the download policies that are available to the file plugin.
-
-    See `Pulp #3320 <https://pulp.plan.io/issues/3320>`_.
-
-    :returns: A subset of
-        :data:`pulp_smash.tests.pulp3.constants.REMOTE_DOWN_POLICY`. (The
-        constant itself might be returned.)
-    """
-    if selectors.bug_is_untestable(3320, config.get_config()):
-        return REMOTE_DOWN_POLICY - {'background', 'on_demand'}
-    return REMOTE_DOWN_POLICY
+from pulp_smash import utils
 
 
 def gen_remote():
     """Return a semi-random dict for use in creating an remote."""
     return {
-        'download_policy': sample(get_remote_down_policy(), 1)[0],
         'name': utils.uuid4(),
-        'sync_mode': sample(REMOTE_SYNC_MODE, 1)[0],
     }
 
 


### PR DESCRIPTION
https://github.com/pulp/pulp/pull/3450

These settings were removed from the Remote in pulpcore:
https://pulp.plan.io/issues/3492

Going forward, these settings will be passed as parameters to the
plugins. Currently however, the file plugin does not make use of either
of them, so we have removed the fields from sync calls altogether.