### PR TITLE
Drop extraneous `noqa` directive

### DIFF
--- a/pulp_smash/tests/pulp3/file/api_v3/test_orphans.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_orphans.py
@@ -18,7 +18,7 @@ from pulp_smash.tests.pulp3.constants import (
 )
 
 from pulp_smash.tests.pulp3.file.api_v3.utils import gen_remote
-from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # noqa pylint:disable=unused-import
+from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
 from pulp_smash.tests.pulp3.utils import (
     delete_orphans,


### PR DESCRIPTION
See: 1e9c99d898c4a429b35f6fe6c9df771e1c980510