### PR TITLE
Remove declaration inherit from object.

### DIFF
--- a/pulp_smash/api.py
+++ b/pulp_smash/api.py
@@ -138,7 +138,7 @@ def json_handler(server_config, response):
     return response.json()
 
 
-class Client(object):
+class Client():
     """A convenience object for working with an API.
 
     This class is a wrapper around the ``requests.api`` module provided by

--- a/pulp_smash/cli.py
+++ b/pulp_smash/cli.py
@@ -52,7 +52,7 @@ def code_handler(completed_proc):
     return completed_proc
 
 
-class CompletedProcess(object):
+class CompletedProcess():
     # pylint:disable=too-few-public-methods
     """A process that has finished running.
 
@@ -127,7 +127,7 @@ class CompletedProcess(object):
             )
 
 
-class Client(object):  # pylint:disable=too-few-public-methods
+class Client():  # pylint:disable=too-few-public-methods
     """A convenience object for working with a CLI.
 
     This class provides the ability to execute shell commands on either the
@@ -596,7 +596,7 @@ class ServiceManager(BaseServiceManager):
             )
 
 
-class PackageManager(object):
+class PackageManager():
     """A package manager on a host.
 
     Each instance of this class represents the package manager on a host. An

--- a/pulp_smash/config.py
+++ b/pulp_smash/config.py
@@ -268,7 +268,7 @@ def validate_config(config_dict):
 PulpSystem = collections.namedtuple('PulpSystem', 'hostname roles')
 
 
-class PulpSmashConfig(object):
+class PulpSmashConfig():
     """Information about a Pulp application.
 
     This object stores information about Pulp application and its constituent

--- a/pulp_smash/tests/pulp2/docker/api_v2/test_sync.py
+++ b/pulp_smash/tests/pulp2/docker/api_v2/test_sync.py
@@ -22,7 +22,7 @@ def setUpModule():  # pylint:disable=invalid-name
         raise unittest.SkipTest('These tests require at least Pulp 2.8.')
 
 
-class UpstreamNameTestsMixin(object):
+class UpstreamNameTestsMixin():
     """Provides tests that sync a repository and override ``upstream_name``.
 
     Any class inheriting from this mixin must also inherit from

--- a/pulp_smash/tests/pulp2/ostree/api_v2/test_sync.py
+++ b/pulp_smash/tests/pulp2/ostree/api_v2/test_sync.py
@@ -32,7 +32,7 @@ def _sync_repo(server_config, href):
 
 
 # It's OK for a mixin to have just one method.
-class _SyncMixin(object):  # pylint:disable=too-few-public-methods
+class _SyncMixin():  # pylint:disable=too-few-public-methods
     """Add test methods verifying Pulp's behaviour when a sync is started.
 
     The ``report`` instance attribute should be available. This is the response
@@ -44,7 +44,7 @@ class _SyncMixin(object):  # pylint:disable=too-few-public-methods
         self.assertEqual(self.report.status_code, 202)
 
 
-class _SyncFailedMixin(object):
+class _SyncFailedMixin():
     """Add test methods verifying Pulp's behaviour when a sync fails.
 
     This mixin assumes that:
@@ -69,7 +69,7 @@ class _SyncFailedMixin(object):
 
 
 # It's OK for a mixin to have just one method.
-class _SyncImportFailedMixin(object):  # pylint:disable=too-few-public-methods
+class _SyncImportFailedMixin():  # pylint:disable=too-few-public-methods
     """Add test methods verifying Pulp's behaviour when a sync fails.
 
     This class is like ``_SyncFailedMixin``, with the additional restriction

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_mirrorlist.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_mirrorlist.py
@@ -61,7 +61,7 @@ def tearDownModule():  # pylint:disable=invalid-name
     api.Client(config.get_config()).delete(ORPHANS_PATH)
 
 
-class UtilsMixin(object):
+class UtilsMixin():
     """A mixin providing methods to the test cases in this module.
 
     Any class inheriting from this mixin must also inherit from

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_no_op_publish.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_no_op_publish.py
@@ -136,7 +136,7 @@ class BaseTestCase(utils.BaseAPITestCase):
         self.assertIsInstance(last_task['result']['summary'], dict)
 
 
-class NoOpPublishMixin(object):
+class NoOpPublishMixin():
     """Provide tests for the no-op publish test cases in this module."""
 
     def test_second_publish_tasks(self):

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_rsync_distributor.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_rsync_distributor.py
@@ -118,7 +118,7 @@ def tearDownModule():  # pylint:disable=invalid-name
     set_pulp_manage_rsync(cfg, False)
 
 
-class _RsyncDistUtilsMixin(object):  # pylint:disable=too-few-public-methods
+class _RsyncDistUtilsMixin():  # pylint:disable=too-few-public-methods
     """A mixin providing methods for working with the RPM rsync distributor.
 
     This mixin requires that the ``unittest.TestCase`` class from the standard

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_schedule_sync.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_schedule_sync.py
@@ -34,7 +34,7 @@ _SCHEDULE_PATH = 'importers/{}/schedules/sync/'
 
 
 # It's OK that this class has one method. It's an intentionally small class.
-class CreateRepoMixin(object):  # pylint:disable=too-few-public-methods
+class CreateRepoMixin():  # pylint:disable=too-few-public-methods
     """Provide a method for creating a repository."""
 
     @classmethod

--- a/pulp_smash/tests/pulp2/rpm/api_v2/utils.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/utils.py
@@ -143,7 +143,7 @@ def xml_handler(_, response):
     return ElementTree.fromstring(xml_bytes)
 
 
-class DisableSELinuxMixin(object):  # pylint:disable=too-few-public-methods
+class DisableSELinuxMixin():  # pylint:disable=too-few-public-methods
     """A mixin providing the ability to temporarily disable SELinux."""
 
     def maybe_disable_selinux(self, cfg, pulp_issue_id):
@@ -193,7 +193,7 @@ class DisableSELinuxMixin(object):  # pylint:disable=too-few-public-methods
         self.addCleanup(client.run, cmd)
 
 
-class TemporaryUserMixin(object):
+class TemporaryUserMixin():
     """A mixin providing the ability to create a temporary user.
 
     A typical usage of this mixin is as follows:

--- a/pulp_smash/tests/pulp2/rpm/cli/test_copy_units.py
+++ b/pulp_smash/tests/pulp2/rpm/cli/test_copy_units.py
@@ -61,7 +61,7 @@ def tearDownModule():  # pylint:disable=invalid-name
     )
 
 
-class UtilsMixin(object):  # pylint:disable=too-few-public-methods
+class UtilsMixin():  # pylint:disable=too-few-public-methods
     """A mixin providing useful tools to unittest subclasses.
 
     Any class inheriting from this mixin must also inherit from

--- a/pulp_smash/utils.py
+++ b/pulp_smash/utils.py
@@ -358,7 +358,7 @@ class BaseAPICrudTestCase(unittest.TestCase):
 
 
 # It's OK for this method to have just one method. It's a mixin.
-class DuplicateUploadsMixin(object):  # pylint:disable=too-few-public-methods
+class DuplicateUploadsMixin():  # pylint:disable=too-few-public-methods
     """A mixin that adds tests for the "duplicate upload" test cases.
 
     Consider the following procedure:

--- a/tests/test_pulp_smash_cli.py
+++ b/tests/test_pulp_smash_cli.py
@@ -21,7 +21,7 @@ class BasePulpSmashCliTestCase(unittest.TestCase):
         self.cli_runner = CliRunner()
 
 
-class MissingSettingsFileMixin(object):
+class MissingSettingsFileMixin():
     # pylint:disable=too-few-public-methods
     """Test missing settings file.
 


### PR DESCRIPTION
Inherit from object is not necessary anymore for Python3.
Update few classes definition to be according to rest of the code base.