### PR TITLE
Move a function to a more appropriate location

### DIFF
--- a/pulp_smash/tests/pulp3/file/api_v3/test_download_content.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_download_content.py
@@ -14,17 +14,13 @@ from pulp_smash.tests.pulp3.constants import (
     REPO_PATH,
 )
 from pulp_smash.tests.pulp3.file.api_v3.utils import (
-    gen_remote,
     gen_publisher,
+    gen_remote,
+    get_content_unit_paths,
 )
 from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_distribution, gen_repo
-from pulp_smash.tests.pulp3.utils import (
-    get_auth,
-    get_content_unit_paths,
-    publish_repo,
-    sync_repo,
-)
+from pulp_smash.tests.pulp3.utils import get_auth, publish_repo, sync_repo
 
 
 class DownloadContentTestCase(unittest.TestCase, utils.SmokeTest):

--- a/pulp_smash/tests/pulp3/file/api_v3/utils.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/utils.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 """Utilities for file plugin tests."""
 from pulp_smash import utils
+from pulp_smash.tests.pulp3.utils import get_content
 
 
 def gen_remote():
@@ -15,3 +16,15 @@ def gen_publisher():
     return {
         'name': utils.uuid4(),
     }
+
+
+def get_content_unit_paths(repo):
+    """Return the relative path of content units present in a file repository.
+
+    :param repo: A dict of information about the repository.
+    :returns: A list with the paths of units present in a given repository.
+    """
+    return [
+        content_unit['relative_path']  # file path and name
+        for content_unit in get_content(repo)['results']
+    ]

--- a/pulp_smash/tests/pulp3/utils.py
+++ b/pulp_smash/tests/pulp3/utils.py
@@ -247,18 +247,6 @@ def get_removed_content(repo, version_href=None):
             .get(urljoin(version_href, 'removed_content/')))
 
 
-def get_content_unit_paths(repo):
-    """Return the relative path of content units present in a given repository.
-
-    :param repo: A dict of information about the repository.
-    :returns: A list with the paths of units present in a given repository.
-    """
-    return [
-        content_unit['relative_path']  # file path and name
-        for content_unit in get_content(repo)['results']
-    ]
-
-
 def delete_orphans(cfg=None):
     """Clean all content units present in pulp.
 


### PR DESCRIPTION
`pulp_smash.tests.pulp3.utils.get_content_unit_paths` only works for
file repositories. Move it into
`pulp_smash.tests.pulp3.file.api_v3.utils`.

Fix: https://github.com/PulpQE/pulp-smash/issues/979