### PR TITLE
Unroll a one-item loop

### DIFF
--- a/pulp_smash/tests/pulp2/platform/api_v2/test_content_applicability.py
+++ b/pulp_smash/tests/pulp2/platform/api_v2/test_content_applicability.py
@@ -83,10 +83,10 @@ class ParallelTestCase(_SuccessTestCase):
     def setUpClass(cls):
         """Make calls to the server and save the responses."""
         super(ParallelTestCase, cls).setUpClass()
-        client = api.Client(cls.cfg, api.echo_handler)
-        for key in {'repo'}:
-            json = {key + '_criteria': {}, 'parallel': True}
-            cls.responses[key] = client.post(_PATHS[key], json)
+        cls.responses['repo'] = (
+            api
+            .Client(cls.cfg, api.echo_handler)
+            .post(_PATHS['repo'], {'repo_criteria': {}, 'parallel': True}))
 
     def setUp(self):
         """Ensure this test only runs on Pulp 2.8 and later."""


### PR DESCRIPTION
What's the point in having a loop hard-coded to a single element?