### PR TITLE
Replace type('') with str

### DIFF
--- a/pulp_smash/config.py
+++ b/pulp_smash/config.py
@@ -374,7 +374,7 @@ class PulpSmashConfig():
     def __repr__(self):
         """Create string representation of the object."""
         attrs = _public_attrs(self)
-        attrs['pulp_version'] = type('')(attrs['pulp_version'])
+        attrs['pulp_version'] = str(attrs['pulp_version'])
         str_kwargs = ', '.join(
             '{}={}'.format(key, repr(value)) for key, value in attrs.items()
         )

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_comps_xml.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_comps_xml.py
@@ -302,7 +302,7 @@ class UploadPackageGroupsTestCase(utils.BaseAPITestCase):
         output = _get_groups_by_id(self.root_element)[input_['id']]
         for key in ('id', 'name', 'description', 'display_order'):
             with self.subTest(key=key):
-                input_text = type('')(input_[key])
+                input_text = str(input_[key])
                 output_text = output.find(key).text
                 self.assertEqual(input_text, output_text)
 
@@ -320,7 +320,7 @@ class UploadPackageGroupsTestCase(utils.BaseAPITestCase):
             with self.subTest(input_key=input_key, output_key=output_key):
                 input_value = input_[input_key]
                 self.assertIn(input_value, (True, False))
-                input_value = type('')(input_value).lower()
+                input_value = str(input_value).lower()
 
                 output_value = output.find(output_key).text
                 self.assertEqual(input_value, output_value)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -72,7 +72,7 @@ def _gen_attrs():
     return {
         'pulp_auth': [utils.uuid4() for _ in range(2)],
         'pulp_version': '.'.join(
-            type('')(random.randint(1, 150)) for _ in range(4)
+            str(random.randint(1, 150)) for _ in range(4)
         ),
         'pulp_selinux_enabled': True,
         'systems': [
@@ -197,7 +197,7 @@ class InitTestCase(unittest.TestCase):
     def test_public_attrs(self):
         """Assert that public attributes have correct values."""
         attrs = config._public_attrs(self.cfg)  # pylint:disable=W0212
-        attrs['pulp_version'] = type('')(attrs['pulp_version'])
+        attrs['pulp_version'] = str(attrs['pulp_version'])
         attrs['pulp_selinux_enabled'] = bool(attrs['pulp_selinux_enabled'])
         self.assertIsNotNone(attrs['pulp_selinux_enabled'])
         self.assertEqual(self.kwargs, attrs)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,7 +13,7 @@ class UUID4TestCase(unittest.TestCase):
 
     def test_type(self):
         """Assert the method returns a unicode string."""
-        self.assertIsInstance(utils.uuid4(), type(''))
+        self.assertIsInstance(utils.uuid4(), str)
 
 
 class GetBrokerTestCase(unittest.TestCase):


### PR DESCRIPTION
When Pulp Smash supported both Python 2 and 3, and when `from __future__
import unicode_literals` was common, `type('')` might evaluate to either
`unicode` or `str`, respectively. Pulp Smash now supports just Python 3.
As a result, it's better to avoid this level of indirection and use just
`str`.