### PR TITLE
Rename functions of utils pulp3.

### DIFF
--- a/pulp_smash/tests/pulp3/file/api_v3/test_crd_publications.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_crd_publications.py
@@ -22,8 +22,8 @@ from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # py
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_distribution, gen_repo
 from pulp_smash.tests.pulp3.utils import (
     get_auth,
-    publish_repo,
-    sync_repo,
+    publish,
+    sync,
 )
 
 
@@ -47,7 +47,7 @@ class PublicationsTestCase(unittest.TestCase, utils.SmokeTest):
             cls.publisher.update(
                 cls.client.post(FILE_PUBLISHER_PATH, gen_publisher())
             )
-            sync_repo(cls.cfg, cls.remote, cls.repo)
+            sync(cls.cfg, cls.remote, cls.repo)
         except:  # noqa:E722
             cls.tearDownClass()
             raise
@@ -62,7 +62,7 @@ class PublicationsTestCase(unittest.TestCase, utils.SmokeTest):
     def test_01_create_publication(self):
         """Create a publication."""
         self.publication.update(
-            publish_repo(self.cfg, self.publisher, self.repo)
+            publish(self.cfg, self.publisher, self.repo)
         )
 
     @selectors.skip_if(bool, 'publication', False)

--- a/pulp_smash/tests/pulp3/file/api_v3/test_crud_content_unit.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_crud_content_unit.py
@@ -21,7 +21,7 @@ from pulp_smash.tests.pulp3.utils import (
     delete_orphans,
     get_auth,
     get_content,
-    sync_repo,
+    sync,
 )
 
 
@@ -135,7 +135,7 @@ class DeleteContentUnitRepoVersionTestCase(unittest.TestCase, utils.SmokeTest):
         self.addCleanup(client.delete, remote['_href'])
         repo = client.post(REPO_PATH, gen_repo())
         self.addCleanup(client.delete, repo['_href'])
-        sync_repo(cfg, remote, repo)
+        sync(cfg, remote, repo)
         repo = client.get(repo['_href'])
         content = get_content(repo)['results']
         with self.assertRaises(HTTPError):

--- a/pulp_smash/tests/pulp3/file/api_v3/test_download_content.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_download_content.py
@@ -20,7 +20,7 @@ from pulp_smash.tests.pulp3.file.api_v3.utils import (
 )
 from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_distribution, gen_repo
-from pulp_smash.tests.pulp3.utils import get_auth, publish_repo, sync_repo
+from pulp_smash.tests.pulp3.utils import get_auth, publish, sync
 
 
 class DownloadContentTestCase(unittest.TestCase, utils.SmokeTest):
@@ -63,7 +63,7 @@ class DownloadContentTestCase(unittest.TestCase, utils.SmokeTest):
         body = gen_remote(urljoin(FILE_FEED_URL, 'PULP_MANIFEST'))
         remote = client.post(FILE_REMOTE_PATH, body)
         self.addCleanup(client.delete, remote['_href'])
-        sync_repo(cfg, remote, repo)
+        sync(cfg, remote, repo)
         repo = client.get(repo['_href'])
 
         # Create a publisher.
@@ -71,7 +71,7 @@ class DownloadContentTestCase(unittest.TestCase, utils.SmokeTest):
         self.addCleanup(client.delete, publisher['_href'])
 
         # Create a publication.
-        publication = publish_repo(cfg, publisher, repo)
+        publication = publish(cfg, publisher, repo)
         self.addCleanup(client.delete, publication['_href'])
 
         # Create a distribution.

--- a/pulp_smash/tests/pulp3/file/api_v3/test_orphans.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_orphans.py
@@ -22,11 +22,11 @@ from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # py
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
 from pulp_smash.tests.pulp3.utils import (
     delete_orphans,
-    delete_repo_version,
+    delete_version,
     get_auth,
     get_content,
-    get_repo_versions,
-    sync_repo,
+    get_version_hrefs,
+    sync,
 )
 
 
@@ -71,7 +71,7 @@ class DeleteOrphansTestCase(unittest.TestCase, utils.SmokeTest):
         body = gen_remote(urljoin(FILE_FEED_URL, 'PULP_MANIFEST'))
         remote = self.api_client.post(FILE_REMOTE_PATH, body)
         self.addCleanup(self.api_client.delete, remote['_href'])
-        sync_repo(self.cfg, remote, repo)
+        sync(self.cfg, remote, repo)
         repo = self.api_client.get(repo['_href'])
         content = choice(get_content(repo)['results'])
 
@@ -88,7 +88,7 @@ class DeleteOrphansTestCase(unittest.TestCase, utils.SmokeTest):
 
         # Delete first repo version. The previous removed content unit will be
         # an orphan.
-        delete_repo_version(repo, get_repo_versions(repo)[0])
+        delete_version(repo, get_version_hrefs(repo)[0])
         content_units = self.api_client.get(FILE_CONTENT_PATH)['results']
         self.assertIn(content, content_units)
         delete_orphans()

--- a/pulp_smash/tests/pulp3/file/api_v3/test_publish.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_publish.py
@@ -22,9 +22,9 @@ from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # py
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
 from pulp_smash.tests.pulp3.utils import (
     get_auth,
-    get_repo_versions,
-    publish_repo,
-    sync_repo,
+    get_version_hrefs,
+    publish,
+    sync,
 )
 
 
@@ -59,7 +59,7 @@ class PublishAnyRepoVersionTestCase(unittest.TestCase, utils.SmokeTest):
         self.addCleanup(client.delete, remote['_href'])
         repo = client.post(REPO_PATH, gen_repo())
         self.addCleanup(client.delete, repo['_href'])
-        sync_repo(cfg, remote, repo)
+        sync(cfg, remote, repo)
         publisher = client.post(FILE_PUBLISHER_PATH, gen_publisher())
         self.addCleanup(client.delete, publisher['_href'])
 
@@ -71,17 +71,17 @@ class PublishAnyRepoVersionTestCase(unittest.TestCase, utils.SmokeTest):
                 repo['_versions_href'],
                 {'add_content_units': [file_content['_href']]}
             )
-        versions = get_repo_versions(repo)
-        non_latest = choice(versions[:-1])
+        version_hrefs = get_version_hrefs(repo)
+        non_latest = choice(version_hrefs[:-1])
 
         # Step 2
-        publication = publish_repo(cfg, publisher, repo)
+        publication = publish(cfg, publisher, repo)
 
         # Step 3
-        self.assertEqual(publication['repository_version'], versions[-1])
+        self.assertEqual(publication['repository_version'], version_hrefs[-1])
 
         # Step 4
-        publication = publish_repo(cfg, publisher, repo, non_latest)
+        publication = publish(cfg, publisher, repo, non_latest)
 
         # Step 5
         self.assertEqual(publication['repository_version'], non_latest)

--- a/pulp_smash/tests/pulp3/file/api_v3/test_sync.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_sync.py
@@ -19,7 +19,7 @@ from pulp_smash.tests.pulp3.file.api_v3.utils import (
 )
 from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
-from pulp_smash.tests.pulp3.utils import get_auth, get_content, sync_repo
+from pulp_smash.tests.pulp3.utils import get_auth, get_content, sync
 
 
 class SyncFileRepoTestCase(unittest.TestCase, utils.SmokeTest):
@@ -56,13 +56,13 @@ class SyncFileRepoTestCase(unittest.TestCase, utils.SmokeTest):
 
         # Sync the repository.
         self.assertIsNone(repo['_latest_version_href'])
-        sync_repo(self.cfg, remote, repo)
+        sync(self.cfg, remote, repo)
         repo = client.get(repo['_href'])
         self.assertIsNotNone(repo['_latest_version_href'])
 
         # Sync the repository again.
         latest_version_href = repo['_latest_version_href']
-        sync_repo(self.cfg, remote, repo)
+        sync(self.cfg, remote, repo)
         repo = client.get(repo['_href'])
         self.assertNotEqual(latest_version_href, repo['_latest_version_href'])
 
@@ -98,7 +98,7 @@ class SyncChangeRepoVersionTestCase(unittest.TestCase):
 
         number_of_syncs = randint(1, 10)
         for _ in range(number_of_syncs):
-            sync_repo(cfg, remote, repo)
+            sync(cfg, remote, repo)
 
         repo = client.get(repo['_href'])
         path = urlsplit(repo['_latest_version_href']).path
@@ -138,7 +138,7 @@ class MultiResourceLockingTestCase(unittest.TestCase, utils.SmokeTest):
         self.addCleanup(client.delete, remote['_href'])
         url = {'url': urljoin(FILE_FEED_URL, 'PULP_MANIFEST')}
         client.patch(remote['_href'], url)
-        sync_repo(cfg, remote, repo)
+        sync(cfg, remote, repo)
         repo = client.get(repo['_href'])
         remote = client.get(remote['_href'])
         self.assertEqual(remote['url'], url['url'])

--- a/pulp_smash/tests/pulp3/file/api_v3/test_unlinking_repo.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_unlinking_repo.py
@@ -20,8 +20,8 @@ from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
 from pulp_smash.tests.pulp3.utils import (
     get_auth,
     get_content,
-    publish_repo,
-    sync_repo,
+    publish,
+    sync,
 )
 
 
@@ -66,7 +66,7 @@ class RemotesPublishersTestCase(unittest.TestCase, utils.SmokeTest):
         for _ in range(2):
             repo = client.post(REPO_PATH, gen_repo())
             self.addCleanup(client.delete, repo['_href'])
-            sync_repo(cfg, remote, repo)
+            sync(cfg, remote, repo)
             repos.append(client.get(repo['_href']))
 
         # Compare contents of repositories.
@@ -81,7 +81,7 @@ class RemotesPublishersTestCase(unittest.TestCase, utils.SmokeTest):
         # Publish repositories.
         publications = []
         for repo in repos:
-            publications.append(publish_repo(cfg, publisher, repo))
+            publications.append(publish(cfg, publisher, repo))
             if selectors.bug_is_testable(3354, cfg.pulp_version):
                 self.addCleanup(client.delete, publications[-1]['_href'])
         self.assertEqual(

--- a/pulp_smash/tests/pulp3/utils.py
+++ b/pulp_smash/tests/pulp3/utils.py
@@ -151,7 +151,7 @@ def get_plugins(cfg=None):
     }
 
 
-def sync_repo(cfg, remote, repo):
+def sync(cfg, remote, repo):
     """Sync a repository.
 
     :param pulp_smash.config.PulpSmashConfig cfg: Information about the Pulp
@@ -167,7 +167,7 @@ def sync_repo(cfg, remote, repo):
     )
 
 
-def publish_repo(cfg, publisher, repo, version_href=None):
+def publish(cfg, publisher, repo, version_href=None):
     """Publish a repository.
 
     :param pulp_smash.config.PulpSmashConfig cfg: Information about the Pulp
@@ -262,18 +262,19 @@ def delete_orphans(cfg=None):
     api.Client(cfg, api.safe_handler).delete(ORPHANS_PATH)
 
 
-def get_repo_versions(repo):
-    """Return hrefs of repository versions.
+def get_version_hrefs(repo):
+    """Return hrefs for repository versions.
 
     :param repo: A dict of information about the repository.
     :returns: A sorted list with the hrefs of repository versions.
     """
     client = api.Client(config.get_config(), api.json_handler)
-    versions = client.get(repo['_versions_href'])['results']
-    return sorted(
-        [version['_href'] for version in versions],
-        key=lambda url: int(urlsplit(url).path.split('/')[-2])
-    )
+    attributes = [
+        version_href['_href']
+        for version_href in client.get(repo['_versions_href'])['results']
+    ]
+    attributes.sort(key=lambda url: int(urlsplit(url).path.split('/')[-2]))
+    return attributes
 
 
 def get_artifact_paths(repo, version_href=None):
@@ -289,7 +290,7 @@ def get_artifact_paths(repo, version_href=None):
     }
 
 
-def delete_repo_version(repo, version_href=None):
+def delete_version(repo, version_href=None):
     """Delete a given repository version.
 
     :param repo: A dict of information about the repository.


### PR DESCRIPTION
Few functions had the repo in their names. Simplify their names,
removing the word repo from it.

Rename the following functions:

 1. `get_repo_versions` = `get_version_hrefs`
 2. `sync_repo` = `sync`
 3. `publish_repo` = `publish`
 4. `delete_repo_version` = `delete_version`

Update the logic for `get_version_hrefs`.

Closes:#990