### PR TITLE
Replace get_version_hrefs() with get_versions()

### DIFF
--- a/pulp_smash/tests/pulp3/file/api_v3/test_orphans.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_orphans.py
@@ -25,7 +25,7 @@ from pulp_smash.tests.pulp3.utils import (
     delete_version,
     get_auth,
     get_content,
-    get_version_hrefs,
+    get_versions,
     sync,
 )
 
@@ -88,7 +88,7 @@ class DeleteOrphansTestCase(unittest.TestCase, utils.SmokeTest):
 
         # Delete first repo version. The previous removed content unit will be
         # an orphan.
-        delete_version(repo, get_version_hrefs(repo)[0])
+        delete_version(repo, get_versions(repo)[0]['_href'])
         content_units = self.api_client.get(FILE_CONTENT_PATH)['results']
         self.assertIn(content, content_units)
         delete_orphans()

--- a/pulp_smash/tests/pulp3/file/api_v3/test_publish.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_publish.py
@@ -20,12 +20,7 @@ from pulp_smash.tests.pulp3.file.api_v3.utils import (
 )
 from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
-from pulp_smash.tests.pulp3.utils import (
-    get_auth,
-    get_version_hrefs,
-    publish,
-    sync,
-)
+from pulp_smash.tests.pulp3.utils import get_auth, get_versions, publish, sync
 
 
 class PublishAnyRepoVersionTestCase(unittest.TestCase, utils.SmokeTest):
@@ -71,7 +66,7 @@ class PublishAnyRepoVersionTestCase(unittest.TestCase, utils.SmokeTest):
                 repo['_versions_href'],
                 {'add_content_units': [file_content['_href']]}
             )
-        version_hrefs = get_version_hrefs(repo)
+        version_hrefs = tuple(ver['_href'] for ver in get_versions(repo))
         non_latest = choice(version_hrefs[:-1])
 
         # Step 2

--- a/pulp_smash/tests/pulp3/utils.py
+++ b/pulp_smash/tests/pulp3/utils.py
@@ -262,19 +262,22 @@ def delete_orphans(cfg=None):
     api.Client(cfg, api.safe_handler).delete(ORPHANS_PATH)
 
 
-def get_version_hrefs(repo):
-    """Return hrefs for repository versions.
+def get_versions(repo, params=None):
+    """Return repository versions, sorted by version ID.
 
     :param repo: A dict of information about the repository.
-    :returns: A sorted list with the hrefs of repository versions.
+    :param params: Dictionary or bytes to be sent in the query string. Used to
+        filter which versions are returned.
+    :returns: A sorted list of dicts of information about repository versions.
     """
-    client = api.Client(config.get_config(), api.json_handler)
-    attributes = [
-        version_href['_href']
-        for version_href in client.get(repo['_versions_href'])['results']
-    ]
-    attributes.sort(key=lambda url: int(urlsplit(url).path.split('/')[-2]))
-    return attributes
+    versions = (
+        api
+        .Client(config.get_config(), api.json_handler)
+        .get(repo['_versions_href'], params=params)['results'])
+    versions.sort(
+        key=lambda version: int(urlsplit(version['_href']).path.split('/')[-2])
+    )
+    return versions
 
 
 def get_artifact_paths(repo, version_href=None):


### PR DESCRIPTION
High-level general-purpose utilities are most useful when they return
complete or near-complete responses from Pulp, instead of attributes
extracted from Pulp's responses. The `get_version_hrefs` function
violates this design principle: it fetches the versions of a repository,
and then returns just the hrefs of each version.

Drop this function in favor of a `get_versions` function, which returns
the complete list of repository versions returned by Pulp. This lets the
function be used in more places, such as in the `get_repo_versions_attr`
function.

In addition, let the revamped function accept a `params` argument, which
can be used to filter which repositories Pulp returns. This lets it
replace the `filter_repo_version` function.