### PR TITLE
Update docstring class DownloadContentTestCase.

### DIFF
--- a/pulp_smash/tests/pulp3/file/api_v3/test_download_content.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_download_content.py
@@ -37,8 +37,8 @@ class DownloadContentTestCase(unittest.TestCase, utils.SmokeTest):
            repository version plus metadata.
         2. Create a distribution from the publication. The distribution defines
            at which URLs a publication is available, e.g.
-           ``http://example.com/content/pub-name/`` and
-           ``https://example.com/content/pub-name/``.
+           ``http://example.com/content/foo/`` and
+           ``http://example.com/content/bar/``.
 
         Do the following:
 


### PR DESCRIPTION
Distributions no longer have the attributes `http` and `https`. Update
dosctring on class `DownloadContentTestCase` to be according to this.

See: https://pulp.plan.io/issues/3413