### PR TITLE
Add populate_pulp()

### DIFF
--- a/pulp_smash/tests/pulp3/file/api_v3/test_auto_distribution.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_auto_distribution.py
@@ -5,15 +5,15 @@ import unittest
 from urllib.parse import urljoin
 
 from pulp_smash import api, config, utils
-from pulp_smash.constants import FILE_FEED_URL, FILE_URL
+from pulp_smash.constants import FILE_URL
 from pulp_smash.tests.pulp3.constants import (
     DISTRIBUTION_PATH,
     FILE_CONTENT_PATH,
     FILE_PUBLISHER_PATH,
-    FILE_REMOTE_PATH,
     REPO_PATH,
 )
-from pulp_smash.tests.pulp3.file.api_v3.utils import gen_publisher, gen_remote
+from pulp_smash.tests.pulp3.file.api_v3.utils import gen_publisher
+from pulp_smash.tests.pulp3.file.utils import populate_pulp
 from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_distribution, gen_repo
 from pulp_smash.tests.pulp3.utils import (
@@ -21,7 +21,6 @@ from pulp_smash.tests.pulp3.utils import (
     get_auth,
     get_versions,
     publish,
-    sync,
 )
 
 
@@ -37,18 +36,7 @@ class AutoDistributionTestCase(unittest.TestCase):
         cls.cfg = config.get_config()
         cls.client = api.Client(cls.cfg, api.json_handler)
         cls.client.request_kwargs['auth'] = get_auth()
-        body = gen_remote(urljoin(FILE_FEED_URL, 'PULP_MANIFEST'))
-        remote = {}
-        repo = {}
-        try:
-            remote.update(cls.client.post(FILE_REMOTE_PATH, body))
-            repo.update(cls.client.post(REPO_PATH, gen_repo()))
-            sync(cls.cfg, remote, repo)
-        finally:
-            if remote:
-                cls.client.delete(remote['_href'])
-            if repo:
-                cls.client.delete(repo['_href'])
+        populate_pulp(cls.cfg)
         cls.contents = cls.client.get(FILE_CONTENT_PATH)['results'][:2]
 
     def test_repo_auto_distribution(self):

--- a/pulp_smash/tests/pulp3/file/api_v3/test_crd_publications.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_crd_publications.py
@@ -14,13 +14,11 @@ from pulp_smash.tests.pulp3.constants import (
     PUBLICATIONS_PATH,
     REPO_PATH,
 )
-from pulp_smash.tests.pulp3.file.api_v3.utils import (
-    gen_remote,
-    gen_publisher,
-)
+from pulp_smash.tests.pulp3.file.api_v3.utils import gen_publisher
 from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_distribution, gen_repo
 from pulp_smash.tests.pulp3.utils import (
+    gen_remote,
     get_auth,
     publish,
     sync,

--- a/pulp_smash/tests/pulp3/file/api_v3/test_crud_content_unit.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_crud_content_unit.py
@@ -14,11 +14,11 @@ from pulp_smash.tests.pulp3.constants import (
     FILE_REMOTE_PATH,
     REPO_PATH,
 )
-from pulp_smash.tests.pulp3.file.api_v3.utils import gen_remote
 from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
 from pulp_smash.tests.pulp3.utils import (
     delete_orphans,
+    gen_remote,
     get_auth,
     get_content,
     sync,

--- a/pulp_smash/tests/pulp3/file/api_v3/test_crud_remotes.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_crud_remotes.py
@@ -8,10 +8,9 @@ from requests.exceptions import HTTPError
 from pulp_smash import api, config, selectors, utils
 from pulp_smash.constants import FILE_FEED_URL, FILE2_FEED_URL
 from pulp_smash.tests.pulp3.constants import FILE_REMOTE_PATH, REPO_PATH
-from pulp_smash.tests.pulp3.file.api_v3.utils import gen_remote
 from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
-from pulp_smash.tests.pulp3.utils import get_auth
+from pulp_smash.tests.pulp3.utils import gen_remote, get_auth
 
 
 class CRUDRemotesTestCase(unittest.TestCase, utils.SmokeTest):

--- a/pulp_smash/tests/pulp3/file/api_v3/test_download_content.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_download_content.py
@@ -15,12 +15,11 @@ from pulp_smash.tests.pulp3.constants import (
 )
 from pulp_smash.tests.pulp3.file.api_v3.utils import (
     gen_publisher,
-    gen_remote,
     get_content_unit_paths,
 )
 from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_distribution, gen_repo
-from pulp_smash.tests.pulp3.utils import get_auth, publish, sync
+from pulp_smash.tests.pulp3.utils import gen_remote, get_auth, publish, sync
 
 
 class DownloadContentTestCase(unittest.TestCase, utils.SmokeTest):

--- a/pulp_smash/tests/pulp3/file/api_v3/test_orphans.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_orphans.py
@@ -17,12 +17,12 @@ from pulp_smash.tests.pulp3.constants import (
     REPO_PATH,
 )
 
-from pulp_smash.tests.pulp3.file.api_v3.utils import gen_remote
 from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
 from pulp_smash.tests.pulp3.utils import (
     delete_orphans,
     delete_version,
+    gen_remote,
     get_auth,
     get_content,
     get_versions,

--- a/pulp_smash/tests/pulp3/file/api_v3/test_publish.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_publish.py
@@ -14,13 +14,16 @@ from pulp_smash.tests.pulp3.constants import (
     FILE_PUBLISHER_PATH,
     REPO_PATH,
 )
-from pulp_smash.tests.pulp3.file.api_v3.utils import (
-    gen_remote,
-    gen_publisher,
-)
+from pulp_smash.tests.pulp3.file.api_v3.utils import gen_publisher
 from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
-from pulp_smash.tests.pulp3.utils import get_auth, get_versions, publish, sync
+from pulp_smash.tests.pulp3.utils import (
+    gen_remote,
+    get_auth,
+    get_versions,
+    publish,
+    sync,
+)
 
 
 class PublishAnyRepoVersionTestCase(unittest.TestCase, utils.SmokeTest):

--- a/pulp_smash/tests/pulp3/file/api_v3/test_repo_version.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_repo_version.py
@@ -13,18 +13,19 @@ from pulp_smash.constants import (
     FILE_FEED_URL,
     FILE_LARGE_FEED_URL,
 )
-
 from pulp_smash.tests.pulp3.constants import (
     FILE_CONTENT_PATH,
     FILE_REMOTE_PATH,
     FILE_PUBLISHER_PATH,
     REPO_PATH,
 )
-from pulp_smash.tests.pulp3.file.api_v3.utils import gen_publisher, gen_remote
+from pulp_smash.tests.pulp3.file.api_v3.utils import gen_publisher
+from pulp_smash.tests.pulp3.file.utils import populate_pulp
 from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
 from pulp_smash.tests.pulp3.utils import (
     delete_version,
+    gen_remote,
     get_added_content,
     get_artifact_paths,
     get_auth,
@@ -213,19 +214,7 @@ class AddRemoveRepoVersionTestCase(unittest.TestCase, utils.SmokeTest):
         cls.cfg = config.get_config()
         cls.client = api.Client(cls.cfg, api.json_handler)
         cls.client.request_kwargs['auth'] = get_auth()
-        body = gen_remote(urljoin(FILE_LARGE_FEED_URL, 'PULP_MANIFEST'))
-        remote = {}
-        repo = {}
-        try:
-            remote.update(cls.client.post(FILE_REMOTE_PATH, body))
-            repo.update(cls.client.post(REPO_PATH, gen_repo()))
-            sync(cls.cfg, remote, repo)
-        finally:
-            if remote:
-                cls.client.delete(remote['_href'])
-            if repo:
-                cls.client.delete(repo['_href'])
-
+        populate_pulp(cls.cfg, urljoin(FILE_LARGE_FEED_URL, 'PULP_MANIFEST'))
         # We need at least three content units. Choosing a relatively low
         # number is useful, to limit how many repo versions are created, and
         # thus how long the test takes.
@@ -358,19 +347,8 @@ class FilterRepoVersionTestCase(unittest.TestCase):
         cls.cfg = config.get_config()
         cls.client = api.Client(cls.cfg, api.json_handler)
         cls.client.request_kwargs['auth'] = get_auth()
-        remote = {}
-        repo = {}
-        try:
-            body = gen_remote(urljoin(FILE_FEED_URL, 'PULP_MANIFEST'))
-            remote.update(cls.client.post(FILE_REMOTE_PATH, body))
-            repo.update(cls.client.post(REPO_PATH, gen_repo()))
-            sync(cls.cfg, remote, repo)
-            cls.contents = cls.client.get(FILE_CONTENT_PATH)['results']
-        finally:
-            if remote:
-                cls.client.delete(remote['_href'])
-            if repo:
-                cls.client.delete(repo['_href'])
+        populate_pulp(cls.cfg)
+        cls.contents = cls.client.get(FILE_CONTENT_PATH)['results']
 
     def setUp(self):
         """Create a repository and give it new versions."""

--- a/pulp_smash/tests/pulp3/file/api_v3/test_sync.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_sync.py
@@ -10,16 +10,15 @@ from pulp_smash.constants import (
     FILE_FEED_URL,
     FILE_LARGE_FEED_URL,
 )
-from pulp_smash.tests.pulp3.constants import (
-    FILE_REMOTE_PATH,
-    REPO_PATH,
-)
-from pulp_smash.tests.pulp3.file.api_v3.utils import (
-    gen_remote,
-)
+from pulp_smash.tests.pulp3.constants import FILE_REMOTE_PATH, REPO_PATH
 from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
-from pulp_smash.tests.pulp3.utils import get_auth, get_content, sync
+from pulp_smash.tests.pulp3.utils import (
+    gen_remote,
+    get_auth,
+    get_content,
+    sync,
+)
 
 
 class SyncFileRepoTestCase(unittest.TestCase, utils.SmokeTest):

--- a/pulp_smash/tests/pulp3/file/api_v3/test_unlinking_repo.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_unlinking_repo.py
@@ -11,13 +11,11 @@ from pulp_smash.tests.pulp3.constants import (
     FILE_PUBLISHER_PATH,
     REPO_PATH,
 )
-from pulp_smash.tests.pulp3.file.api_v3.utils import (
-    gen_remote,
-    gen_publisher,
-)
+from pulp_smash.tests.pulp3.file.api_v3.utils import gen_publisher
 from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
 from pulp_smash.tests.pulp3.utils import (
+    gen_remote,
     get_auth,
     get_content,
     publish,

--- a/pulp_smash/tests/pulp3/file/api_v3/utils.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/utils.py
@@ -4,19 +4,9 @@ from pulp_smash import utils
 from pulp_smash.tests.pulp3.utils import get_content
 
 
-def gen_remote(url):
-    """Return a semi-random dict for use in creating an remote.
-
-    :param url: The URL of an external content source.
-    """
-    return {'name': utils.uuid4(), 'url': url}
-
-
 def gen_publisher():
     """Return a semi-random dict for use in creating a publisher."""
-    return {
-        'name': utils.uuid4(),
-    }
+    return {'name': utils.uuid4()}
 
 
 def get_content_unit_paths(repo):

--- a/pulp_smash/tests/pulp3/file/utils.py
+++ b/pulp_smash/tests/pulp3/file/utils.py
@@ -1,9 +1,51 @@
 # coding=utf-8
 """Utilities for tests for the file plugin."""
-from pulp_smash.tests.pulp3 import utils
+from urllib.parse import urljoin
+
+from pulp_smash import api
+from pulp_smash.constants import FILE_FEED_URL
+from pulp_smash.tests.pulp3.constants import (
+    FILE_CONTENT_PATH,
+    FILE_REMOTE_PATH,
+    REPO_PATH,
+)
+from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
+from pulp_smash.tests.pulp3.utils import (
+    gen_remote,
+    require_pulp_3,
+    require_pulp_plugins,
+    sync,
+)
+
+
+def populate_pulp(cfg, url=None):
+    """Add file contents to Pulp.
+
+    :param pulp_smash.config.PulpSmashConfig: Information about a Pulp
+        application.
+    :param url: The URL to a file repository's ``PULP_MANIFEST`` file. Defaults
+        to :data:`pulp_smash.constants.FILE_FEED_URL` + ``PULP_MANIFEST``.
+    :returns: A list of dicts, where each dict describes one file content in
+        Pulp.
+    """
+    if url is None:
+        url = urljoin(FILE_FEED_URL, 'PULP_MANIFEST')
+    client = api.Client(cfg, api.json_handler)
+    remote = {}
+    repo = {}
+    try:
+        remote.update(client.post(FILE_REMOTE_PATH, gen_remote(url)))
+        repo.update(client.post(REPO_PATH, gen_repo()))
+        sync(cfg, remote, repo)
+    finally:
+        if remote:
+            client.delete(remote['_href'])
+        if repo:
+            client.delete(repo['_href'])
+    return client.get(FILE_CONTENT_PATH)['results']
 
 
 def set_up_module():
     """Skip tests Pulp 3 isn't under test or if pulp-file isn't installed."""
-    utils.require_pulp_3()
-    utils.require_pulp_plugins({'pulp_file'})
+    require_pulp_3()
+    require_pulp_plugins({'pulp_file'})

--- a/pulp_smash/tests/pulp3/utils.py
+++ b/pulp_smash/tests/pulp3/utils.py
@@ -9,7 +9,7 @@ from urllib.parse import urljoin, urlsplit
 from packaging.version import Version
 from requests.auth import AuthBase, HTTPBasicAuth
 
-from pulp_smash import api, config, selectors
+from pulp_smash import api, config, selectors, utils
 from pulp_smash.tests.pulp3.constants import (
     JWT_PATH,
     ORPHANS_PATH,
@@ -309,3 +309,11 @@ def delete_version(repo, version_href=None):
     # As of this writing, Pulp 3 only returns one task. If Pulp 3 starts
     # returning multiple tasks, this may need to be re-written.
     return tuple(api.poll_spawned_tasks(cfg, call_report))
+
+
+def gen_remote(url):
+    """Return a semi-random dict for use in creating an remote.
+
+    :param url: The URL of an external content source.
+    """
+    return {'name': utils.uuid4(), 'url': url}


### PR DESCRIPTION
This function syncs file content into Pulp, then deletes the repository
and remote and repository used for the task. In a fresh Pulp 3 system,
the result is that orphaned file contents will be present.

Within Pulp Smash, modules may import from siblings or parents, but not
children. This helps to prevent circular imports. Unfortunately,
populate_pulp() imports gen_remote() from a child module. Move
gen_remote() up the namespace hierarchy.