### PR TITLE
Move functions higher up namespace

### DIFF
--- a/pulp_smash/tests/pulp3/file/api_v3/test_auto_distribution.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_auto_distribution.py
@@ -15,8 +15,9 @@ from pulp_smash.tests.pulp3.constants import (
 from pulp_smash.tests.pulp3.file.api_v3.utils import gen_publisher
 from pulp_smash.tests.pulp3.file.utils import populate_pulp
 from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
-from pulp_smash.tests.pulp3.pulpcore.utils import gen_distribution, gen_repo
 from pulp_smash.tests.pulp3.utils import (
+    gen_distribution,
+    gen_repo,
     get_added_content,
     get_auth,
     get_versions,

--- a/pulp_smash/tests/pulp3/file/api_v3/test_crd_publications.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_crd_publications.py
@@ -16,9 +16,10 @@ from pulp_smash.tests.pulp3.constants import (
 )
 from pulp_smash.tests.pulp3.file.api_v3.utils import gen_publisher
 from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
-from pulp_smash.tests.pulp3.pulpcore.utils import gen_distribution, gen_repo
 from pulp_smash.tests.pulp3.utils import (
+    gen_distribution,
     gen_remote,
+    gen_repo,
     get_auth,
     publish,
     sync,

--- a/pulp_smash/tests/pulp3/file/api_v3/test_crud_content_unit.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_crud_content_unit.py
@@ -15,10 +15,10 @@ from pulp_smash.tests.pulp3.constants import (
     REPO_PATH,
 )
 from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
-from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
 from pulp_smash.tests.pulp3.utils import (
     delete_orphans,
     gen_remote,
+    gen_repo,
     get_auth,
     get_content,
     sync,

--- a/pulp_smash/tests/pulp3/file/api_v3/test_crud_publishers.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_crud_publishers.py
@@ -8,8 +8,7 @@ from pulp_smash import api, config, selectors, utils
 from pulp_smash.tests.pulp3.constants import FILE_PUBLISHER_PATH, REPO_PATH
 from pulp_smash.tests.pulp3.file.api_v3.utils import gen_publisher
 from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
-from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
-from pulp_smash.tests.pulp3.utils import get_auth
+from pulp_smash.tests.pulp3.utils import gen_repo, get_auth
 
 
 class CRUDPublishersTestCase(unittest.TestCase, utils.SmokeTest):

--- a/pulp_smash/tests/pulp3/file/api_v3/test_crud_remotes.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_crud_remotes.py
@@ -9,8 +9,7 @@ from pulp_smash import api, config, selectors, utils
 from pulp_smash.constants import FILE_FEED_URL, FILE2_FEED_URL
 from pulp_smash.tests.pulp3.constants import FILE_REMOTE_PATH, REPO_PATH
 from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
-from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
-from pulp_smash.tests.pulp3.utils import gen_remote, get_auth
+from pulp_smash.tests.pulp3.utils import gen_remote, gen_repo, get_auth
 
 
 class CRUDRemotesTestCase(unittest.TestCase, utils.SmokeTest):

--- a/pulp_smash/tests/pulp3/file/api_v3/test_download_content.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_download_content.py
@@ -18,8 +18,14 @@ from pulp_smash.tests.pulp3.file.api_v3.utils import (
     get_content_unit_paths,
 )
 from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
-from pulp_smash.tests.pulp3.pulpcore.utils import gen_distribution, gen_repo
-from pulp_smash.tests.pulp3.utils import gen_remote, get_auth, publish, sync
+from pulp_smash.tests.pulp3.utils import (
+    gen_distribution,
+    gen_remote,
+    gen_repo,
+    get_auth,
+    publish,
+    sync,
+)
 
 
 class DownloadContentTestCase(unittest.TestCase, utils.SmokeTest):

--- a/pulp_smash/tests/pulp3/file/api_v3/test_orphans.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_orphans.py
@@ -18,11 +18,11 @@ from pulp_smash.tests.pulp3.constants import (
 )
 
 from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
-from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
 from pulp_smash.tests.pulp3.utils import (
     delete_orphans,
     delete_version,
     gen_remote,
+    gen_repo,
     get_auth,
     get_content,
     get_versions,

--- a/pulp_smash/tests/pulp3/file/api_v3/test_publish.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_publish.py
@@ -16,9 +16,9 @@ from pulp_smash.tests.pulp3.constants import (
 )
 from pulp_smash.tests.pulp3.file.api_v3.utils import gen_publisher
 from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
-from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
 from pulp_smash.tests.pulp3.utils import (
     gen_remote,
+    gen_repo,
     get_auth,
     get_versions,
     publish,

--- a/pulp_smash/tests/pulp3/file/api_v3/test_repo_version.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_repo_version.py
@@ -22,10 +22,10 @@ from pulp_smash.tests.pulp3.constants import (
 from pulp_smash.tests.pulp3.file.api_v3.utils import gen_publisher
 from pulp_smash.tests.pulp3.file.utils import populate_pulp
 from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
-from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
 from pulp_smash.tests.pulp3.utils import (
     delete_version,
     gen_remote,
+    gen_repo,
     get_added_content,
     get_artifact_paths,
     get_auth,

--- a/pulp_smash/tests/pulp3/file/api_v3/test_sync.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_sync.py
@@ -12,9 +12,9 @@ from pulp_smash.constants import (
 )
 from pulp_smash.tests.pulp3.constants import FILE_REMOTE_PATH, REPO_PATH
 from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
-from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
 from pulp_smash.tests.pulp3.utils import (
     gen_remote,
+    gen_repo,
     get_auth,
     get_content,
     sync,

--- a/pulp_smash/tests/pulp3/file/api_v3/test_unlinking_repo.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_unlinking_repo.py
@@ -13,9 +13,9 @@ from pulp_smash.tests.pulp3.constants import (
 )
 from pulp_smash.tests.pulp3.file.api_v3.utils import gen_publisher
 from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
-from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
 from pulp_smash.tests.pulp3.utils import (
     gen_remote,
+    gen_repo,
     get_auth,
     get_content,
     publish,

--- a/pulp_smash/tests/pulp3/file/utils.py
+++ b/pulp_smash/tests/pulp3/file/utils.py
@@ -9,9 +9,9 @@ from pulp_smash.tests.pulp3.constants import (
     FILE_REMOTE_PATH,
     REPO_PATH,
 )
-from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
 from pulp_smash.tests.pulp3.utils import (
     gen_remote,
+    gen_repo,
     require_pulp_3,
     require_pulp_plugins,
     sync,

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_distributions.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_distributions.py
@@ -6,9 +6,8 @@ from requests.exceptions import HTTPError
 
 from pulp_smash import api, config, selectors, utils
 from pulp_smash.tests.pulp3.constants import DISTRIBUTION_PATH
-from pulp_smash.tests.pulp3.pulpcore.utils import gen_distribution
 from pulp_smash.tests.pulp3.pulpcore.utils import set_up_module as setUpModule  # pylint:disable=unused-import
-from pulp_smash.tests.pulp3.utils import get_auth
+from pulp_smash.tests.pulp3.utils import gen_distribution, get_auth
 
 
 class CRUDDistributionsTestCase(unittest.TestCase, utils.SmokeTest):

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_repos.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_repos.py
@@ -6,9 +6,8 @@ from requests.exceptions import HTTPError
 
 from pulp_smash import api, config, selectors, utils
 from pulp_smash.tests.pulp3.constants import REPO_PATH
-from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
 from pulp_smash.tests.pulp3.pulpcore.utils import set_up_module as setUpModule  # pylint:disable=unused-import
-from pulp_smash.tests.pulp3.utils import get_auth
+from pulp_smash.tests.pulp3.utils import gen_repo, get_auth
 
 
 class CRUDRepoTestCase(unittest.TestCase, utils.SmokeTest):

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_tasks.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_tasks.py
@@ -7,9 +7,8 @@ from requests import HTTPError
 from pulp_smash import api, config, selectors, utils
 from pulp_smash.api import P3_TASK_END_STATES
 from pulp_smash.tests.pulp3.constants import REPO_PATH, TASKS_PATH
-from pulp_smash.tests.pulp3.pulpcore.utils import gen_repo
 from pulp_smash.tests.pulp3.pulpcore.utils import set_up_module as setUpModule  # pylint:disable=unused-import
-from pulp_smash.tests.pulp3.utils import get_auth
+from pulp_smash.tests.pulp3.utils import gen_repo, get_auth
 
 _DYNAMIC_TASKS_ATTRS = ('finished_at',)
 """Task attributes that are dynamically set by Pulp, not set by a user."""

--- a/pulp_smash/tests/pulp3/pulpcore/utils.py
+++ b/pulp_smash/tests/pulp3/pulpcore/utils.py
@@ -1,20 +1,9 @@
 # coding=utf-8
 """Utilities for Pulpcore tests."""
-from pulp_smash import utils
-from pulp_smash.tests.pulp3 import utils as pulp3_utils
-
-
-def gen_distribution():
-    """Return a semi-random dict for use in creating a distribution."""
-    return {'base_path': utils.uuid4(), 'name': utils.uuid4()}
-
-
-def gen_repo():
-    """Return a semi-random dict for use in creating a repository."""
-    return {'name': utils.uuid4(), 'notes': {}}
+from pulp_smash.tests.pulp3.utils import require_pulp_3, require_pulp_plugins
 
 
 def set_up_module():
     """Skip tests Pulp 3 isn't under test or if pulpcore isn't installed."""
-    pulp3_utils.require_pulp_3()
-    pulp3_utils.require_pulp_plugins({'pulpcore'})
+    require_pulp_3()
+    require_pulp_plugins({'pulpcore'})

--- a/pulp_smash/tests/pulp3/utils.py
+++ b/pulp_smash/tests/pulp3/utils.py
@@ -311,9 +311,19 @@ def delete_version(repo, version_href=None):
     return tuple(api.poll_spawned_tasks(cfg, call_report))
 
 
+def gen_distribution():
+    """Return a semi-random dict for use in creating a distribution."""
+    return {'base_path': utils.uuid4(), 'name': utils.uuid4()}
+
+
 def gen_remote(url):
     """Return a semi-random dict for use in creating an remote.
 
     :param url: The URL of an external content source.
     """
     return {'name': utils.uuid4(), 'url': url}
+
+
+def gen_repo():
+    """Return a semi-random dict for use in creating a repository."""
+    return {'name': utils.uuid4(), 'notes': {}}


### PR DESCRIPTION
Move gen_distribution() and gen_repo() up the namespace hierarchy. This
lets tests for different plugins avoid importing from each other. In
this particular case, file plugin tests no longer need to import from
the pulp core tests. This is especially useful if plugins are going to
be pulled out of Pulp Smash and pushed into individual plugins.