### PR TITLE
Drop astroid from dependency list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,6 @@ setup(
             'flake8-quotes',
             'pydocstyle',
             'pylint',
-            'astroid',
             # For `make test-coverage`
             'coveralls',
             # For `make docs-html` and `make docs-clean`


### PR DESCRIPTION
Pylint depends on astroid. Astroid was added to the dependency list some
time back because of a bug which forced us to pin dependencies. However,
that bug has since been fixed.

Dependency pinning: 5e14a0e66c811ff4f02e67e440a3da42c99c814b

Dependency un-pinning: d07605ff6e331d67ab70d808822e71eee25a6e9c