### PR TITLE
Rename server_config to cfg

### DIFF
--- a/pulp_smash/cli.py
+++ b/pulp_smash/cli.py
@@ -170,7 +170,7 @@ class Client():  # pylint:disable=too-few-public-methods
     If they match, ``machine`` is set to execute commands locally; and vice
     versa.
 
-    :param pulp_smash.config.PulpSmashConfig server_config: Information about
+    :param pulp_smash.config.PulpSmashConfig cfg: Information about
         the host on which commands will be executed.
     :param response_handler: A callback function. Defaults to
         :func:`pulp_smash.cli.code_handler`.
@@ -180,11 +180,11 @@ class Client():  # pylint:disable=too-few-public-methods
     .. _Plumbum: http://plumbum.readthedocs.io/en/latest/index.html
     """
 
-    def __init__(self, server_config, response_handler=None, pulp_system=None):
+    def __init__(self, cfg, response_handler=None, pulp_system=None):
         """Initialize this object with needed instance attributes."""
         # How do we make requests?
         if not pulp_system:
-            pulp_system = server_config.get_systems('pulp cli')[0]
+            pulp_system = cfg.get_systems('pulp cli')[0]
         self.pulp_system = pulp_system
         hostname = pulp_system.hostname
         transport = pulp_system.roles.get('shell', {}).get('transport')

--- a/pulp_smash/tests/pulp2/docker/cli/utils.py
+++ b/pulp_smash/tests/pulp2/docker/cli/utils.py
@@ -12,18 +12,18 @@ For the meaning of each argument, see pulp-admin.
 from pulp_smash import cli
 
 
-def repo_copy(server_config, unit_type, from_repo_id=None, to_repo_id=None):
+def repo_copy(cfg, unit_type, from_repo_id=None, to_repo_id=None):
     """Execute ``pulp-admin docker repo copy {unit_type}``."""
     cmd = 'pulp-admin docker repo copy {}'.format(unit_type).split()
     if from_repo_id is not None:
         cmd.extend(('--from-repo-id', from_repo_id))
     if to_repo_id is not None:
         cmd.extend(('--to-repo-id', to_repo_id))
-    return cli.Client(server_config).run(cmd)
+    return cli.Client(cfg).run(cmd)
 
 
 def repo_create(  # pylint:disable=too-many-arguments
-        server_config,
+        cfg,
         enable_v1=None,
         enable_v2=None,
         feed=None,
@@ -44,44 +44,44 @@ def repo_create(  # pylint:disable=too-many-arguments
         cmd.extend(('--repo-registry-id', repo_registry_id))
     if upstream_name is not None:
         cmd.extend(('--upstream-name', upstream_name))
-    return cli.Client(server_config).run(cmd)
+    return cli.Client(cfg).run(cmd)
 
 
-def repo_delete(server_config, repo_id):
+def repo_delete(cfg, repo_id):
     """Execute ``pulp-admin docker repo delete``."""
     cmd = 'pulp-admin docker repo delete --repo-id {}'.format(repo_id).split()
-    return cli.Client(server_config).run(cmd)
+    return cli.Client(cfg).run(cmd)
 
 
-def repo_list(server_config, repo_id=None, details=False):
+def repo_list(cfg, repo_id=None, details=False):
     """Execute ``pulp-admin docker repo list``."""
     cmd = 'pulp-admin docker repo list'.split()
     if repo_id is not None:
         cmd.extend(('--repo-id', repo_id))
     if details:
         cmd.append('--details')
-    return cli.Client(server_config).run(cmd)
+    return cli.Client(cfg).run(cmd)
 
 
-def repo_search(server_config, unit_type, fields=None, repo_id=None):
+def repo_search(cfg, unit_type, fields=None, repo_id=None):
     """Execute ``pulp-admin docker repo search {unit_type}``."""
     cmd = 'pulp-admin docker repo search {}'.format(unit_type).split()
     if fields is not None:
         cmd.extend(('--fields', fields))
     if repo_id is not None:
         cmd.extend(('--repo-id', repo_id))
-    return cli.Client(server_config).run(cmd)
+    return cli.Client(cfg).run(cmd)
 
 
-def repo_sync(server_config, repo_id):
+def repo_sync(cfg, repo_id):
     """Execute ``pulp-admin docker repo sync run``."""
     cmd = 'pulp-admin docker repo sync run'.split()
     cmd.extend(('--repo-id', repo_id))
-    return cli.Client(server_config).run(cmd)
+    return cli.Client(cfg).run(cmd)
 
 
 def repo_update(  # pylint:disable=too-many-arguments
-        server_config,
+        cfg,
         enable_v1=None,
         enable_v2=None,
         feed=None,
@@ -102,10 +102,10 @@ def repo_update(  # pylint:disable=too-many-arguments
         cmd.extend(('--upstream-name', upstream_name))
     if repo_registry_id is not None:
         cmd.extend(('--repo-registry-id', repo_registry_id))
-    return cli.Client(server_config).run(cmd)
+    return cli.Client(cfg).run(cmd)
 
 
-def repo_publish(server_config, repo_id, bg=None, force_full=None):  # pylint:disable=invalid-name
+def repo_publish(cfg, repo_id, bg=None, force_full=None):  # pylint:disable=invalid-name
     """Execute ``pulp-admin docker repo publish run``."""
     cmd = (
         'pulp-admin', 'docker', 'repo', 'publish', 'run', '--repo-id', repo_id
@@ -114,4 +114,4 @@ def repo_publish(server_config, repo_id, bg=None, force_full=None):  # pylint:di
         cmd += '--bg'
     if force_full:
         cmd += '--force-full'
-    return cli.Client(server_config).run(cmd)
+    return cli.Client(cfg).run(cmd)

--- a/pulp_smash/tests/pulp2/ostree/api_v2/test_sync.py
+++ b/pulp_smash/tests/pulp2/ostree/api_v2/test_sync.py
@@ -16,18 +16,18 @@ from pulp_smash.tests.pulp2.ostree.utils import gen_repo
 from pulp_smash.tests.pulp2.ostree.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
-def _sync_repo(server_config, href):
+def _sync_repo(cfg, href):
     """Sync a repository and wait for the sync to complete.
 
     Verify only the HTTP status codes of Pulp's responses. Don't verify
     response contents, as the default response handler does. Return ``call
     report, tasks``.
     """
-    response = api.Client(server_config, api.code_handler).post(
+    response = api.Client(cfg, api.code_handler).post(
         urljoin(href, 'actions/sync/'),
         {'override_config': {}},
     )
-    tasks = tuple(api.poll_spawned_tasks(server_config, response.json()))
+    tasks = tuple(api.poll_spawned_tasks(cfg, response.json()))
     return response, tasks
 
 

--- a/pulp_smash/tests/pulp2/puppet/cli/test_sync.py
+++ b/pulp_smash/tests/pulp2/puppet/cli/test_sync.py
@@ -17,16 +17,16 @@ def setUpModule():  # pylint:disable=invalid-name
         raise unittest.SkipTest('https://pulp.plan.io/issues/2574')
 
 
-def get_num_units_in_repo(server_config, repo_id):
+def get_num_units_in_repo(cfg, repo_id):
     """Tell how many puppet modules are in a repository.
 
-    :param pulp_smash.config.PulpSmashConfig server_config: Information about
+    :param pulp_smash.config.PulpSmashConfig cfg: Information about
         the Pulp server being targeted.
     :param repo_id: A Puppet repository ID.
     :returns: The number of puppet modules in a repository, as an ``int``.
     """
     keyword = 'Puppet Module:'
-    completed_proc = cli.Client(server_config).run((
+    completed_proc = cli.Client(cfg).run((
         'pulp-admin puppet repo list --repo-id {} --fields content_unit_counts'
     ).format(repo_id).split())
     lines = [

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_comps_xml.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_comps_xml.py
@@ -93,14 +93,14 @@ def _get_groups_by_id(comps_tree):
     }
 
 
-def _upload_import_package_group(server_config, repo, unit_metadata):
+def _upload_import_package_group(cfg, repo, unit_metadata):
     """Import a unit of type ``package_group`` into a repository.
 
     :param repo: A dict of attributes about a repository.
     :param unit_metadata: A dict of unit metadata.
     :returns: The call report generated when importing and uploading.
     """
-    client = api.Client(server_config, api.json_handler)
+    client = api.Client(cfg, api.json_handler)
     malloc = client.post(CONTENT_UPLOAD_PATH)
     call_report = client.post(
         urljoin(repo['_href'], 'actions/import_upload/'),

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_download_policies.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_download_policies.py
@@ -51,7 +51,7 @@ def setUpModule():  # pylint:disable=invalid-name
         raise unittest.SkipTest('https://pulp.plan.io/issues/2144')
 
 
-def _create_repo(server_config, download_policy):
+def _create_repo(cfg, download_policy):
     """Create an RPM repository with the given download policy.
 
     The repository has a valid feed and is configured to auto-publish. Return
@@ -64,7 +64,7 @@ def _create_repo(server_config, download_policy):
     distributor['auto_publish'] = True
     distributor['distributor_config']['relative_url'] = body['id']
     body['distributors'] = [distributor]
-    return api.Client(server_config).post(REPOSITORY_PATH, body).json()
+    return api.Client(cfg).post(REPOSITORY_PATH, body).json()
 
 
 class BackgroundTestCase(utils.BaseAPITestCase):

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_export.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_export.py
@@ -45,15 +45,14 @@ def setUpModule():  # pylint:disable=invalid-name
         raise unittest.SkipTest('https://pulp.plan.io/issues/2277')
 
 
-def _create_distributor(
-        server_config, href, distributor_type_id, checksum_type=None):
+def _create_distributor(cfg, href, distributor_type_id, checksum_type=None):
     """Create an export distributor for the entity at ``href``."""
     path = urljoin(href, 'distributors/')
     body = gen_distributor()
     body['distributor_type_id'] = distributor_type_id
     if checksum_type is not None:
         body['distributor_config']['checksum_type'] = checksum_type
-    return api.Client(server_config).post(path, body).json()
+    return api.Client(cfg).post(path, body).json()
 
 
 def _get_iso_url(cfg, entity, entity_type, distributor):

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_repository_layout.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_repository_layout.py
@@ -34,10 +34,10 @@ from pulp_smash.tests.pulp2.rpm.utils import check_issue_2277, check_issue_3104
 from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
-def get_parse_repodata_xml(server_config, distributor, file_path):
+def get_parse_repodata_xml(cfg, distributor, file_path):
     """Fetch, parse and return an XML file from a ``repodata`` directory.
 
-    :param pulp_smash.config.PulpSmashConfig server_config: Information about
+    :param pulp_smash.config.PulpSmashConfig cfg: Information about
         the Pulp deployment being targeted.
     :param distributor: Information about a distributor. It should be a dict
         containing at least ``{'config': {'relative_url': …}}``.
@@ -47,7 +47,7 @@ def get_parse_repodata_xml(server_config, distributor, file_path):
     """
     path = urljoin('/pulp/repos/', distributor['config']['relative_url'])
     path = urljoin(path, file_path)
-    return api.Client(server_config, xml_handler).get(path)
+    return api.Client(cfg, xml_handler).get(path)
 
 
 def get_parse_repodata_primary_xml(cfg, distributor):

--- a/pulp_smash/tests/pulp2/rpm/cli/utils.py
+++ b/pulp_smash/tests/pulp2/rpm/cli/utils.py
@@ -3,10 +3,10 @@
 from pulp_smash import cli
 
 
-def count_langpacks(server_config, repo_id):
+def count_langpacks(cfg, repo_id):
     """Tell how many langpack content units are in the given repository.
 
-    :param pulp_smash.config.PulpSmashConfig server_config: Information about
+    :param pulp_smash.config.PulpSmashConfig cfg: Information about
         the Pulp deployment being targeted.
     :param repo_id: A repository ID.
     :returns: The number of langpacks in the named repository, as an integer.
@@ -14,7 +14,7 @@ def count_langpacks(server_config, repo_id):
     # This function could be refactored to take a third "keyword" argument. But
     # what do we do about the "rpm" word in the command below?
     keyword = 'Package Langpacks:'
-    completed_proc = cli.Client(server_config).run(
+    completed_proc = cli.Client(cfg).run(
         'pulp-admin rpm repo list --repo-id {} --fields content_unit_counts'
         .format(repo_id).split()
     )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -11,18 +11,18 @@ class EchoHandlerTestCase(unittest.TestCase):
 
     def test_return(self):
         """Assert the passed-in ``response`` is returned."""
-        kwargs = {key: mock.Mock() for key in ('server_config', 'response')}
+        kwargs = {key: mock.Mock() for key in ('cfg', 'response')}
         self.assertIs(kwargs['response'], api.echo_handler(**kwargs))
 
     def test_raise_for_status(self):
         """Assert ``response.raise_for_status()`` is not called."""
-        kwargs = {key: mock.Mock() for key in ('server_config', 'response')}
+        kwargs = {key: mock.Mock() for key in ('cfg', 'response')}
         api.echo_handler(**kwargs)
         self.assertEqual(kwargs['response'].raise_for_status.call_count, 0)
 
     def test_202_check_skipped(self):
         """Assert HTTP 202 responses are not treated specially."""
-        kwargs = {key: mock.Mock() for key in ('server_config', 'response')}
+        kwargs = {key: mock.Mock() for key in ('cfg', 'response')}
         with mock.patch.object(api, '_handle_202') as handle_202:
             api.echo_handler(**kwargs)
         self.assertEqual(handle_202.call_count, 0)
@@ -33,18 +33,18 @@ class CodeHandlerTestCase(unittest.TestCase):
 
     def test_return(self):
         """Assert the passed-in ``response`` is returned."""
-        kwargs = {key: mock.Mock() for key in ('server_config', 'response')}
+        kwargs = {key: mock.Mock() for key in ('cfg', 'response')}
         self.assertIs(kwargs['response'], api.code_handler(**kwargs))
 
     def test_raise_for_status(self):
         """Assert ``response.raise_for_status()`` is called."""
-        kwargs = {key: mock.Mock() for key in ('server_config', 'response')}
+        kwargs = {key: mock.Mock() for key in ('cfg', 'response')}
         api.code_handler(**kwargs)
         self.assertEqual(kwargs['response'].raise_for_status.call_count, 1)
 
     def test_202_check_skipped(self):
         """Assert HTTP 202 responses are not treated specially."""
-        kwargs = {key: mock.Mock() for key in ('server_config', 'response')}
+        kwargs = {key: mock.Mock() for key in ('cfg', 'response')}
         with mock.patch.object(api, '_handle_202') as handle_202:
             api.code_handler(**kwargs)
         self.assertEqual(handle_202.call_count, 0)
@@ -55,18 +55,18 @@ class SafeHandlerTestCase(unittest.TestCase):
 
     def test_return(self):
         """Assert the passed-in ``response`` is returned."""
-        kwargs = {key: mock.Mock() for key in ('server_config', 'response')}
+        kwargs = {key: mock.Mock() for key in ('cfg', 'response')}
         self.assertIs(kwargs['response'], api.safe_handler(**kwargs))
 
     def test_raise_for_status(self):
         """Assert ``response.raise_for_status()`` is called."""
-        kwargs = {key: mock.Mock() for key in ('server_config', 'response')}
+        kwargs = {key: mock.Mock() for key in ('cfg', 'response')}
         api.safe_handler(**kwargs)
         self.assertEqual(kwargs['response'].raise_for_status.call_count, 1)
 
     def test_202_check_run(self):
         """Assert HTTP 202 responses are treated specially."""
-        kwargs = {key: mock.Mock() for key in ('server_config', 'response')}
+        kwargs = {key: mock.Mock() for key in ('cfg', 'response')}
         with mock.patch.object(api, '_handle_202') as handle_202:
             api.safe_handler(**kwargs)
         self.assertEqual(handle_202.call_count, 1)
@@ -77,26 +77,26 @@ class JsonHandlerTestCase(unittest.TestCase):
 
     def test_return(self):
         """Assert the JSON-decoded body of ``response`` is returned."""
-        kwargs = {key: mock.Mock() for key in ('server_config', 'response')}
+        kwargs = {key: mock.Mock() for key in ('cfg', 'response')}
         out = api.json_handler(**kwargs)
         self.assertEqual(kwargs['response'].json.return_value, out)
 
     def test_raise_for_status(self):
         """Assert ``response.raise_for_status()`` is called."""
-        kwargs = {key: mock.Mock() for key in ('server_config', 'response')}
+        kwargs = {key: mock.Mock() for key in ('cfg', 'response')}
         api.json_handler(**kwargs)
         self.assertEqual(kwargs['response'].raise_for_status.call_count, 1)
 
     def test_202_check_run(self):
         """Assert HTTP 202 responses are treated specially."""
-        kwargs = {key: mock.Mock() for key in ('server_config', 'response')}
+        kwargs = {key: mock.Mock() for key in ('cfg', 'response')}
         with mock.patch.object(api, '_handle_202') as handle_202:
             api.json_handler(**kwargs)
         self.assertEqual(handle_202.call_count, 1)
 
     def test_204_check_run(self):
         """Assert HTTP 204 responses are treated specially."""
-        kwargs = {key: mock.Mock() for key in ('server_config', 'response')}
+        kwargs = {key: mock.Mock() for key in ('cfg', 'response')}
         kwargs['response'].status_code = 204
         with mock.patch.object(api, '_handle_202'):
             api.json_handler(**kwargs)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,12 +25,12 @@ class GetBrokerTestCase(unittest.TestCase):
         Assert that:
 
         * ``get_broker(…)`` returns a string.
-        * The ``server_config`` argument is passed to the service object.
+        * The ``cfg`` argument is passed to the service object.
         * The "qpidd" broker is the preferred broker.
         """
         with mock.patch.object(cli, 'Client') as client:
             client.return_value.run.return_value.returncode = 0
-            broker = utils.get_broker(server_config=mock.Mock())
+            broker = utils.get_broker(cfg=mock.Mock())
         self.assertEqual(broker, 'qpidd')
 
     def test_failure(self):
@@ -163,7 +163,7 @@ class UploadImportErratumTestCase(unittest.TestCase):
                 'upload_id': 'bar',
             }
             response = utils.upload_import_erratum(
-                mock.Mock(),  # server_config
+                mock.Mock(),  # cfg
                 {'id': 'abc123'},  # erratum
                 'http://example.com',  # repo_href
             )


### PR DESCRIPTION
Both `server_config` and `cfg` are used to reference the same type of
object in various places throughout the code base. There's no good
reason to use two names. Settle on one.

Given the high likelihood that Pulp Smash will become a full-fledged
framework in the near future, now seems like a good time to make a push
for having the best interfaces possible.