### PR TITLE
Drop compatibility with old config file schema

### DIFF
--- a/pulp_smash/pulp_smash_cli.py
+++ b/pulp_smash/pulp_smash_cli.py
@@ -175,26 +175,12 @@ def settings_validate(ctx):
     path = ctx.obj['cfg_path']
     if not path:
         _raise_settings_not_found()
-
     with open(path) as handle:
         config_dict = json.load(handle)
-    if 'systems' not in config_dict and 'pulp' in config_dict:
-        message = (
-            'the settings file at {} appears to be following the old '
-            'configuration file format, please update it like below:\n'
-            .format(path)
-        )
-        message += json.dumps(config.convert_old_config(config_dict), indent=2)
-        result = click.ClickException(message)
-        result.exit_code = -1
-        raise result
     try:
         config.validate_config(config_dict)
     except exceptions.ConfigValidationError as err:
-        message = (
-            'invalid settings file {}\n'
-            .format(path)
-        )
+        message = ('Invalid settings file: {}\n' .format(path))
         for error_message in err.error_messages:
             message += error_message
         result = click.ClickException(message)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -49,19 +49,6 @@ PULP_SMASH_CONFIG = """
 """
 
 
-OLD_CONFIG = """
-{
-    "pulp": {
-        "base_url": "https://pulp.example.com",
-        "auth": ["username", "password"],
-        "verify": false,
-        "version": "2.12",
-        "cli_transport": "ssh"
-    }
-}
-"""
-
-
 def _gen_attrs():
     """Generate attributes for populating a ``PulpSmashConfig``.
 
@@ -114,39 +101,6 @@ class GetConfigTestCase(unittest.TestCase):
             with mock.patch.object(config.PulpSmashConfig, 'read') as read:
                 config.get_config()
         self.assertEqual(read.call_count, 1)
-
-
-class ConvertOldConfigTestCase(unittest.TestCase):
-    """Test :func:`pulp_smash.config.convert_old_config`."""
-
-    def test_convert_old_config(self):
-        """Assert the conversion works."""
-        expected_config = {
-            'pulp': {
-                'auth': ['username', 'password'],
-                'version': '2.12'
-            },
-            'systems': [
-                {
-                    'hostname': 'pulp.example.com',
-                    'roles': {
-                        'amqp broker': {'service': 'qpidd'},
-                        'api': {'scheme': 'https', 'verify': False},
-                        'mongod': {},
-                        'pulp celerybeat': {},
-                        'pulp cli': {},
-                        'pulp resource manager': {},
-                        'pulp workers': {},
-                        'shell': {'transport': 'ssh'},
-                        'squid': {},
-                    }
-                }
-            ]
-        }
-        self.assertEqual(
-            config.convert_old_config(json.loads(OLD_CONFIG)),
-            expected_config
-        )
 
 
 class ValidateConfigTestCase(unittest.TestCase):
@@ -285,43 +239,6 @@ class ReadTestCase(unittest.TestCase):
                     ),
                 ])
             )
-
-    def test_read_old_config_file(self):
-        """Ensure Pulp Smash can read old config file format."""
-        open_ = mock.mock_open(read_data=OLD_CONFIG)
-        with mock.patch.object(builtins, 'open', open_):
-            cfg = config.PulpSmashConfig()
-            with mock.patch.object(cfg, 'get_config_file_path'):
-                with self.assertWarns(DeprecationWarning):
-                    cfg = cfg.read()
-        with self.subTest('check pulp_auth'):
-            self.assertEqual(cfg.pulp_auth, ['username', 'password'])
-        with self.subTest('check pulp_version'):
-            self.assertEqual(cfg.pulp_version, config.Version('2.12'))
-        with self.subTest('check pulp_selinux_enabled'):
-            self.assertEqual(cfg.pulp_selinux_enabled, True)
-        with self.subTest('check systems'):
-            self.assertEqual(
-                cfg.systems,
-                [
-                    config.PulpSystem(
-                        hostname='pulp.example.com',
-                        roles={
-                            'amqp broker': {'service': 'qpidd'},
-                            'api': {
-                                'scheme': 'https',
-                                'verify': False,
-                            },
-                            'mongod': {},
-                            'pulp cli': {},
-                            'pulp celerybeat': {},
-                            'pulp resource manager': {},
-                            'pulp workers': {},
-                            'shell': {'transport': 'ssh'},
-                            'squid': {},
-                        }
-                    )
-                ])
 
 
 class HelperMethodsTestCase(unittest.TestCase):

--- a/tests/test_pulp_smash_cli.py
+++ b/tests/test_pulp_smash_cli.py
@@ -7,9 +7,9 @@ import unittest
 from unittest import mock
 
 from click.testing import CliRunner
-from pulp_smash import config, exceptions, pulp_smash_cli, utils
+from pulp_smash import exceptions, pulp_smash_cli, utils
 
-from .test_config import OLD_CONFIG, PULP_SMASH_CONFIG
+from .test_config import PULP_SMASH_CONFIG
 
 
 class BasePulpSmashCliTestCase(unittest.TestCase):
@@ -295,40 +295,12 @@ class SettingsValidateTestCase(
                 )
             self.assertNotEqual(result.exit_code, 0)
             self.assertIn(
-                'invalid settings file settings.json',
+                'Invalid settings file: settings.json',
                 result.output,
             )
             self.assertIn(
                 "Failed to validate config['pulp'] because 'auth' is a "
                 'required property.',
-                result.output,
-            )
-
-    def test_old_config_alert(self):
-        """Ensure validate notifies about the old config format."""
-        with self.cli_runner.isolated_filesystem():
-            with open('settings.json', 'w') as handler:
-                handler.write(OLD_CONFIG)
-            with mock.patch.object(pulp_smash_cli, 'PulpSmashConfig') as psc:
-                cfg = mock.MagicMock()
-                psc.return_value = cfg
-                cfg.get_config_file_path.return_value = 'settings.json'
-                result = self.cli_runner.invoke(
-                    pulp_smash_cli.settings,
-                    ['validate'],
-                )
-            self.assertNotEqual(result.exit_code, 0)
-            self.assertIn(
-                'the settings file at settings.json appears to be following '
-                'the old configuration file format, please update it like '
-                'below:',
-                result.output
-            )
-            self.assertIn(
-                json.dumps(
-                    config.convert_old_config(json.loads(OLD_CONFIG)),
-                    indent=2,
-                ),
                 result.output,
             )
 


### PR DESCRIPTION
The old configuration file schema was deprecated over 14 months ago, on
March 8, 2017. Retaining compatibility with the old configuration file
schema is user-friendly, but hinders additional improvements. Given the
high likelihood that Pulp Smash will become a full-fledged framework in
the near future, now seems like a good time to make a push for having
the best interfaces possible.

See: 5f8838fb7432da9b7cfcb5775a120711d65042f9