### PR TITLE
Rename "systems" to "hosts" in config file

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -61,7 +61,7 @@ configuration file format is. Consider the example below:
             "version": "2.12.2",
             "selinux enable": true
         },
-        "systems": [
+        "hosts": [
             {
                 "hostname": "pulp.example.com",
                 "roles": {
@@ -82,33 +82,33 @@ configuration file format is. Consider the example below:
         ]
     }
 
-A single Pulp application may be deployed on just one system or on several
-systems. The configuration file above describes the former case. The "pulp"
-section lets you declare properties of the entire Pulp application. The
-"systems" section lets you declare properties of the individual systems that
-comprise the Pulp application.
+A single Pulp application may be deployed on just one host or on several hosts.
+The configuration file above describes the former case. The "pulp" section lets
+you declare properties of the entire Pulp application. The "hosts" section lets
+you declare properties of the individual hosts that comprise the Pulp
+application.
 
-Each system must fulfill the "shell" role. In addition, the systems must
+Each host must fulfill the "shell" role. In addition, the hosts must
 collectively fulfill the :obj:`pulp_smash.config.REQUIRED_ROLES`.
 
 Not all roles requires additional information. Currently, only the ``amqp
 broker``, ``api`` and ``shell`` roles do. The ``amqp broker`` object must have a
 ``service`` key set to either ``qpidd`` or ``rabbitmq``. The ``api`` role means
-that ``httpd`` will be running on the system. Its ``scheme`` key specifies
-whether the API should be accessed over HTTP or HTTPS, and its ``verify`` key
-specifies whether and how SSL certificates should be verified. (It may be true,
-false, or a path to a custom certificate file. In the latter case, the
-certificate must be on the Pulp Smash system.) The ``shell`` role specifies
-whether to access the system using a ``local`` shell or over ``ssh``.
+that ``httpd`` will be running on the host. Its ``scheme`` key specifies whether
+the API should be accessed over HTTP or HTTPS, and its ``verify`` key specifies
+whether and how SSL certificates should be verified. (It may be true, false, or
+a path to a custom certificate file. In the latter case, the certificate must be
+on the Pulp Smash host.) The ``shell`` role specifies whether to access the host
+using a ``local`` shell or over ``ssh``.
 
 .. note::
 
-    Pulp Smash can access a system via SSH only if the SSH connection can be
-    made without typing a password. Make sure to configure SSH so just running
-    ``ssh $hostname`` will access the system. See sshd_config(5).
+    Pulp Smash can access a host via SSH only if the SSH connection can be made
+    without typing a password. Make sure to configure SSH so just running ``ssh
+    $hostname`` will access the host. See sshd_config(5).
 
-The example below shows a configuration file that enables Pulp Smash to access
-a clustered Pulp deployment:
+The example below shows a configuration file that enables Pulp Smash to access a
+clustered Pulp deployment:
 
 .. code-block:: json
 
@@ -118,7 +118,7 @@ a clustered Pulp deployment:
             "version": "2.12.1",
             "selinux enable": true
         },
-        "systems": [
+        "hosts": [
             {
                 "hostname": "first.example.com",
                 "roles": {
@@ -148,12 +148,12 @@ a clustered Pulp deployment:
     }
 
 Note that the roles ``mongod`` and ``amqp broker`` is only available on the
-first system and that the Pulp related roles plus the ``squid`` are available
+first host and that the Pulp related roles plus the ``squid`` are available
 on both. The example shows how to have a clustered deployment where second
-system will connect to the first system's ``mongod`` and ``amqp broker``, all
-the other services will work as a failover redundancy. Like, if first system's
+host will connect to the first host's ``mongod`` and ``amqp broker``, all
+the other services will work as a failover redundancy. Like, if first host's
 ``pulp resource manager`` goes down than Pulp failover feature will activate
-and start using the second system's ``pulp resource manager``.
+and start using the second host's ``pulp resource manager``.
 
 Pulp Smash also has two other commands to help with configuration file
 management: ``pulp-smash settings show`` and ``pulp-smash settings validate``

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_errata.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_errata.py
@@ -73,7 +73,7 @@ class ApplyErratumTestCase(unittest.TestCase):
 
         Also, schedule it for deletion. Return nothing.
         """
-        verify = cfg.get_systems('api')[0].roles['api'].get('verify')
+        verify = cfg.get_hosts('api')[0].roles['api'].get('verify')
         sudo = () if utils.is_root(cfg) else ('sudo',)
         repo_path = gen_yum_config_file(
             cfg,

--- a/pulp_smash/tests/pulp2/rpm/cli/test_copy_units.py
+++ b/pulp_smash/tests/pulp2/rpm/cli/test_copy_units.py
@@ -215,7 +215,7 @@ class UpdateRpmTestCase(UtilsMixin, unittest.TestCase):
         client = cli.Client(cfg)
         pkg_mgr = cli.PackageManager(cfg)
         sudo = '' if is_root(cfg) else 'sudo '
-        verify = cfg.get_systems('api')[0].roles['api'].get('verify')
+        verify = cfg.get_hosts('api')[0].roles['api'].get('verify')
 
         # Create the second repository.
         repo_id = self.create_repo(cfg)

--- a/pulp_smash/tests/pulp3/file/api_v3/test_auto_distribution.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_auto_distribution.py
@@ -111,7 +111,7 @@ class AutoDistributionTestCase(unittest.TestCase):
         self.assertEqual(distribution['publication'], publication['_href'])
         unit_path = get_added_content(
             repo, last_version_href)['results'][0]['relative_path']
-        unit_url = self.cfg.get_systems('api')[0].roles['api']['scheme']
+        unit_url = self.cfg.get_hosts('api')[0].roles['api']['scheme']
         unit_url += '://' + distribution['base_url'] + '/'
         unit_url = urljoin(unit_url, unit_path)
 

--- a/pulp_smash/tests/pulp3/file/api_v3/test_download_content.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_download_content.py
@@ -93,7 +93,7 @@ class DownloadContentTestCase(unittest.TestCase, utils.SmokeTest):
 
         # …and Pulp.
         client.response_handler = api.safe_handler
-        unit_url = cfg.get_systems('api')[0].roles['api']['scheme']
+        unit_url = cfg.get_hosts('api')[0].roles['api']['scheme']
         unit_url += '://' + distribution['base_url'] + '/'
         unit_url = urljoin(unit_url, unit_path)
         pulp_hash = hashlib.sha256(client.get(unit_url).content).hexdigest()

--- a/pulp_smash/utils.py
+++ b/pulp_smash/utils.py
@@ -103,17 +103,16 @@ def reset_pulp(cfg):
     #
     # Why use `runuser` instead of `sudo`? Because some systems are configured
     # to refuse to execute `sudo` unless a tty is present (The author has
-    # encountered this on at least one RHEL 7.2 system.)
+    # encountered this on at least one RHEL 7.2 host.)
     #
     # Why not use runuser's `-u` flag? Because RHEL 6 ships an old version of
     # runuser that doesn't support the flag, and RHEL 6 is a supported Pulp
     # platform.
-    system = cfg.get_systems('mongod')[0]
-    client = cli.Client(cfg, pulp_system=system)
+    client = cli.Client(cfg, pulp_host=cfg.get_hosts('mongod')[0])
     client.run('mongo pulp_database --eval db.dropDatabase()'.split())
 
-    for index, system in enumerate(cfg.get_systems('api')):
-        prefix = '' if is_root(cfg, pulp_system=system) else 'sudo '
+    for index, host in enumerate(cfg.get_hosts('api')):
+        prefix = '' if is_root(cfg, pulp_host=host) else 'sudo '
         if index == 0:
             client.run((
                 prefix + 'runuser --shell /bin/sh apache --command '
@@ -511,16 +510,16 @@ def search_units(cfg, repo, criteria=None, response_handler=None):
     )
 
 
-def os_is_f26(cfg, pulp_system=None):
+def os_is_f26(cfg, pulp_host=None):
     """Return ``True`` if the server runs Fedora 26, or ``False`` otherwise.
 
     :param pulp_smash.config.PulpSmashConfig cfg: Information about the system
         being targeted.
-    :param pulp_system: A :class:`pulp_smash.config.PulpSystem` to target,
+    :param pulp_host: A :class:`pulp_smash.config.PulpHost` to target,
         instead of the default chosen by :class:`pulp_smash.cli.Client`.
     :returns: True or false.
     """
-    response = cli.Client(cfg, cli.echo_handler, pulp_system).run((
+    response = cli.Client(cfg, cli.echo_handler, pulp_host).run((
         'grep',
         '-i',
         'fedora release 26',
@@ -529,16 +528,16 @@ def os_is_f26(cfg, pulp_system=None):
     return response.returncode == 0
 
 
-def os_is_f27(cfg, pulp_system=None):
+def os_is_f27(cfg, pulp_host=None):
     """Return ``True`` if the server runs Fedora 27, or ``False`` otherwise.
 
     :param pulp_smash.config.PulpSmashConfig cfg: Information about the system
         being targeted.
-    :param pulp_system: A :class:`pulp_smash.config.PulpSystem` to target,
+    :param pulp_host: A :class:`pulp_smash.config.PulpHost` to target,
         instead of the default chosen by :class:`pulp_smash.cli.Client`.
     :returns: True or false.
     """
-    response = cli.Client(cfg, cli.echo_handler, pulp_system).run((
+    response = cli.Client(cfg, cli.echo_handler, pulp_host).run((
         'grep',
         '-i',
         'fedora release 27',

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -120,8 +120,8 @@ class ClientTestCase(unittest.TestCase):
         for method in methods:
             client = api.Client(config.PulpSmashConfig(
                 pulp_auth=['admin', 'admin'],
-                systems=[
-                    config.PulpSystem(
+                hosts=[
+                    config.PulpHost(
                         hostname='example.com',
                         roles={'api': {
                             'scheme': 'http',
@@ -157,8 +157,8 @@ class ClientTestCase2(unittest.TestCase):
         response_handler = mock.Mock()
         client = api.Client(config.PulpSmashConfig(
             pulp_auth=['admin', 'admin'],
-            systems=[
-                config.PulpSystem(
+            hosts=[
+                config.PulpHost(
                     hostname='base url',
                     roles={'api': {'scheme': 'http'}},
                 )
@@ -171,8 +171,8 @@ class ClientTestCase2(unittest.TestCase):
         json = mock.Mock()
         client = api.Client(config.PulpSmashConfig(
             pulp_auth=['admin', 'admin'],
-            systems=[
-                config.PulpSystem(
+            hosts=[
+                config.PulpHost(
                     hostname='base url',
                     roles={'api': {'scheme': 'http'}},
                 )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -89,8 +89,8 @@ class ClientTestCase(unittest.TestCase):
 
     def test_explicit_local_transport(self):
         """Assert it is possible to explicitly ask for a "local" transport."""
-        cfg = config.PulpSmashConfig(systems=[
-            config.PulpSystem(
+        cfg = config.PulpSmashConfig(hosts=[
+            config.PulpHost(
                 hostname=utils.uuid4(),
                 roles={
                     'pulp cli': {},
@@ -102,8 +102,8 @@ class ClientTestCase(unittest.TestCase):
 
     def test_implicit_local_transport(self):
         """Assert it is possible to implicitly ask for a "local" transport."""
-        cfg = config.PulpSmashConfig(systems=[
-            config.PulpSystem(
+        cfg = config.PulpSmashConfig(hosts=[
+            config.PulpHost(
                 hostname=socket.getfqdn(),
                 roles={
                     'pulp cli': {},
@@ -114,8 +114,8 @@ class ClientTestCase(unittest.TestCase):
 
     def test_default_response_handler(self):
         """Assert the default response handler checks return codes."""
-        cfg = config.PulpSmashConfig(systems=[
-            config.PulpSystem(
+        cfg = config.PulpSmashConfig(hosts=[
+            config.PulpHost(
                 hostname=utils.uuid4(),
                 roles={
                     'pulp cli': {},
@@ -127,8 +127,8 @@ class ClientTestCase(unittest.TestCase):
 
     def test_explicit_response_handler(self):
         """Assert it is possible to explicitly set a response handler."""
-        cfg = config.PulpSmashConfig(systems=[
-            config.PulpSystem(
+        cfg = config.PulpSmashConfig(hosts=[
+            config.PulpHost(
                 hostname=utils.uuid4(),
                 roles={
                     'pulp cli': {},
@@ -139,16 +139,16 @@ class ClientTestCase(unittest.TestCase):
         handler = mock.Mock()
         self.assertIs(cli.Client(cfg, handler).response_handler, handler)
 
-    def test_implicit_pulp_system(self):
-        """Assert it is possible to implicitly target a pulp cli PulpSystem."""
-        cfg = config.PulpSmashConfig(systems=[
-            config.PulpSystem(
+    def test_implicit_pulp_host(self):
+        """Assert it is possible to implicitly target a pulp cli PulpHost."""
+        cfg = config.PulpSmashConfig(hosts=[
+            config.PulpHost(
                 hostname=utils.uuid4(),
                 roles={
                     'pulp cli': {},
                 }
             ),
-            config.PulpSystem(
+            config.PulpHost(
                 hostname=utils.uuid4(),
                 roles={
                     'pulp cli': {},
@@ -160,18 +160,18 @@ class ClientTestCase(unittest.TestCase):
             plumbum.machines.SshMachine.return_value = machine
             self.assertEqual(cli.Client(cfg).machine, machine)
             plumbum.machines.SshMachine.assert_called_once_with(
-                cfg.systems[0].hostname)
+                cfg.hosts[0].hostname)
 
-    def test_explicit_pulp_system(self):
-        """Assert it is possible to explicitly target a pulp cli PulpSystem."""
-        cfg = config.PulpSmashConfig(systems=[
-            config.PulpSystem(
+    def test_explicit_pulp_host(self):
+        """Assert it is possible to explicitly target a pulp cli PulpHost."""
+        cfg = config.PulpSmashConfig(hosts=[
+            config.PulpHost(
                 hostname=utils.uuid4(),
                 roles={
                     'pulp cli': {},
                 }
             ),
-            config.PulpSystem(
+            config.PulpHost(
                 hostname=utils.uuid4(),
                 roles={
                     'pulp cli': {},
@@ -182,6 +182,6 @@ class ClientTestCase(unittest.TestCase):
             machine = mock.Mock()
             plumbum.machines.SshMachine.return_value = machine
             self.assertEqual(
-                cli.Client(cfg, pulp_system=cfg.systems[1]).machine, machine)
+                cli.Client(cfg, pulp_host=cfg.hosts[1]).machine, machine)
             plumbum.machines.SshMachine.assert_called_once_with(
-                cfg.systems[1].hostname)
+                cfg.hosts[1].hostname)

--- a/tests/test_pulp_smash_cli.py
+++ b/tests/test_pulp_smash_cli.py
@@ -62,7 +62,7 @@ class SettingsCreateTestCase(BasePulpSmashCliTestCase):
                 'version': '2.13',
                 'selinux enabled': True,
             },
-            'systems': [{
+            'hosts': [{
                 'hostname': 'pulp.example.com',
                 'roles': {
                     'amqp broker': {'service': 'qpidd'},
@@ -125,12 +125,12 @@ class SettingsCreateTestCase(BasePulpSmashCliTestCase):
             '\n'  # admin password
             '2.13\n'  # pulp version
             '\n'  # pulp_selinux_enabled
-            'pulp.example.com\n'  # system hostname
+            'pulp.example.com\n'  # host hostname
             '\n'  # published via HTTPS
             '\n'  # verify HTTPS
             '\n'  # API port
             '\n'  # using qpidd
-            '\n'  # running on Pulp system
+            '\n'  # running on Pulp host
         )
         generated_settings = self._test_common_logic(create_input)
         self.assertEqual(
@@ -144,12 +144,12 @@ class SettingsCreateTestCase(BasePulpSmashCliTestCase):
             '\n'  # admin password
             '2.13\n'  # pulp version
             '\n'  # pulp_selinux_enabled
-            'pulp.example.com\n'  # system hostname
+            'pulp.example.com\n'  # host hostname
             '\n'  # published via HTTPS
             '\n'  # verify HTTPS
             '\n'  # API port
             '\n'  # using qpidd
-            '\n'  # running on Pulp system
+            '\n'  # running on Pulp host
         )
         generated_settings = self._test_common_logic(
             create_input, 'settings.json')
@@ -163,16 +163,16 @@ class SettingsCreateTestCase(BasePulpSmashCliTestCase):
             '\n'  # admin password
             '2.13\n'  # pulp version
             '\n'  # pulp_selinux_enabled
-            'pulp.example.com\n'  # system hostname
+            'pulp.example.com\n'  # host hostname
             '\n'  # published via HTTPS
             'y\n'  # verify HTTPS
             '/path/to/ssl/certificate\n'  # SSL certificate path
             '\n'  # API port
             '\n'  # using qpidd
-            '\n'  # running on Pulp system
+            '\n'  # running on Pulp host
         )
         generated_settings = self._test_common_logic(create_input)
-        self.expected_config_dict['systems'][0]['roles']['api']['verify'] = (
+        self.expected_config_dict['hosts'][0]['roles']['api']['verify'] = (
             '/path/to/ssl/certificate'
         )
         self.assertEqual(
@@ -185,20 +185,20 @@ class SettingsCreateTestCase(BasePulpSmashCliTestCase):
             'password\n'  # admin password
             '2.13\n'  # pulp version
             'n\n'  # pulp_selinux_enabled
-            'pulp.example.com\n'  # system hostname
+            'pulp.example.com\n'  # host hostname
             'n\n'  # published via HTTPS
             '\n'  # API port
             'n\n'  # using qpidd
-            'y\n'  # running on Pulp system
+            'y\n'  # running on Pulp host
         )
         generated_settings = self._test_common_logic(create_input)
         self.expected_config_dict['pulp']['auth'] = ['username', 'password']
         self.expected_config_dict['pulp']['selinux enabled'] = False
-        system_roles = self.expected_config_dict['systems'][0]['roles']
-        system_roles['amqp broker']['service'] = 'rabbitmq'
-        system_roles['api']['scheme'] = 'http'
-        system_roles['api']['verify'] = False
-        system_roles['shell']['transport'] = 'local'
+        host_roles = self.expected_config_dict['hosts'][0]['roles']
+        host_roles['amqp broker']['service'] = 'rabbitmq'
+        host_roles['api']['scheme'] = 'http'
+        host_roles['api']['verify'] = False
+        host_roles['shell']['transport'] = 'local'
         self.assertEqual(
             json.loads(generated_settings), self.expected_config_dict)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -178,8 +178,8 @@ class PulpAdminLoginTestCase(unittest.TestCase):
         with mock.patch.object(cli, 'Client') as client:
             cfg = config.PulpSmashConfig(
                 pulp_auth=['u', 'p'],
-                systems=[
-                    config.PulpSystem(
+                hosts=[
+                    config.PulpHost(
                         hostname='example.com',
                         roles={'pulp cli': {}}
                     )


### PR DESCRIPTION
The configuration file lets one declare information about a Pulp
application and the computers that it's deployed on. A good name to use
for these computers is "hosts." Consider a definition from Wiktionary:

> Any computer attached to a network.

However, the configuration file calls these hosts "systems." Consider a
definition from Wiktionary:

> The set of hardware and software operating in a computer.

"host" seems more appropriate than "system" for several reasons. First,
it makes more semantic sense to talk about computers than to talk about
the hardware and software in a computer. Second, Pulp makes services
available to a network, even if just the local network. If no network is
available, then Pulp can't function. It seems appropriate to use
terminology which reflects this focus.

Rename "systems" to "hosts" in the configuration file. This resolves a
long-standing discrepancy within the code base itself, where both terms
are used to reference the same concept.