### PR TITLE
Fix failing Python test

### DIFF
--- a/pulp_smash/tests/pulp2/python/api_v2/test_duplicate_uploads.py
+++ b/pulp_smash/tests/pulp2/python/api_v2/test_duplicate_uploads.py
@@ -15,6 +15,7 @@ The second upload should silently fail for all Pulp releases in the 2.x series.
 .. _Pulp Smash #81: https://github.com/PulpQE/pulp-smash/issues/81
 """
 import unittest
+from urllib.parse import urlsplit
 
 from packaging.version import Version
 
@@ -38,7 +39,12 @@ class DuplicateUploadsTestCase(
                 selectors.bug_is_untestable(2334, cls.cfg.pulp_version)):
             raise unittest.SkipTest('https://pulp.plan.io/issues/2334')
         unit = utils.http_get(PYTHON_EGG_URL)
-        import_params = {'unit_type_id': 'python_package'}
+        import_params = {
+            'unit_key': {
+                'filename': urlsplit(PYTHON_EGG_URL).path.split('/')[-1],
+            },
+            'unit_type_id': 'python_package',
+        }
         repo = api.Client(cls.cfg).post(REPOSITORY_PATH, gen_repo()).json()
         cls.upload_import_unit_args = (cls.cfg, unit, import_params, repo)
         cls.resources.add(repo['_href'])


### PR DESCRIPTION
It's unclear whether a 'filename' is required when uploading an egg to
Python. The de-facto standard appears to be that one is required. Make
the affected Python tests use one.

See: https://pulp.plan.io/issues/2334