### PR TITLE
Revamp PulpSmashConfig object

### DIFF
--- a/pulp_smash/api.py
+++ b/pulp_smash/api.py
@@ -201,6 +201,8 @@ class Client():
     >>> from pulp_smash.config import PulpSmashConfig
     >>> cfg = config.PulpSmashConfig(
     ...     pulp_auth=('username', 'password'),
+    ...     pulp_version='1!0',
+    ...     pulp_selinux_enabled=True,
     ...     hosts=[
     ...         config.PulpHost(
     ...             hostname='example.com',

--- a/pulp_smash/cli.py
+++ b/pulp_smash/cli.py
@@ -131,14 +131,10 @@ class Client():  # pylint:disable=too-few-public-methods
     """A convenience object for working with a CLI.
 
     This class provides the ability to execute shell commands on either the
-    local host or a remote host. Here is a pedagogic usage example:
+    local host or a remote host. Here is a typical usage example:
 
     >>> from pulp_smash import cli, config
-    >>> host = (
-    ...     config.PulpHost('localhost', {'shell': {'transport': 'local'}})
-    ... )
-    >>> cfg = config.PulpSmashConfig(hosts=[host])
-    >>> client = cli.Client(cfg, pulp_host=host)
+    >>> client = cli.Client(config.PulpSmashConfig.load())
     >>> response = client.run(('echo', '-n', 'foo'))
     >>> response.returncode == 0
     True
@@ -147,9 +143,14 @@ class Client():  # pylint:disable=too-few-public-methods
     >>> response.stderr == ''
     True
 
-    The above example shows how various classes fit together. It's also
-    verbose: smartly chosen defaults mean that most real code is much more
-    concise.
+    Smartly chosen defaults make this example concise, but it's also quite
+    flexible. For example, if a single Pulp application is deployed across
+    several hosts, one can choose on which host commands are executed:
+
+    >>> from pulp_smash import cli, config
+    >>> cfg = config.PulpSmashConfig.load()
+    >>> client = cli.Client(cfg, pulp_host=cfg.get_hosts('shell')[0])
+    >>> response = client.run(('echo', '-n', 'foo'))
 
     You can customize how ``Client`` objects execute commands and handle
     responses by fiddling with the two public instance attributes:
@@ -422,7 +423,7 @@ class GlobalServiceManager(BaseServiceManager):
         result = {}
         for host in self._cfg.hosts:
             intersection = services.intersection(
-                self._cfg.services_for_roles(host.roles))
+                self._cfg.get_services(host.roles))
             if intersection:
                 client = Client(self._cfg, pulp_host=host)
                 svc_mgr = self._get_service_manager(self._cfg, host)
@@ -452,7 +453,7 @@ class GlobalServiceManager(BaseServiceManager):
         result = {}
         for host in self._cfg.hosts:
             intersection = services.intersection(
-                self._cfg.services_for_roles(host.roles))
+                self._cfg.get_services(host.roles))
             if intersection:
                 client = Client(self._cfg, pulp_host=host)
                 svc_mgr = self._get_service_manager(self._cfg, host)
@@ -481,7 +482,7 @@ class GlobalServiceManager(BaseServiceManager):
         result = {}
         for host in self._cfg.hosts:
             intersection = services.intersection(
-                self._cfg.services_for_roles(host.roles))
+                self._cfg.get_services(host.roles))
             if intersection:
                 client = Client(self._cfg, pulp_host=host)
                 svc_mgr = self._get_service_manager(self._cfg, host)
@@ -508,7 +509,7 @@ class ServiceManager(BaseServiceManager):
 
     >>> from pulp_smash import cli, config
     >>> cfg = config.get_config()
-    >>> pulp_host = cfg.get_services_for_roles(('api',))[0]
+    >>> pulp_host = cfg.get_get_services(('api',))[0]
     >>> svc_mgr = cli.ServiceManager(cfg, pulp_host)
     >>> completed_process_list = svc_mgr.stop(['httpd'])
     >>> completed_process_list = svc_mgr.start(['httpd'])

--- a/pulp_smash/pulp_smash_cli.py
+++ b/pulp_smash/pulp_smash_cli.py
@@ -28,14 +28,13 @@ def pulp_smash():
 @click.pass_context
 def settings(ctx):
     """Manage settings file."""
-    cfg = PulpSmashConfig()
     try:
-        cfg_path = cfg.get_config_file_path()
+        load_path = PulpSmashConfig.get_load_path()
     except exceptions.ConfigFileNotFoundError:
-        cfg_path = None
+        load_path = None
     ctx.obj = {
-        'cfg_path': cfg_path,
-        'default_cfg_path': cfg.default_config_file_path,
+        'load_path': load_path,
+        'save_path': PulpSmashConfig.get_save_path()
     }
 
 
@@ -43,14 +42,14 @@ def settings(ctx):
 @click.pass_context
 def settings_create(ctx):  # pylint:disable=too-many-locals
     """Create a settings file."""
-    path = ctx.obj['cfg_path']
+    path = ctx.obj['load_path']
     if path:
         click.echo(
             'A settings file already exists. Continuing will override it.'
         )
         click.confirm('Do you want to continue?', abort=True)
     else:
-        path = ctx.obj['default_cfg_path']
+        path = ctx.obj['save_path']
     pulp_username = click.prompt('Pulp admin username', default='admin')
     pulp_password = click.prompt('Pulp admin password', default='admin')
     pulp_version = click.prompt('Pulp version')
@@ -150,7 +149,7 @@ def settings_create(ctx):  # pylint:disable=too-many-locals
 @click.pass_context
 def settings_path(ctx):
     """Show the path to the settings file."""
-    path = ctx.obj['cfg_path']
+    path = ctx.obj['load_path']
     if not path:
         _raise_settings_not_found()
     click.echo(path)
@@ -160,7 +159,7 @@ def settings_path(ctx):
 @click.pass_context
 def settings_show(ctx):
     """Show the settings file."""
-    path = ctx.obj['cfg_path']
+    path = ctx.obj['load_path']
     if not path:
         _raise_settings_not_found()
 
@@ -172,7 +171,7 @@ def settings_show(ctx):
 @click.pass_context
 def settings_validate(ctx):
     """Validate the settings file."""
-    path = ctx.obj['cfg_path']
+    path = ctx.obj['load_path']
     if not path:
         _raise_settings_not_found()
     with open(path) as handle:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -118,17 +118,7 @@ class ClientTestCase(unittest.TestCase):
         methods = {'delete', 'get', 'head', 'options', 'patch', 'post', 'put'}
         cls.mocks = {}
         for method in methods:
-            client = api.Client(config.PulpSmashConfig(
-                pulp_auth=['admin', 'admin'],
-                hosts=[
-                    config.PulpHost(
-                        hostname='example.com',
-                        roles={'api': {
-                            'scheme': 'http',
-                        }}
-                    )
-                ]
-            ))
+            client = api.Client(_get_pulp_smash_config())
             with mock.patch.object(client, 'request') as request:
                 getattr(client, method)('')
             cls.mocks[method] = request
@@ -155,29 +145,13 @@ class ClientTestCase2(unittest.TestCase):
         The argument should be saved as an instance attribute.
         """
         response_handler = mock.Mock()
-        client = api.Client(config.PulpSmashConfig(
-            pulp_auth=['admin', 'admin'],
-            hosts=[
-                config.PulpHost(
-                    hostname='base url',
-                    roles={'api': {'scheme': 'http'}},
-                )
-            ]
-        ), response_handler)
+        client = api.Client(_get_pulp_smash_config(), response_handler)
         self.assertIs(client.response_handler, response_handler)
 
     def test_json_arg(self):
         """Assert methods with a ``json`` argument pass on that argument."""
         json = mock.Mock()
-        client = api.Client(config.PulpSmashConfig(
-            pulp_auth=['admin', 'admin'],
-            hosts=[
-                config.PulpHost(
-                    hostname='base url',
-                    roles={'api': {'scheme': 'http'}},
-                )
-            ]
-        ))
+        client = api.Client(_get_pulp_smash_config())
         for method in {'patch', 'post', 'put'}:
             with self.subTest(method=method):
                 with mock.patch.object(client, 'request') as request:
@@ -185,3 +159,21 @@ class ClientTestCase2(unittest.TestCase):
                 self.assertEqual(
                     request.call_args[0], (method.upper(), 'some url'))
                 self.assertIs(request.call_args[1]['json'], json)
+
+
+def _get_pulp_smash_config():
+    """Return a config object with made-up attributes.
+
+    :rtype: pulp_smash.config.PulpSmashConfig
+    """
+    return config.PulpSmashConfig(
+        pulp_auth=['admin', 'admin'],
+        pulp_version='1!0',
+        pulp_selinux_enabled=True,
+        hosts=[
+            config.PulpHost(
+                hostname='example.com',
+                roles={'api': {'scheme': 'http'}},
+            )
+        ]
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -89,51 +89,40 @@ class ClientTestCase(unittest.TestCase):
 
     def test_explicit_local_transport(self):
         """Assert it is possible to explicitly ask for a "local" transport."""
-        cfg = config.PulpSmashConfig(hosts=[
+        cfg = _get_pulp_smash_config(hosts=[
             config.PulpHost(
                 hostname=utils.uuid4(),
-                roles={
-                    'pulp cli': {},
-                    'shell': {'transport': 'local'},
-                }
+                roles={'pulp cli': {}, 'shell': {'transport': 'local'}},
             )
         ])
         self.assertIsInstance(cli.Client(cfg).machine, LocalMachine)
 
     def test_implicit_local_transport(self):
         """Assert it is possible to implicitly ask for a "local" transport."""
-        cfg = config.PulpSmashConfig(hosts=[
+        cfg = _get_pulp_smash_config(hosts=[
             config.PulpHost(
                 hostname=socket.getfqdn(),
-                roles={
-                    'pulp cli': {},
-                }
+                roles={'pulp cli': {}},
             )
         ])
         self.assertIsInstance(cli.Client(cfg).machine, LocalMachine)
 
     def test_default_response_handler(self):
         """Assert the default response handler checks return codes."""
-        cfg = config.PulpSmashConfig(hosts=[
+        cfg = _get_pulp_smash_config(hosts=[
             config.PulpHost(
                 hostname=utils.uuid4(),
-                roles={
-                    'pulp cli': {},
-                    'shell': {'transport': 'local'},
-                }
+                roles={'pulp cli': {}, 'shell': {'transport': 'local'}},
             )
         ])
         self.assertIs(cli.Client(cfg).response_handler, cli.code_handler)
 
     def test_explicit_response_handler(self):
         """Assert it is possible to explicitly set a response handler."""
-        cfg = config.PulpSmashConfig(hosts=[
+        cfg = _get_pulp_smash_config(hosts=[
             config.PulpHost(
                 hostname=utils.uuid4(),
-                roles={
-                    'pulp cli': {},
-                    'shell': {'transport': 'local'},
-                }
+                roles={'pulp cli': {}, 'shell': {'transport': 'local'}},
             )
         ])
         handler = mock.Mock()
@@ -141,18 +130,14 @@ class ClientTestCase(unittest.TestCase):
 
     def test_implicit_pulp_host(self):
         """Assert it is possible to implicitly target a pulp cli PulpHost."""
-        cfg = config.PulpSmashConfig(hosts=[
+        cfg = _get_pulp_smash_config(hosts=[
             config.PulpHost(
                 hostname=utils.uuid4(),
-                roles={
-                    'pulp cli': {},
-                }
+                roles={'pulp cli': {}},
             ),
             config.PulpHost(
                 hostname=utils.uuid4(),
-                roles={
-                    'pulp cli': {},
-                }
+                roles={'pulp cli': {}},
             )
         ])
         with mock.patch('pulp_smash.cli.plumbum') as plumbum:
@@ -164,18 +149,14 @@ class ClientTestCase(unittest.TestCase):
 
     def test_explicit_pulp_host(self):
         """Assert it is possible to explicitly target a pulp cli PulpHost."""
-        cfg = config.PulpSmashConfig(hosts=[
+        cfg = _get_pulp_smash_config(hosts=[
             config.PulpHost(
                 hostname=utils.uuid4(),
-                roles={
-                    'pulp cli': {},
-                }
+                roles={'pulp cli': {}},
             ),
             config.PulpHost(
                 hostname=utils.uuid4(),
-                roles={
-                    'pulp cli': {},
-                }
+                roles={'pulp cli': {}},
             )
         ])
         with mock.patch('pulp_smash.cli.plumbum') as plumbum:
@@ -185,3 +166,17 @@ class ClientTestCase(unittest.TestCase):
                 cli.Client(cfg, pulp_host=cfg.hosts[1]).machine, machine)
             plumbum.machines.SshMachine.assert_called_once_with(
                 cfg.hosts[1].hostname)
+
+
+def _get_pulp_smash_config(hosts):
+    """Return a config object with made-up attributes.
+
+    :param hosts: Passed through to :data:`pulp_smash.config.PulpSmashConfig`.
+    :rtype: pulp_smash.config.PulpSmashConfig
+    """
+    return config.PulpSmashConfig(
+        pulp_auth=['admin', 'admin'],
+        pulp_version='1!0',
+        pulp_selinux_enabled=True,
+        hosts=hosts,
+    )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -177,11 +177,13 @@ class PulpAdminLoginTestCase(unittest.TestCase):
         """Assert the function executes ``cli.Client.run``."""
         with mock.patch.object(cli, 'Client') as client:
             cfg = config.PulpSmashConfig(
-                pulp_auth=['u', 'p'],
+                pulp_auth=['admin', 'admin'],
+                pulp_version='1!0',
+                pulp_selinux_enabled=True,
                 hosts=[
                     config.PulpHost(
                         hostname='example.com',
-                        roles={'pulp cli': {}}
+                        roles={'pulp cli': {}},
                     )
                 ]
             )


### PR DESCRIPTION
The `PulpSmashConfig` object has a weird constructor: all arguments are
optional. As a result, it's excessively easy to create a new object that
has an invalid state. For example, this will raise an exception, as
necessary information is not available:

    config.PulpSmashConfig().get_base_url()

From a design perspective, this is bad. No amount of linting can help
discover improperly written code when the underlying code doesn't even
define constructor parameters as required.

Why is this done? Because certain methods, like `read`, are instance
methods. This code needs to work:

    config.PulpSmashConfig().read()

What's to be done? The obvious solution is to change methods which don't
require instance data from instance to class or static methods. This
makes it possible to define constructor parameters as required. And it
opens the door to more aggressive input validation in the future, if so
desired. To summarize: this change leads to more efficient *and* more
correct code.

Given how fundamental this change is, it's also a good time to review
other aspects of `PulpSmashConfig`'s design. And as it happens, there
are a few other improvements to be made:

* There are two types of paths that are especially useful for users of
  the `PulpSmashConfig` class: a path to which one might save settings,
  and a path from which one might load settings. The
  `default_config_file_path` and `get_config_file_path` methods provide
  this information, respectively. These method names aren't terribly
  obvious. Rename them to `get_save_path` and `get_load_path`,
  respectively.
* The `read` method verifies that the file being read from disk is a
  file. This is an overly aggressive check. It prevents interesting use
  cases such as the file on disk being a symlink.
* It's quite possible that a corresponding `write` method might be
  written in the future. But the names "read" and "write" don't convey
  quite the right semantics. The names "load" and "save" are more
  appropriate. Think about playing a video game: one loads and saves a
  game; one does not read and write a game.
* The `services_for_roles` method has a parameter named `roles`. This is
  redundant. Change the method name to `get_services`. This change is in
  line with some other changes that have been made recently.

Fix: https://github.com/PulpQE/pulp-smash/issues/981