### PR TITLE
Make final argument to PulpSmashConfig kwarg only

### DIFF
--- a/pulp_smash/config.py
+++ b/pulp_smash/config.py
@@ -318,7 +318,8 @@ class PulpSmashConfig():
         http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
     """
 
-    def __init__(self, pulp_auth, pulp_version, pulp_selinux_enabled, hosts):
+    def __init__(
+            self, pulp_auth, pulp_version, pulp_selinux_enabled, *, hosts):
         """Initialize this object with needed instance attributes."""
         self.pulp_auth = pulp_auth
         self.pulp_version = Version(pulp_version)
@@ -457,7 +458,7 @@ class PulpSmashConfig():
             pulp_auth,
             pulp_version,
             pulp_selinux_enabled,
-            hosts,
+            hosts=hosts,
         )
 
     @classmethod


### PR DESCRIPTION
The PulpSmashConfig constructor may gain additional arguments in the
future. For example, it might gain a `pulp_fips_enabled` argument,
stating whether FIPS tests should be enabled. If this occurs, it would
be ideal if this argument could be added after the other `pulp_*`
arguments, all of which define system-wide information, and before the
`hosts` argument, which defines per-host information. This can only
seamlessly occur if all users of the `PulpSmashConfig` object pass the
final `hosts` argument as a keyword argument, instead of as a positional
argument.

Make the final `hosts` argument to the `PulpSmashConfig` constructor
keyword-only.