### PR TITLE
Move constants and utils out of pulp_smash/tests/

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -16,11 +16,13 @@ developers, not a gospel.
     api/pulp_smash.config
     api/pulp_smash.constants
     api/pulp_smash.exceptions
+    api/pulp_smash.pulp2
+    api/pulp_smash.pulp2.constants
+    api/pulp_smash.pulp2.utils
     api/pulp_smash.pulp_smash_cli
     api/pulp_smash.selectors
     api/pulp_smash.tests
     api/pulp_smash.tests.pulp2
-    api/pulp_smash.tests.pulp2.constants
     api/pulp_smash.tests.pulp2.docker
     api/pulp_smash.tests.pulp2.docker.api_v2
     api/pulp_smash.tests.pulp2.docker.api_v2.test_copy
@@ -126,7 +128,6 @@ developers, not a gospel.
     api/pulp_smash.tests.pulp2.rpm.cli.test_upload
     api/pulp_smash.tests.pulp2.rpm.cli.utils
     api/pulp_smash.tests.pulp2.rpm.utils
-    api/pulp_smash.tests.pulp2.utils
     api/pulp_smash.tests.pulp3
     api/pulp_smash.tests.pulp3.constants
     api/pulp_smash.tests.pulp3.file

--- a/docs/api/pulp_smash.pulp2.constants.rst
+++ b/docs/api/pulp_smash.pulp2.constants.rst
@@ -1,0 +1,6 @@
+`pulp_smash.pulp2.constants`
+============================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.pulp2.constants`
+
+.. automodule:: pulp_smash.pulp2.constants

--- a/docs/api/pulp_smash.pulp2.rst
+++ b/docs/api/pulp_smash.pulp2.rst
@@ -1,0 +1,6 @@
+`pulp_smash.pulp2`
+==================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.pulp2`
+
+.. automodule:: pulp_smash.pulp2

--- a/docs/api/pulp_smash.pulp2.utils.rst
+++ b/docs/api/pulp_smash.pulp2.utils.rst
@@ -1,0 +1,6 @@
+`pulp_smash.pulp2.utils`
+========================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.pulp2.utils`
+
+.. automodule:: pulp_smash.pulp2.utils

--- a/docs/api/pulp_smash.tests.pulp2.constants.rst
+++ b/docs/api/pulp_smash.tests.pulp2.constants.rst
@@ -1,6 +1,0 @@
-`pulp_smash.tests.pulp2.constants`
-==================================
-
-Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.pulp2.constants`
-
-.. automodule:: pulp_smash.tests.pulp2.constants

--- a/docs/api/pulp_smash.tests.pulp2.utils.rst
+++ b/docs/api/pulp_smash.tests.pulp2.utils.rst
@@ -1,6 +1,0 @@
-`pulp_smash.tests.pulp2.utils`
-==============================
-
-Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.pulp2.utils`
-
-.. automodule:: pulp_smash.tests.pulp2.utils

--- a/pulp_smash/pulp2/__init__.py
+++ b/pulp_smash/pulp2/__init__.py
@@ -1,0 +1,2 @@
+# coding=utf-8
+"""Tools for Pulp 2 tests."""

--- a/pulp_smash/pulp2/constants.py
+++ b/pulp_smash/pulp2/constants.py
@@ -1,6 +1,5 @@
 # coding=utf-8
 """Constants for Pulp 2 tests."""
-
 from urllib.parse import urljoin
 
 

--- a/pulp_smash/pulp2/utils.py
+++ b/pulp_smash/pulp2/utils.py
@@ -5,7 +5,7 @@ import unittest
 from packaging.version import Version
 
 from pulp_smash import api, config, selectors, utils
-from pulp_smash.tests.pulp2.constants import PLUGIN_TYPES_PATH
+from pulp_smash.pulp2.constants import PLUGIN_TYPES_PATH
 
 
 def get_unit_types():

--- a/pulp_smash/tests/pulp2/docker/api_v2/test_copy.py
+++ b/pulp_smash/tests/pulp2/docker/api_v2/test_copy.py
@@ -5,7 +5,7 @@ from urllib.parse import urljoin
 
 from pulp_smash import api, config, selectors, utils
 from pulp_smash.constants import DOCKER_V1_FEED_URL, DOCKER_V2_FEED_URL
-from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
+from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.docker.api_v2.utils import gen_repo
 from pulp_smash.tests.pulp2.docker.utils import get_upstream_name
 from pulp_smash.tests.pulp2.docker.utils import set_up_module as setUpModule  # pylint:disable=unused-import

--- a/pulp_smash/tests/pulp2/docker/api_v2/test_crud.py
+++ b/pulp_smash/tests/pulp2/docker/api_v2/test_crud.py
@@ -10,7 +10,7 @@ from urllib.parse import urljoin
 from packaging.version import Version
 
 from pulp_smash import api, config, utils
-from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
+from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.docker.api_v2.utils import gen_repo
 from pulp_smash.tests.pulp2.docker.utils import set_up_module
 

--- a/pulp_smash/tests/pulp2/docker/api_v2/test_duplicate_uploads.py
+++ b/pulp_smash/tests/pulp2/docker/api_v2/test_duplicate_uploads.py
@@ -16,7 +16,7 @@ The second upload should silently fail for all Pulp releases in the 2.x series.
 """
 from pulp_smash import api, utils
 from pulp_smash.constants import DOCKER_IMAGE_URL
-from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
+from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.docker.api_v2.utils import gen_repo
 from pulp_smash.tests.pulp2.docker.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 

--- a/pulp_smash/tests/pulp2/docker/api_v2/test_sync.py
+++ b/pulp_smash/tests/pulp2/docker/api_v2/test_sync.py
@@ -7,7 +7,7 @@ from packaging.version import Version
 
 from pulp_smash import api, config, selectors, utils
 from pulp_smash.constants import DOCKER_V1_FEED_URL, DOCKER_V2_FEED_URL
-from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
+from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.docker.api_v2.utils import gen_repo
 from pulp_smash.tests.pulp2.docker.utils import (
     get_upstream_name,

--- a/pulp_smash/tests/pulp2/docker/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/pulp2/docker/api_v2/test_sync_publish.py
@@ -7,7 +7,7 @@ from packaging.version import Version
 
 from pulp_smash import api, cli, config, selectors, utils
 from pulp_smash.constants import DOCKER_V1_FEED_URL, DOCKER_V2_FEED_URL
-from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
+from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.docker.api_v2.utils import (
     SyncPublishMixin,
     gen_distributor,

--- a/pulp_smash/tests/pulp2/docker/api_v2/test_tags.py
+++ b/pulp_smash/tests/pulp2/docker/api_v2/test_tags.py
@@ -9,7 +9,7 @@ from packaging.version import Version
 
 from pulp_smash import api, config, utils
 from pulp_smash.constants import DOCKER_V1_FEED_URL, DOCKER_V2_FEED_URL
-from pulp_smash.tests.pulp2.constants import (
+from pulp_smash.pulp2.constants import (
     CONTENT_UPLOAD_PATH,
     REPOSITORY_PATH,
 )

--- a/pulp_smash/tests/pulp2/docker/api_v2/utils.py
+++ b/pulp_smash/tests/pulp2/docker/api_v2/utils.py
@@ -3,7 +3,7 @@
 from urllib.parse import urlsplit, urlunsplit
 
 from pulp_smash import api, cli, utils
-from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
+from pulp_smash.pulp2.constants import REPOSITORY_PATH
 
 
 def gen_repo():

--- a/pulp_smash/tests/pulp2/docker/utils.py
+++ b/pulp_smash/tests/pulp2/docker/utils.py
@@ -10,7 +10,7 @@ from pulp_smash.constants import (
     DOCKER_UPSTREAM_NAME,
     DOCKER_UPSTREAM_NAME_NOLIST,
 )
-from pulp_smash.tests.pulp2 import utils as pulp2_utils
+from pulp_smash.pulp2 import utils as pulp2_utils
 
 
 def set_up_module():

--- a/pulp_smash/tests/pulp2/ostree/api_v2/test_copy.py
+++ b/pulp_smash/tests/pulp2/ostree/api_v2/test_copy.py
@@ -6,7 +6,7 @@ from urllib.parse import urljoin
 
 from pulp_smash import api, config, utils
 from pulp_smash.constants import OSTREE_BRANCHES, OSTREE_FEED
-from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
+from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.ostree.utils import gen_distributor, gen_repo
 from pulp_smash.tests.pulp2.ostree.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 

--- a/pulp_smash/tests/pulp2/ostree/api_v2/test_crud.py
+++ b/pulp_smash/tests/pulp2/ostree/api_v2/test_crud.py
@@ -15,7 +15,7 @@ from requests.exceptions import HTTPError
 
 from pulp_smash import api, config, exceptions, selectors, utils
 from pulp_smash.constants import OSTREE_FEED, OSTREE_BRANCHES
-from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
+from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.ostree.utils import gen_repo
 from pulp_smash.tests.pulp2.ostree.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 

--- a/pulp_smash/tests/pulp2/ostree/api_v2/test_publish.py
+++ b/pulp_smash/tests/pulp2/ostree/api_v2/test_publish.py
@@ -4,7 +4,7 @@ import unittest
 
 from pulp_smash import api, config, utils
 from pulp_smash.constants import OSTREE_BRANCHES, OSTREE_FEED
-from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
+from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.ostree.utils import gen_distributor, gen_repo
 from pulp_smash.tests.pulp2.ostree.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 

--- a/pulp_smash/tests/pulp2/ostree/api_v2/test_sync.py
+++ b/pulp_smash/tests/pulp2/ostree/api_v2/test_sync.py
@@ -11,7 +11,7 @@ from urllib.parse import urljoin
 
 from pulp_smash import api, selectors, utils
 from pulp_smash.constants import OSTREE_FEED, OSTREE_BRANCHES
-from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
+from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.ostree.utils import gen_repo
 from pulp_smash.tests.pulp2.ostree.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 

--- a/pulp_smash/tests/pulp2/ostree/utils.py
+++ b/pulp_smash/tests/pulp2/ostree/utils.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 """Utilities for interacting with OS tree."""
-from pulp_smash.tests.pulp2 import utils
+from pulp_smash.pulp2 import utils
 from pulp_smash.utils import uuid4
 
 

--- a/pulp_smash/tests/pulp2/platform/api_v2/test_consumer.py
+++ b/pulp_smash/tests/pulp2/platform/api_v2/test_consumer.py
@@ -8,7 +8,7 @@ import unittest
 from urllib.parse import urljoin
 
 from pulp_smash import api, config, utils
-from pulp_smash.tests.pulp2.constants import CONSUMERS_PATH, REPOSITORY_PATH
+from pulp_smash.pulp2.constants import CONSUMERS_PATH, REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_repo, gen_distributor
 from pulp_smash.tests.pulp2.platform.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 

--- a/pulp_smash/tests/pulp2/platform/api_v2/test_content_applicability.py
+++ b/pulp_smash/tests/pulp2/platform/api_v2/test_content_applicability.py
@@ -6,8 +6,8 @@ call report and starts executing tasks in series. Starting with Pulp 2.8, it is
 possible for a user to explicitly request that Pulp execute tasks in parallel
 instead. This functionality is only available for certain API calls, and when
 this is done, Pulp returns a group call report instead of a regular call
-report.  (See :data:`pulp_smash.tests.pulp2.constants.CALL_REPORT_KEYS` and
-:data:`pulp_smash.tests.pulp2.constants.GROUP_CALL_REPORT_KEYS`.)
+report.  (See :data:`pulp_smash.pulp2.constants.CALL_REPORT_KEYS` and
+:data:`pulp_smash.pulp2.constants.GROUP_CALL_REPORT_KEYS`.)
 :class:`SeriesTestCase` and :class:`ParallelTestCase` test these two use
 cases, respectively.
 
@@ -20,7 +20,7 @@ import unittest
 from packaging.version import Version
 
 from pulp_smash import api, config
-from pulp_smash.tests.pulp2.constants import (
+from pulp_smash.pulp2.constants import (
     CALL_REPORT_KEYS,
     GROUP_CALL_REPORT_KEYS,
 )

--- a/pulp_smash/tests/pulp2/platform/api_v2/test_login.py
+++ b/pulp_smash/tests/pulp2/platform/api_v2/test_login.py
@@ -83,7 +83,7 @@
 import unittest
 
 from pulp_smash import api, config, selectors
-from pulp_smash.tests.pulp2.constants import (
+from pulp_smash.pulp2.constants import (
     ERROR_KEYS,
     LOGIN_KEYS,
     LOGIN_PATH,

--- a/pulp_smash/tests/pulp2/platform/api_v2/test_repository.py
+++ b/pulp_smash/tests/pulp2/platform/api_v2/test_repository.py
@@ -19,7 +19,7 @@ from urllib.parse import urljoin, urlparse
 from packaging.version import Version
 
 from pulp_smash import api, utils
-from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH, ERROR_KEYS
+from pulp_smash.pulp2.constants import REPOSITORY_PATH, ERROR_KEYS
 from pulp_smash.selectors import bug_is_untestable, require
 from pulp_smash.tests.pulp2.platform.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 

--- a/pulp_smash/tests/pulp2/platform/api_v2/test_search.py
+++ b/pulp_smash/tests/pulp2/platform/api_v2/test_search.py
@@ -30,7 +30,7 @@ import random
 import unittest
 
 from pulp_smash import api, config, selectors, utils
-from pulp_smash.tests.pulp2.constants import USER_PATH
+from pulp_smash.pulp2.constants import USER_PATH
 from pulp_smash.tests.pulp2.platform.utils import set_up_module
 
 

--- a/pulp_smash/tests/pulp2/platform/api_v2/test_user.py
+++ b/pulp_smash/tests/pulp2/platform/api_v2/test_user.py
@@ -14,7 +14,7 @@ The assumptions explored in this module have the following dependencies::
     https://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/user/index.html
 """
 from pulp_smash import api, utils
-from pulp_smash.tests.pulp2.constants import LOGIN_PATH, USER_PATH
+from pulp_smash.pulp2.constants import LOGIN_PATH, USER_PATH
 from pulp_smash.tests.pulp2.platform.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 

--- a/pulp_smash/tests/pulp2/platform/utils.py
+++ b/pulp_smash/tests/pulp2/platform/utils.py
@@ -2,8 +2,8 @@
 """Utilities for platform tests."""
 import unittest
 
-from pulp_smash.tests.pulp2 import utils
 from pulp_smash import config
+from pulp_smash.pulp2 import utils
 
 
 def set_up_module():

--- a/pulp_smash/tests/pulp2/puppet/api_v2/test_duplicate_uploads.py
+++ b/pulp_smash/tests/pulp2/puppet/api_v2/test_duplicate_uploads.py
@@ -16,7 +16,7 @@ The second upload should silently fail for all Pulp releases in the 2.x series.
 """
 from pulp_smash import api, utils
 from pulp_smash.constants import PUPPET_MODULE_URL_1
-from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
+from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.puppet.api_v2.utils import gen_repo
 from pulp_smash.tests.pulp2.puppet.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 

--- a/pulp_smash/tests/pulp2/puppet/api_v2/test_install_distributor.py
+++ b/pulp_smash/tests/pulp2/puppet/api_v2/test_install_distributor.py
@@ -10,7 +10,7 @@ from requests.exceptions import HTTPError
 
 from pulp_smash import api, cli, utils, selectors
 from pulp_smash.constants import PUPPET_MODULE_1, PUPPET_MODULE_URL_1
-from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
+from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.puppet.api_v2.utils import (
     gen_install_distributor,
     gen_repo,

--- a/pulp_smash/tests/pulp2/puppet/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/pulp2/puppet/api_v2/test_sync_publish.py
@@ -19,7 +19,7 @@ from pulp_smash.constants import (
     PUPPET_MODULE_URL_2,
     PUPPET_QUERY_2,
 )
-from pulp_smash.tests.pulp2.constants import (
+from pulp_smash.pulp2.constants import (
     CALL_REPORT_KEYS,
     CONTENT_UPLOAD_PATH,
     REPOSITORY_PATH

--- a/pulp_smash/tests/pulp2/puppet/utils.py
+++ b/pulp_smash/tests/pulp2/puppet/utils.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 """Utilities for Puppet tests."""
-from pulp_smash.tests.pulp2 import utils
+from pulp_smash.pulp2 import utils
 
 
 def set_up_module():

--- a/pulp_smash/tests/pulp2/python/api_v2/test_duplicate_uploads.py
+++ b/pulp_smash/tests/pulp2/python/api_v2/test_duplicate_uploads.py
@@ -20,7 +20,7 @@ from packaging.version import Version
 
 from pulp_smash import api, utils
 from pulp_smash.constants import PYTHON_EGG_URL
-from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
+from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.python.api_v2.utils import gen_repo
 from pulp_smash.tests.pulp2.python.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 

--- a/pulp_smash/tests/pulp2/python/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/pulp2/python/api_v2/test_sync_publish.py
@@ -8,7 +8,7 @@ from urllib.parse import urljoin, urlparse
 from packaging.version import Version
 
 from pulp_smash import api, config, constants, selectors, utils
-from pulp_smash.tests.pulp2.constants import (
+from pulp_smash.pulp2.constants import (
     REPOSITORY_PATH,
     ORPHANS_PATH,
 )

--- a/pulp_smash/tests/pulp2/python/utils.py
+++ b/pulp_smash/tests/pulp2/python/utils.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 """Utilities for Python tests."""
-from pulp_smash.tests.pulp2 import utils
+from pulp_smash.pulp2 import utils
 
 
 def set_up_module():

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_broker.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_broker.py
@@ -35,7 +35,7 @@ from pulp_smash.constants import (
     RPM_SIGNED_FEED_URL,
     RPM_SIGNED_URL,
 )
-from pulp_smash.tests.pulp2.constants import PULP_SERVICES, REPOSITORY_PATH
+from pulp_smash.pulp2.constants import PULP_SERVICES, REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import (
     gen_distributor,
     gen_repo,

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_character_encoding.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_character_encoding.py
@@ -12,7 +12,7 @@ from pulp_smash.constants import (
     RPM_WITH_NON_ASCII_URL,
     RPM_WITH_NON_UTF_8_URL,
 )
-from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
+from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_repo
 from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_comps_xml.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_comps_xml.py
@@ -14,7 +14,7 @@ from packaging.version import Version
 
 from pulp_smash import api, config, selectors, utils
 from pulp_smash.constants import RPM_SIGNED_FEED_URL
-from pulp_smash.tests.pulp2.constants import (
+from pulp_smash.pulp2.constants import (
     CONTENT_UPLOAD_PATH,
     ORPHANS_PATH,
     REPOSITORY_PATH,

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_content_applicability.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_content_applicability.py
@@ -16,7 +16,7 @@ from pulp_smash.constants import (
     RPM_DATA,
     RPM2_DATA,
 )
-from pulp_smash.tests.pulp2.constants import (
+from pulp_smash.pulp2.constants import (
     CONSUMERS_ACTIONS_CONTENT_REGENERATE_APPLICABILITY_PATH,
     CONSUMERS_CONTENT_APPLICABILITY_PATH,
     CONSUMERS_PATH,

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_content_sources.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_content_sources.py
@@ -11,7 +11,7 @@ from urllib.parse import urlsplit, urlunsplit
 
 from pulp_smash import api, cli, config, selectors, utils
 from pulp_smash.constants import PULP_FIXTURES_BASE_URL
-from pulp_smash.tests.pulp2.constants import CONTENT_SOURCES_PATH
+from pulp_smash.pulp2.constants import CONTENT_SOURCES_PATH
 from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 _HEADERS = {'X-RHUI-ID', 'X-CSRF-TOKEN'}

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_copy.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_copy.py
@@ -11,7 +11,7 @@ from pulp_smash.constants import (
     RPM_UNSIGNED_FEED_URL,
     RPM_UPDATED_INFO_FEED_URL,
 )
-from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
+from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_distributor, gen_repo
 from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_crud.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_crud.py
@@ -17,7 +17,7 @@ from pulp_smash.constants import (
     RPM_UNSIGNED_FEED_URL,
     RPM_WITH_PULP_DISTRIBUTION_FEED_URL,
 )
-from pulp_smash.tests.pulp2.constants import (
+from pulp_smash.pulp2.constants import (
     REPOSITORY_GROUP_PATH,
     REPOSITORY_PATH,
 )

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_download_policies.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_download_policies.py
@@ -17,7 +17,7 @@ from pulp_smash.constants import (
     RPM_SIGNED_FEED_URL,
     RPM_SIGNED_URL,
 )
-from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
+from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import (
     gen_distributor,
     gen_repo,

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_duplicate_uploads.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_duplicate_uploads.py
@@ -7,7 +7,7 @@ from urllib.parse import urlsplit
 
 from pulp_smash import api, config, selectors, utils
 from pulp_smash.constants import FILE_URL, RPM_UNSIGNED_URL
-from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
+from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_repo
 from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_errata.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_errata.py
@@ -4,7 +4,7 @@ from urllib.parse import urljoin
 
 from pulp_smash import api, cli, config, selectors, utils
 from pulp_smash.constants import RPM_LARGE_UPDATEINFO, RPM_UNSIGNED_FEED_URL
-from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
+from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import (
     gen_distributor,
     gen_repo,

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_export.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_export.py
@@ -19,7 +19,7 @@ from pulp_smash.constants import (
     RPM_SIGNED_FEED_URL,
     RPM_SIGNED_URL,
 )
-from pulp_smash.tests.pulp2.constants import (
+from pulp_smash.pulp2.constants import (
     REPOSITORY_EXPORT_DISTRIBUTOR,
     REPOSITORY_GROUP_EXPORT_DISTRIBUTOR,
     REPOSITORY_GROUP_PATH,

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_force_full.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_force_full.py
@@ -13,7 +13,7 @@ from packaging.version import Version
 
 from pulp_smash import api, selectors, utils
 from pulp_smash.constants import RPM_SIGNED_FEED_URL
-from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
+from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_distributor, gen_repo
 from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_iso_crud.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_iso_crud.py
@@ -15,7 +15,7 @@ from pulp_smash.constants import (
     FILE_MIXED_FEED_URL,
     FILE2_FEED_URL,
 )
-from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
+from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_iso_sync_publish.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_iso_sync_publish.py
@@ -11,7 +11,7 @@ from pulp_smash.constants import (
     FILE_FEED_URL,
     FILE_URL,
 )
-from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
+from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import (
     TemporaryUserMixin,
     get_dists_by_type_id,

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_mirrorlist.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_mirrorlist.py
@@ -26,7 +26,7 @@ from pulp_smash.constants import (
     RPM_UNSIGNED_URL,
 )
 from pulp_smash.exceptions import TaskReportError
-from pulp_smash.tests.pulp2.constants import (
+from pulp_smash.pulp2.constants import (
     ORPHANS_PATH,
     REPOSITORY_PATH,
 )

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_no_op_publish.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_no_op_publish.py
@@ -32,7 +32,7 @@ from packaging.version import Version
 
 from pulp_smash import api, config, exceptions, utils
 from pulp_smash.constants import RPM_SIGNED_FEED_URL
-from pulp_smash.tests.pulp2.constants import (
+from pulp_smash.pulp2.constants import (
     ORPHANS_PATH,
     REPOSITORY_PATH,
 )

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_orphan_remove.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_orphan_remove.py
@@ -18,7 +18,7 @@ from packaging.version import Version
 
 from pulp_smash import api, config, selectors, utils
 from pulp_smash.constants import RPM_SIGNED_FEED_URL
-from pulp_smash.tests.pulp2.constants import (
+from pulp_smash.pulp2.constants import (
     ORPHANS_PATH,
     REPOSITORY_PATH,
 )
@@ -164,10 +164,10 @@ class OrphansTestCase(unittest.TestCase):
         """Ensure that a specific orphan is well and truly deleted.
 
         :param orphans_pre: The response to GET
-            :data:`pulp_smash.tests.pulp2.constants.ORPHANS_PATH` before the
+            :data:`pulp_smash.pulp2.constants.ORPHANS_PATH` before the
             orphan was deleted.
         :param orphans_post: The response to GET
-            :data:`pulp_smash.tests.pulp2.constants.ORPHANS_PATH` after the
+            :data:`pulp_smash.pulp2.constants.ORPHANS_PATH` after the
             orphan was deleted.
         :param orphan: A dict describing the orphan that was deleted.
         :returns: Nothing.

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_package_paths.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_package_paths.py
@@ -37,7 +37,7 @@ from pulp_smash.constants import (
     RPM_ALT_LAYOUT_FEED_URL,
     RPM_UNSIGNED_FEED_URL,
 )
-from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
+from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import (
     gen_distributor,
     gen_repo,

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_remove_unit.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_remove_unit.py
@@ -13,7 +13,7 @@ from pulp_smash.constants import (
     RPM_SIGNED_FEED_URL,
     RPM_UNSIGNED_FEED_URL,
 )
-from pulp_smash.tests.pulp2.constants import (
+from pulp_smash.pulp2.constants import (
     ORPHANS_PATH,
     REPOSITORY_PATH,
 )

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_repomd.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_repomd.py
@@ -12,7 +12,7 @@ from pulp_smash.constants import (
     RPM_NAMESPACES,
     RPM_UNSIGNED_FEED_URL,
 )
-from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
+from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import (
     gen_distributor,
     gen_repo,

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_repository_layout.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_repository_layout.py
@@ -24,7 +24,7 @@ from pulp_smash.constants import (
     RPM_NAMESPACES,
     RPM_SIGNED_FEED_URL,
 )
-from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
+from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import (
     gen_distributor,
     gen_repo,

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_repoview.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_repoview.py
@@ -14,7 +14,7 @@ from urllib.parse import urljoin
 from packaging.version import Version
 
 from pulp_smash import api, config, constants, selectors, utils
-from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
+from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_distributor, gen_repo
 

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_republish.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_republish.py
@@ -11,7 +11,7 @@ from pulp_smash.constants import (
     RPM_UNSIGNED_FEED_URL,
     RPM_UNSIGNED_URL,
 )
-from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
+from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import (
     gen_distributor,
     gen_repo,

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_retain_old_count.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_retain_old_count.py
@@ -14,7 +14,7 @@ from urllib.parse import urljoin
 
 from pulp_smash import api, utils
 from pulp_smash.constants import RPM_UNSIGNED_FEED_URL
-from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
+from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_distributor, gen_repo
 from pulp_smash.tests.pulp2.rpm.utils import check_issue_3104
 from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_rsync_distributor.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_rsync_distributor.py
@@ -65,7 +65,7 @@ from pulp_smash.constants import (
     RPM_SIGNED_FEED_URL,
     RPM_UNSIGNED_URL,
 )
-from pulp_smash.tests.pulp2.constants import (
+from pulp_smash.pulp2.constants import (
     ORPHANS_PATH,
     REPOSITORY_PATH,
 )

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_schedule_publish.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_schedule_publish.py
@@ -9,7 +9,7 @@ from urllib.parse import urljoin
 
 from pulp_smash import api, utils
 from pulp_smash.constants import RPM_SIGNED_FEED_URL
-from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
+from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_repo, gen_distributor
 from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_schedule_sync.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_schedule_sync.py
@@ -11,7 +11,7 @@ from packaging.version import Version
 
 from pulp_smash import api, utils
 from pulp_smash.constants import RPM_SIGNED_FEED_URL
-from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
+from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_repo
 from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_search.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_search.py
@@ -24,7 +24,7 @@ from pulp_smash.constants import (
     SRPM,
     SRPM_SIGNED_FEED_URL,
 )
-from pulp_smash.tests.pulp2.constants import (
+from pulp_smash.pulp2.constants import (
     CONTENT_UNITS_PATH,
     REPOSITORY_PATH,
 )

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_service_resiliency.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_service_resiliency.py
@@ -15,7 +15,7 @@ from pulp_smash.constants import (
     RPM_MIRRORLIST_LARGE,
     RPM_UNSIGNED_FEED_URL,
 )
-from pulp_smash.tests.pulp2.constants import (
+from pulp_smash.pulp2.constants import (
     PULP_SERVICES,
     REPOSITORY_PATH,
     TASKS_PATH,

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_signatures_checked_for_copies.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_signatures_checked_for_copies.py
@@ -35,7 +35,7 @@ from pulp_smash.constants import (
     SRPM_SIGNED_URL,
     SRPM_UNSIGNED_URL,
 )
-from pulp_smash.tests.pulp2.constants import ORPHANS_PATH, REPOSITORY_PATH
+from pulp_smash.pulp2.constants import ORPHANS_PATH, REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_repo
 from pulp_smash.tests.pulp2.rpm.utils import set_up_module
 

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_signatures_checked_for_syncs.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_signatures_checked_for_syncs.py
@@ -38,7 +38,7 @@ from pulp_smash.constants import (
     SRPM_UNSIGNED_FEED_URL,
 )
 
-from pulp_smash.tests.pulp2.constants import ORPHANS_PATH, REPOSITORY_PATH
+from pulp_smash.pulp2.constants import ORPHANS_PATH, REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_repo
 from pulp_smash.tests.pulp2.rpm.utils import set_up_module
 

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_signatures_checked_for_uploads.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_signatures_checked_for_uploads.py
@@ -59,7 +59,7 @@ from pulp_smash.constants import (
     SRPM_SIGNED_URL,
     SRPM_UNSIGNED_URL,
 )
-from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
+from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_repo
 from pulp_smash.tests.pulp2.rpm.utils import set_up_module
 

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_signatures_saved_for_packages.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_signatures_saved_for_packages.py
@@ -35,7 +35,7 @@ from pulp_smash.constants import (
     SRPM_UNSIGNED_FEED_URL,
     SRPM_UNSIGNED_URL,
 )
-from pulp_smash.tests.pulp2.constants import ORPHANS_PATH, REPOSITORY_PATH
+from pulp_smash.pulp2.constants import ORPHANS_PATH, REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_repo
 from pulp_smash.tests.pulp2.rpm.utils import check_issue_2620
 from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_sync_publish.py
@@ -33,7 +33,7 @@ from pulp_smash.constants import (
     RPM_UNSIGNED_URL,
     SRPM_SIGNED_FEED_URL,
 )
-from pulp_smash.tests.pulp2.constants import ORPHANS_PATH, REPOSITORY_PATH
+from pulp_smash.pulp2.constants import ORPHANS_PATH, REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import (
     gen_distributor,
     gen_repo,

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_tasks.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_tasks.py
@@ -14,7 +14,7 @@ from urllib.parse import urljoin
 
 from pulp_smash import api, config, selectors, utils
 from pulp_smash.constants import RPM_SIGNED_FEED_URL
-from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH, TASKS_PATH
+from pulp_smash.pulp2.constants import REPOSITORY_PATH, TASKS_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_distributor, gen_repo
 from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_unassociate.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_unassociate.py
@@ -21,7 +21,7 @@ from pulp_smash.constants import (
     RPM_UNSIGNED_URL,
     SRPM_UNSIGNED_FEED_URL,
 )
-from pulp_smash.tests.pulp2.constants import ORPHANS_PATH, REPOSITORY_PATH
+from pulp_smash.pulp2.constants import ORPHANS_PATH, REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_distributor, gen_repo
 from pulp_smash.tests.pulp2.rpm.utils import check_issue_2620
 from pulp_smash.tests.pulp2.rpm.utils import set_up_module

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_unavailable_checksum.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_unavailable_checksum.py
@@ -9,7 +9,7 @@ from pulp_smash.constants import (
     RPM_UNSIGNED_FEED_URL,
     SRPM_UNSIGNED_FEED_URL,
 )
-from pulp_smash.tests.pulp2.constants import REPOSITORY_PATH
+from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.exceptions import TaskReportError
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import (
     gen_distributor,

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_updateinfo.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_updateinfo.py
@@ -58,7 +58,7 @@ from pulp_smash.constants import (
     RPM_UNSIGNED_FEED_URL,
     RPM_UNSIGNED_URL,
 )
-from pulp_smash.tests.pulp2.constants import ORPHANS_PATH, REPOSITORY_PATH
+from pulp_smash.pulp2.constants import ORPHANS_PATH, REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import (
     gen_distributor,
     gen_repo,

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_upload_publish.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_upload_publish.py
@@ -26,7 +26,7 @@ from pulp_smash.constants import (
     SRPM,
     SRPM_UNSIGNED_URL,
 )
-from pulp_smash.tests.pulp2.constants import ORPHANS_PATH, REPOSITORY_PATH
+from pulp_smash.pulp2.constants import ORPHANS_PATH, REPOSITORY_PATH
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import (
     gen_distributor,
     gen_repo,

--- a/pulp_smash/tests/pulp2/rpm/cli/test_process_recycling.py
+++ b/pulp_smash/tests/pulp2/rpm/cli/test_process_recycling.py
@@ -5,7 +5,7 @@ import unittest
 
 from pulp_smash import cli, config, selectors, utils
 from pulp_smash.constants import RPM_UNSIGNED_FEED_URL
-from pulp_smash.tests.pulp2.constants import PULP_SERVICES
+from pulp_smash.pulp2.constants import PULP_SERVICES
 from pulp_smash.tests.pulp2.rpm.utils import set_up_module
 
 

--- a/pulp_smash/tests/pulp2/rpm/utils.py
+++ b/pulp_smash/tests/pulp2/rpm/utils.py
@@ -6,7 +6,7 @@ from io import StringIO
 from packaging.version import Version
 
 from pulp_smash import cli, selectors, utils
-from pulp_smash.tests.pulp2 import utils as pulp2_utils
+from pulp_smash.pulp2 import utils as pulp2_utils
 
 
 def set_up_module():

--- a/pulp_smash/utils.py
+++ b/pulp_smash/utils.py
@@ -15,7 +15,7 @@ from packaging.version import Version
 
 from pulp_smash import api, cli, config, exceptions
 from pulp_smash.cli import _is_root as is_root  # for backward compatibility
-from pulp_smash.tests.pulp2.constants import (
+from pulp_smash.pulp2.constants import (
     CONTENT_UPLOAD_PATH,
     ORPHANS_PATH,
     PULP_SERVICES,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -86,7 +86,7 @@ class BaseAPITestCase(unittest.TestCase):
 
         :meth:`pulp_smash.api.Client.delete` should be called once for each
         resource listed in ``resources``, and once for
-        :data:`pulp_smash.tests.pulp2.constants.ORPHANS_PATH`.
+        :data:`pulp_smash.pulp2.constants.ORPHANS_PATH`.
         """
         with mock.patch.object(api, 'Client') as client:
             self.child.tearDownClass()


### PR DESCRIPTION
Move `pulp_smash/tests/pulp2/{constants,utils}.py` to
`pulp_smash/pulp2/`. This makes it easier to blow away the
`pulp_smash/tests/` directory.

See: https://github.com/PulpQE/pulp-smash/issues/996