### PR TITLE
Deprecate BaseAPITestCase

### DIFF
--- a/pulp_smash/pulp2/utils.py
+++ b/pulp_smash/pulp2/utils.py
@@ -3,6 +3,7 @@
 import inspect
 import io
 import unittest
+import warnings
 from urllib.parse import urljoin, urlparse
 
 from packaging.version import Version
@@ -134,9 +135,27 @@ class BaseAPITestCase(unittest.TestCase):
     """A class with behaviour that is of use in many API test cases.
 
     This test case provides set-up and tear-down behaviour that is common to
-    many API test cases. It is not necessary to use this class as the parent of
-    all API test cases, but it serves well in many cases.
+    many API test cases.
+
+    .. WARNING:: Avoid using BaseAPITestCase. Its design encourages fragile
+        clean-up logic, and it slows down tests by unnecessarily deleting
+        orphans. Try using the `addCleanup`_ instance method instead, and only
+        delete orphans as needed.
+
+    .. _addCleanup:
+        https://docs.python.org/3.6/library/unittest.html#unittest.TestCase.addCleanup
     """
+
+    def __init__(self, *args, **kwargs):
+        """Raise a deprecation warning."""
+        warnings.warn(
+            'Avoid using BaseAPITestCase. Its design encourages fragile '
+            'clean-up logic, and it slows down tests by unnecessarily '
+            'deleting orphans. Try using the addCleanup instance method '
+            'instead, and only delete orphans as needed.',
+            DeprecationWarning
+        )
+        super().__init__(*args, **kwargs)
 
     @classmethod
     def setUpClass(cls):

--- a/tests/test_pulp_smash_cli.py
+++ b/tests/test_pulp_smash_cli.py
@@ -309,6 +309,14 @@ class SmokeTestsTestCase(BasePulpSmashCliTestCase):
         fq_names = result.output.strip().splitlines()
         self.assertGreater(len(fq_names), 0)
         for fq_name in fq_names:
+            # By default, deprecation warnings are suppressed. However,
+            # unittest undoes that filtering. In addition, Click's CliRunner
+            # captures both stdout and stderr, and combines them into a single
+            # `output` stream, with no apparent way to separate them. As a
+            # result, the normally invisible warning raised by BaseAPITestCase
+            # makes its way to here and can cause this test to fail.
+            if 'DeprecationWarning' in fq_name:
+                continue
             with self.subTest(fq_name=fq_name):
                 module_name, _, class_name = fq_name.rpartition('.')
                 module = importlib.import_module(module_name)


### PR DESCRIPTION
It encourages fragile clean-up logic and slows down tests by
unnecessarily deleting orphans.