### PR TITLE
Update `pulp-smash settings` subcommands

### DIFF
--- a/pulp_smash/pulp_smash_cli.py
+++ b/pulp_smash/pulp_smash_cli.py
@@ -147,18 +147,45 @@ def settings_create(ctx):  # pylint:disable=too-many-locals
 
 @settings.command('path')
 @click.pass_context
-def settings_path(ctx):
-    """Show the path to the settings file."""
+def settings_path(ctx):  # noqa:D401
+    """Deprecated in favor of 'load-path'."""
+    ctx.forward(settings_load_path)
+
+
+@settings.command('load-path')
+@click.pass_context
+def settings_load_path(ctx):
+    """Print the path from which settings are loaded.
+
+    Search several paths for a settings file, in order of preference. If a file
+    is found, print its path. Otherwise, return a non-zero exit code. This load
+    path is used by sibling commands such as "show".
+    """
     path = ctx.obj['load_path']
     if not path:
         _raise_settings_not_found()
     click.echo(path)
 
 
+@settings.command('save-path')
+@click.pass_context
+def settings_save_path(ctx):
+    """Print the path to which settings are saved.
+
+    As a side-effect, create all directories in the path that don't yet exist.
+    As a result, it's safe to execute a Bash expression such as:
+
+        echo '{...}' > "$(pulp-smash settings path)"
+
+    This save path is used by sibling commands such as "create".
+    """
+    click.echo(ctx.obj['save_path'])
+
+
 @settings.command('show')
 @click.pass_context
 def settings_show(ctx):
-    """Show the settings file."""
+    """Print the settings file."""
     path = ctx.obj['load_path']
     if not path:
         _raise_settings_not_found()

--- a/tests/test_pulp_smash_cli.py
+++ b/tests/test_pulp_smash_cli.py
@@ -205,21 +205,59 @@ class SettingsPathTestCase(BasePulpSmashCliTestCase, MissingSettingsFileMixin):
     settings_subcommand = 'path'
 
     def test_settings_path(self):
-        """Ensure path outputs proper settings file path."""
+        """Ensure ``path`` outputs proper settings file path."""
         with self.cli_runner.isolated_filesystem():
             with open('settings.json', 'w') as handler:
                 handler.write(PULP_SMASH_CONFIG)
             with mock.patch.object(pulp_smash_cli, 'PulpSmashConfig') as psc:
-                psc.get_load_path.return_value = 'settings.json'
+                psc.get_load_path.return_value = utils.uuid4()
                 result = self.cli_runner.invoke(
                     pulp_smash_cli.settings,
-                    ['path'],
+                    [self.settings_subcommand],
                 )
-            self.assertEqual(result.exit_code, 0)
-            self.assertIn(
-                'settings.json',
-                result.output,
+            self.assertEqual(result.exit_code, 0, result.output)
+            self.assertEqual(
+                psc.get_load_path.return_value,
+                result.output.strip(),
             )
+
+
+class SettingsLoadPathTestCase(BasePulpSmashCliTestCase, MissingSettingsFileMixin):
+    """Test ``pulp_smash.pulp_smash_cli.settings_load_path`` command."""
+
+    settings_subcommand = 'load-path'
+
+    def test_settings_load_path(self):
+        """Ensure ``load-path`` outputs proper settings file path."""
+        with self.cli_runner.isolated_filesystem():
+            with open('settings.json', 'w') as handler:
+                handler.write(PULP_SMASH_CONFIG)
+            with mock.patch.object(pulp_smash_cli, 'PulpSmashConfig') as psc:
+                psc.get_load_path.return_value = utils.uuid4()
+                result = self.cli_runner.invoke(
+                    pulp_smash_cli.settings,
+                    [self.settings_subcommand],
+                )
+            self.assertEqual(result.exit_code, 0, result.output)
+            self.assertEqual(
+                psc.get_load_path.return_value,
+                result.output.strip(),
+            )
+
+
+class SettingsSavePathTestCase(BasePulpSmashCliTestCase):
+    """Test ``pulp_smash.pulp_smash_cli.settings_save_path`` command."""
+
+    def test_settings_save_path(self):
+        """Ensure ``save-path`` outputs proper settings file path."""
+        with mock.patch.object(pulp_smash_cli, 'PulpSmashConfig') as psc:
+            psc.get_save_path.return_value = utils.uuid4()
+            result = self.cli_runner.invoke(
+                pulp_smash_cli.settings,
+                ['save-path'],
+            )
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(psc.get_save_path.return_value, result.output.strip())
 
 
 class SettingsShowTestCase(BasePulpSmashCliTestCase, MissingSettingsFileMixin):


### PR DESCRIPTION
Deprecate `pulp-smash settings path` in favor of `pulp-smash settings
load-path`, and add `pulp-smash settings save-path`. This change has two
benefits:

* Users are made conscious of the fact that the path used when loading
  settings may be different then the path used when saving settings.
  Being aware of this distinction may help to prevent bugs.
* Users who wish to create a settings file in a non-interactive manner
  (as opposed to with `pulp-smash settings create`) can now do so more
  easily.

Without this commit, a user who wants to create a settings file must
both hard-code knowledge about the path at which a settings file should
be created, and must make sure to create parent directories. The
procedure looks like this:

    mkdir -p ~/.config/pulp_smash
    cat >~/.config/pulp_smash/settings.json <<EOF
    {...}
    EOF
    pulp-smash settings validate

With this commit, the procedure changes:

    cat >"$(pulp-smash settings save-path)" <<EOF
    {...}
    EOF
    pulp-smash settings validate