### PR TITLE
Consolidate bug status checks

### DIFF
--- a/pulp_smash/pulp2/utils.py
+++ b/pulp_smash/pulp2/utils.py
@@ -314,7 +314,7 @@ def require_issue_3159():
     .. _Pulp #3159: https://pulp.plan.io/issues/3159
     """
     cfg = config.get_config()
-    if (selectors.bug_is_untestable(3159, cfg.pulp_version) and
+    if (not selectors.bug_is_fixed(3159, cfg.pulp_version) and
             utils.os_is_f27(cfg)):
         raise unittest.SkipTest('https://pulp.plan.io/issues/3159')
 

--- a/pulp_smash/pulp3/utils.py
+++ b/pulp_smash/pulp3/utils.py
@@ -104,7 +104,7 @@ def get_auth(cfg=None):
     if not cfg:
         cfg = config.get_config()
     choices = [_get_basic_auth]
-    if selectors.bug_is_testable(3248, cfg.pulp_version):
+    if selectors.bug_is_fixed(3248, cfg.pulp_version):
         choices.append(_get_jwt_auth)
     return random.choice(choices)(cfg)
 

--- a/pulp_smash/selectors.py
+++ b/pulp_smash/selectors.py
@@ -134,7 +134,7 @@ def _get_bug(bug_id):
     return _BUG_STATUS_CACHE[bug_id]
 
 
-def bug_is_testable(bug_id, pulp_version):
+def bug_is_fixed(bug_id, pulp_version):
     """Tell the caller whether bug ``bug_id`` should be tested.
 
     :param bug_id: An integer bug ID, taken from https://pulp.plan.io.
@@ -168,11 +168,6 @@ def bug_is_testable(bug_id, pulp_version):
             bug.target_platform_release <= pulp_version):
         return True
     return False
-
-
-def bug_is_untestable(bug_id, pulp_version):
-    """Return the inverse of :meth:`bug_is_testable`."""
-    return not bug_is_testable(bug_id, pulp_version)
 
 
 def require(version_string):

--- a/pulp_smash/tests/__init__.py
+++ b/pulp_smash/tests/__init__.py
@@ -28,9 +28,9 @@ From a Pulp Smash developer's perspective, some work needs to be done to make
 this happen. There are two especially common ways to make this happen. First,
 bug-specific skipping logic can be implemented with the methods in
 :mod:`pulp_smash.selectors`, especially
-:func:`pulp_smash.selectors.bug_is_testable` and it's sibling. Second, a
-`setUpModule`_ function must be present in **every** ``test*`` module. In the
-simplest case, this can be done with pre-defined functions. For example,
+:func:`pulp_smash.selectors.bug_is_fixed`. Second, a `setUpModule`_ function
+must be present in **every** ``test*`` module. In the simplest case, this can
+be done with pre-defined functions. For example,
 :mod:`pulp_smash.tests.pulp2.rpm.api_v2.test_broker` might do the following:
 
 .. code-block:: python

--- a/pulp_smash/tests/pulp2/docker/api_v2/test_copy.py
+++ b/pulp_smash/tests/pulp2/docker/api_v2/test_copy.py
@@ -149,7 +149,7 @@ class CopyV2ContentTestCase(unittest.TestCase):
         * `Pulp #2385 <https://pulp.plan.io/issues/2385>`_
         """
         for issue_id in (2384, 2385):
-            if selectors.bug_is_untestable(issue_id, self.cfg.pulp_version):
+            if not selectors.bug_is_fixed(issue_id, self.cfg.pulp_version):
                 self.skipTest(
                     'https://pulp.plan.io/issues/{}'.format(issue_id)
                 )

--- a/pulp_smash/tests/pulp2/docker/api_v2/test_sync.py
+++ b/pulp_smash/tests/pulp2/docker/api_v2/test_sync.py
@@ -45,7 +45,7 @@ class UpstreamNameTestsMixin():
 
         Verify the sync request is rejected with an HTTP 400 status code.
         """
-        if selectors.bug_is_untestable(2230, self.cfg.pulp_version):
+        if not selectors.bug_is_fixed(2230, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2230')
         docker_upstream_name = get_upstream_name(self.cfg).replace('/', ' ')
         response = api.Client(self.cfg, api.echo_handler).post(

--- a/pulp_smash/tests/pulp2/docker/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/pulp2/docker/api_v2/test_sync_publish.py
@@ -168,7 +168,7 @@ class V1RegistryTestCase(SyncPublishMixin, unittest.TestCase):
         super().setUpClass()
         cls.cfg = config.get_config()
         if (utils.os_is_f26(cls.cfg) and
-                selectors.bug_is_untestable(3036, cls.cfg.pulp_version)):
+                not selectors.bug_is_fixed(3036, cls.cfg.pulp_version)):
             raise unittest.SkipTest('https://pulp.plan.io/issues/3036')
 
     def setUp(self):
@@ -200,7 +200,7 @@ class V1RegistryTestCase(SyncPublishMixin, unittest.TestCase):
         <http://docs.pulpproject.org/plugins/crane/index.html#crane-admin>`_.
         """
         if (self.cfg.pulp_version < Version('2.14') or
-                selectors.bug_is_untestable(2723, self.cfg.pulp_version)):
+                not selectors.bug_is_fixed(2723, self.cfg.pulp_version)):
             self.skipTest('https://pulp.plan.io/issues/2723')
         repo_id = self.repo['id']
         repos = self.make_crane_client(self.cfg).get('/crane/repositories/v1')
@@ -226,10 +226,10 @@ class V2RegistryTestCase(SyncPublishMixin, unittest.TestCase):
         super().setUpClass()
         cls.cfg = config.get_config()
         if (utils.os_is_f26(cls.cfg) and
-                selectors.bug_is_untestable(3036, cls.cfg.pulp_version)):
+                not selectors.bug_is_fixed(3036, cls.cfg.pulp_version)):
             raise unittest.SkipTest('https://pulp.plan.io/issues/3036')
         for issue_id in (2287, 2384):
-            if selectors.bug_is_untestable(issue_id, cls.cfg.pulp_version):
+            if not selectors.bug_is_fixed(issue_id, cls.cfg.pulp_version):
                 raise unittest.SkipTest(
                     'https://pulp.plan.io/issues/{}'.format(issue_id)
                 )
@@ -251,7 +251,7 @@ class V2RegistryTestCase(SyncPublishMixin, unittest.TestCase):
         <http://docs.pulpproject.org/plugins/crane/index.html#crane-admin>`_.
         """
         if (self.cfg.pulp_version < Version('2.14') or
-                selectors.bug_is_untestable(2723, self.cfg.pulp_version)):
+                not selectors.bug_is_fixed(2723, self.cfg.pulp_version)):
             self.skipTest('https://pulp.plan.io/issues/2723')
         repo_id = self.repo['id']
         repos = self.make_crane_client(self.cfg).get('/crane/repositories/v2')
@@ -272,7 +272,7 @@ class V2RegistryTestCase(SyncPublishMixin, unittest.TestCase):
 
         This test targets `Pulp #2336 <https://pulp.plan.io/issues/2336>`_.
         """
-        if selectors.bug_is_untestable(2336, self.cfg.pulp_version):
+        if not selectors.bug_is_fixed(2336, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2336')
         client = api.Client(self.cfg, api.json_handler)
         client.request_kwargs['url'] = self.adjust_url(
@@ -301,7 +301,7 @@ class V2RegistryTestCase(SyncPublishMixin, unittest.TestCase):
 
         This test targets `Pulp #2336 <https://pulp.plan.io/issues/2336>`_.
         """
-        if selectors.bug_is_untestable(2336, self.cfg.pulp_version):
+        if not selectors.bug_is_fixed(2336, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2336')
         client = api.Client(self.cfg, api.json_handler, {'headers': {
             'accept': 'application/vnd.docker.distribution.manifest.v2+json'
@@ -371,7 +371,7 @@ class NonNamespacedImageTestCase(SyncPublishMixin, unittest.TestCase):
 
         # Get and inspect /crane/repositories/v2.
         if (cfg.pulp_version >= Version('2.14') and
-                selectors.bug_is_testable(2723, cfg.pulp_version)):
+                selectors.bug_is_fixed(2723, cfg.pulp_version)):
             client = self.make_crane_client(cfg)
             repo_id = repo['id']
             repos = client.get('/crane/repositories/v2')
@@ -422,9 +422,9 @@ class NoAmd64LinuxTestCase(SyncPublishMixin, unittest.TestCase):
         cls.cfg = config.get_config()
         cls.repo = {}
         if (utils.os_is_f26(cls.cfg) and
-                selectors.bug_is_untestable(3036, cls.cfg.pulp_version)):
+                not selectors.bug_is_fixed(3036, cls.cfg.pulp_version)):
             raise unittest.SkipTest('https://pulp.plan.io/issues/3036')
-        if selectors.bug_is_untestable(2384, cls.cfg.pulp_version):
+        if not selectors.bug_is_fixed(2384, cls.cfg.pulp_version):
             raise unittest.SkipTest('https://pulp.plan.io/issues/2384')
 
     @classmethod
@@ -558,7 +558,7 @@ class RepoRegistryIdTestCase(SyncPublishMixin, unittest.TestCase):
         """
         cfg = config.get_config()
         if (cfg.pulp_version < Version('2.14') or
-                selectors.bug_is_untestable(2723, cfg.pulp_version)):
+                not selectors.bug_is_fixed(2723, cfg.pulp_version)):
             self.skipTest('https://pulp.plan.io/issues/2723')
         for i in range(1, 4):
             repo_registry_id = '/'.join(utils.uuid4() for _ in range(i))

--- a/pulp_smash/tests/pulp2/docker/api_v2/test_upload.py
+++ b/pulp_smash/tests/pulp2/docker/api_v2/test_upload.py
@@ -29,10 +29,10 @@ class UploadManifestListV2TestCase(SyncPublishMixin, unittest.TestCase):
         super().setUpClass()
         cls.cfg = config.get_config()
         if (utils.os_is_f26(cls.cfg) and
-                selectors.bug_is_untestable(3036, cls.cfg.pulp_version)):
+                not selectors.bug_is_fixed(3036, cls.cfg.pulp_version)):
             raise unittest.SkipTest('https://pulp.plan.io/issues/3036')
         for issue_id in (2287, 2384, 2993):
-            if selectors.bug_is_untestable(issue_id, cls.cfg.pulp_version):
+            if not selectors.bug_is_fixed(issue_id, cls.cfg.pulp_version):
                 raise unittest.SkipTest(
                     'https://pulp.plan.io/issues/{}'.format(issue_id)
                 )

--- a/pulp_smash/tests/pulp2/docker/cli/test_crud.py
+++ b/pulp_smash/tests/pulp2/docker/cli/test_crud.py
@@ -128,7 +128,7 @@ class UpdateEnableV1TestCase(unittest.TestCase):
 
         if cls.cfg.pulp_version < version.Version('2.8'):
             raise unittest.SkipTest('These tests require Pulp 2.8 or above.')
-        if selectors.bug_is_untestable(1710, cls.cfg.pulp_version):
+        if not selectors.bug_is_fixed(1710, cls.cfg.pulp_version):
             raise unittest.SkipTest('https://pulp.plan.io/issues/1710')
 
         pulp_admin_login(cls.cfg)
@@ -182,7 +182,7 @@ class UpdateEnableV2TestCase(unittest.TestCase):
 
         if cls.cfg.pulp_version < version.Version('2.8'):
             raise unittest.SkipTest('These tests require Pulp 2.8 or above.')
-        if selectors.bug_is_untestable(1710, cls.cfg.pulp_version):
+        if not selectors.bug_is_fixed(1710, cls.cfg.pulp_version):
             raise unittest.SkipTest('https://pulp.plan.io/issues/1710')
 
         pulp_admin_login(cls.cfg)
@@ -236,7 +236,7 @@ class UpdateDistributorTestCase(unittest.TestCase):
         cls.cfg = config.get_config()
         if cls.cfg.pulp_version < version.Version('2.8'):
             raise unittest.SkipTest('These tests require Pulp 2.8 or above.')
-        if selectors.bug_is_untestable(1710, cls.cfg.pulp_version):
+        if not selectors.bug_is_fixed(1710, cls.cfg.pulp_version):
             raise unittest.SkipTest('https://pulp.plan.io/issues/1710')
 
         pulp_admin_login(cls.cfg)

--- a/pulp_smash/tests/pulp2/docker/cli/test_sync_publish.py
+++ b/pulp_smash/tests/pulp2/docker/cli/test_sync_publish.py
@@ -32,7 +32,7 @@ class InvalidFeedTestCase(BaseAPITestCase):
         proc = client.run((
             'pulp-admin', 'docker', 'repo', 'sync', 'run', '--repo-id', repo_id
         ))
-        if selectors.bug_is_testable(427, self.cfg.pulp_version):
+        if selectors.bug_is_fixed(427, self.cfg.pulp_version):
             with self.subTest():
                 self.assertNotEqual(proc.returncode, 0)
         with self.subTest():

--- a/pulp_smash/tests/pulp2/ostree/api_v2/test_crud.py
+++ b/pulp_smash/tests/pulp2/ostree/api_v2/test_crud.py
@@ -126,7 +126,7 @@ class CreateDistributorsTestCase(BaseAPITestCase):
         path is ``foo/bar``, then this relative path would be ``foo/bar``.
         """
         if (self.cfg.pulp_version >= Version('2.14') and
-                selectors.bug_is_untestable(2769, self.cfg.pulp_version)):
+                not selectors.bug_is_fixed(2769, self.cfg.pulp_version)):
             self.skipTest('https://pulp.plan.io/issues/2769')
         client = api.Client(self.cfg, api.json_handler)
         path = urljoin(self.repos[1]['_href'], 'distributors/')
@@ -143,7 +143,7 @@ class CreateDistributorsTestCase(BaseAPITestCase):
         path is ``foo/bar``, then this relative path would be ``foo/bar/biz``.
         """
         if (self.cfg.pulp_version >= Version('2.14') and
-                selectors.bug_is_untestable(2769, self.cfg.pulp_version)):
+                not selectors.bug_is_fixed(2769, self.cfg.pulp_version)):
             self.skipTest('https://pulp.plan.io/issues/2769')
         client = api.Client(self.cfg, api.json_handler)
         path = urljoin(self.repos[1]['_href'], 'distributors/')
@@ -162,7 +162,7 @@ class CreateDistributorsTestCase(BaseAPITestCase):
         ``/foo/bar``.
         """
         if (self.cfg.pulp_version >= Version('2.14') and
-                selectors.bug_is_untestable(2769, self.cfg.pulp_version)):
+                not selectors.bug_is_fixed(2769, self.cfg.pulp_version)):
             self.skipTest('https://pulp.plan.io/issues/2769')
         client = api.Client(self.cfg, api.json_handler)
         path = urljoin(self.repos[1]['_href'], 'distributors/')
@@ -254,7 +254,7 @@ class UpdateDistributorsTestCase(BaseAPITestCase):
         path is ``foo/bar``, then this relative path would be ``foo/bar``.
         """
         if (self.cfg.pulp_version >= Version('2.14') and
-                selectors.bug_is_untestable(2769, self.cfg.pulp_version)):
+                not selectors.bug_is_fixed(2769, self.cfg.pulp_version)):
             self.skipTest('https://pulp.plan.io/issues/2769')
 
         # update
@@ -280,7 +280,7 @@ class UpdateDistributorsTestCase(BaseAPITestCase):
         path is ``foo/bar``, then this relative path would be ``foo/bar/biz``.
         """
         if (self.cfg.pulp_version >= Version('2.14') and
-                selectors.bug_is_untestable(2769, self.cfg.pulp_version)):
+                not selectors.bug_is_fixed(2769, self.cfg.pulp_version)):
             self.skipTest('https://pulp.plan.io/issues/2769')
 
         # update
@@ -310,7 +310,7 @@ class UpdateDistributorsTestCase(BaseAPITestCase):
         ``/foo/bar``.
         """
         if (self.cfg.pulp_version >= Version('2.14') and
-                selectors.bug_is_untestable(2769, self.cfg.pulp_version)):
+                not selectors.bug_is_fixed(2769, self.cfg.pulp_version)):
             self.skipTest('https://pulp.plan.io/issues/2769')
 
         # update
@@ -351,7 +351,7 @@ class UpdateImportersTestCase(unittest.TestCase):
         3. Perform assertions about the just updated ``importer``.
         """
         cfg = config.get_config()
-        if selectors.bug_is_untestable(3210, cfg.pulp_version):
+        if not selectors.bug_is_fixed(3210, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/3210')
         client = api.Client(cfg, api.json_handler)
         body = gen_repo()

--- a/pulp_smash/tests/pulp2/ostree/api_v2/test_sync.py
+++ b/pulp_smash/tests/pulp2/ostree/api_v2/test_sync.py
@@ -97,7 +97,7 @@ class SyncTestCase(_SyncMixin, BaseAPITestCase):
     def setUpClass(cls):
         """Create an OSTree repository with a valid feed and branch."""
         super(SyncTestCase, cls).setUpClass()
-        if selectors.bug_is_untestable(1934, cls.cfg.pulp_version):
+        if not selectors.bug_is_fixed(1934, cls.cfg.pulp_version):
             raise unittest.SkipTest('https://pulp.plan.io/issues/1934')
         body = gen_repo()
         body['importer_config']['feed'] = OSTREE_FEED

--- a/pulp_smash/tests/pulp2/platform/api_v2/test_login.py
+++ b/pulp_smash/tests/pulp2/platform/api_v2/test_login.py
@@ -151,6 +151,6 @@ class LoginTestCase(unittest.TestCase):
         # The `version` attribute should correspond to the version of the Pulp
         # server under test. This block of code says "if bug 1412 is not fixed
         # in Pulp version X, then skip this test."
-        if selectors.bug_is_testable(1412, cfg.pulp_version):
+        if selectors.bug_is_fixed(1412, cfg.pulp_version):
             with self.subTest(comment='check response body'):
                 self.assertEqual(frozenset(response.json().keys()), ERROR_KEYS)

--- a/pulp_smash/tests/pulp2/platform/api_v2/test_repository.py
+++ b/pulp_smash/tests/pulp2/platform/api_v2/test_repository.py
@@ -18,10 +18,9 @@ from urllib.parse import urljoin, urlparse
 
 from packaging.version import Version
 
-from pulp_smash import api, utils
+from pulp_smash import api, selectors, utils
 from pulp_smash.pulp2.constants import REPOSITORY_PATH, ERROR_KEYS
 from pulp_smash.pulp2.utils import BaseAPITestCase
-from pulp_smash.selectors import bug_is_untestable, require
 from pulp_smash.tests.pulp2.platform.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
@@ -56,7 +55,7 @@ class CreateSuccessTestCase(BaseAPITestCase):
             with self.subTest(body=body):
                 self.assertEqual(response.status_code, 201)
 
-    @require('2.7')  # https://pulp.plan.io/issues/695
+    @selectors.require('2.7')  # https://pulp.plan.io/issues/695
     def test_location_header(self):
         """Assert the Location header is correctly set in each response.
 
@@ -161,7 +160,7 @@ class CreateFailureTestCase(BaseAPITestCase):
         """Assert the JSON body returned contains the correct keys."""
         for body, response in zip(self.bodies, self.responses):
             with self.subTest(body=body):
-                if bug_is_untestable(1413, self.cfg.pulp_version):
+                if not selectors.bug_is_fixed(1413, self.cfg.pulp_version):
                     self.skipTest('https://pulp.plan.io/issues/1413')
                 response_keys = frozenset(response.json().keys())
                 self.assertEqual(response_keys, ERROR_KEYS)

--- a/pulp_smash/tests/pulp2/platform/api_v2/test_search.py
+++ b/pulp_smash/tests/pulp2/platform/api_v2/test_search.py
@@ -148,7 +148,7 @@ class FieldTestCase(_BaseTestCase):
     def setUpClass(cls):
         """Create one user. Execute searches."""
         super(FieldTestCase, cls).setUpClass()
-        if selectors.bug_is_untestable(1933, cls.cfg.pulp_version):
+        if not selectors.bug_is_fixed(1933, cls.cfg.pulp_version):
             raise unittest.SkipTest('https://pulp.plan.io/issues/1933')
         client = api.Client(cls.cfg)
         cls.searches = {
@@ -180,7 +180,7 @@ class FieldsTestCase(_BaseTestCase):
     def setUpClass(cls):
         """Create one user. Execute searches."""
         super(FieldsTestCase, cls).setUpClass()
-        if selectors.bug_is_untestable(1933, cls.cfg.pulp_version):
+        if not selectors.bug_is_fixed(1933, cls.cfg.pulp_version):
             raise unittest.SkipTest('https://pulp.plan.io/issues/1933')
         client = api.Client(cls.cfg)
         cls.searches = {

--- a/pulp_smash/tests/pulp2/platform/cli/test_pulp_manage_db.py
+++ b/pulp_smash/tests/pulp2/platform/cli/test_pulp_manage_db.py
@@ -45,7 +45,7 @@ class BaseTestCase(unittest.TestCase):
         if inspect.getmro(cls)[0] == BaseTestCase:
             raise unittest.SkipTest('Abstract base class.')
         cls.cfg = config.get_config()
-        if selectors.bug_is_untestable(2186, cls.cfg.pulp_version):
+        if not selectors.bug_is_fixed(2186, cls.cfg.pulp_version):
             raise unittest.SkipTest('https://pulp.plan.io/issues/2186')
         cls.cmd = () if utils.is_root(cls.cfg) else ('sudo',)
         cls.cmd += (
@@ -74,7 +74,7 @@ class PositiveTestCase(BaseTestCase):
 
     def test_dry_run(self):
         """Make sure pulp-manage-db runs if --dry-run is passed."""
-        if selectors.bug_is_untestable(2776, self.cfg.pulp_version):
+        if not selectors.bug_is_fixed(2776, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2776')
         cmd = () if utils.is_root(self.cfg) else ('sudo',)
         cmd += (
@@ -108,7 +108,7 @@ class NegativeTestCase(BaseTestCase):
 
         This test targets `Pulp #2684 <https://pulp.plan.io/issues/2684>`_.
         """
-        if selectors.bug_is_untestable(2684, self.cfg.pulp_version):
+        if not selectors.bug_is_fixed(2684, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2684')
         cli.GlobalServiceManager(config.get_config()).stop((
             CONFLICTING_SERVICES.difference(('pulp_resource_manager',))
@@ -120,7 +120,7 @@ class NegativeTestCase(BaseTestCase):
 
         This test targets `Pulp #2684 <https://pulp.plan.io/issues/2684>`_.
         """
-        if selectors.bug_is_untestable(2684, self.cfg.pulp_version):
+        if not selectors.bug_is_fixed(2684, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2684')
         cli.GlobalServiceManager(config.get_config()).stop((
             CONFLICTING_SERVICES.difference(('pulp_workers',))

--- a/pulp_smash/tests/pulp2/platform/cli/test_selinux.py
+++ b/pulp_smash/tests/pulp2/platform/cli/test_selinux.py
@@ -181,7 +181,7 @@ class FileLabelsTestCase(unittest.TestCase):
             ('/usr/share/pulp/wsgi', ':object_r:httpd_sys_content_t:s0'),
             ('/var/log/pulp', ':object_r:httpd_sys_rw_content_t:s0'),
         ]
-        if selectors.bug_is_testable(2508, config.get_config().pulp_version):
+        if selectors.bug_is_fixed(2508, config.get_config().pulp_version):
             files_labels.append(
                 ('/var/lib/pulp', ':object_r:httpd_sys_rw_content_t:s0')
             )

--- a/pulp_smash/tests/pulp2/puppet/api_v2/test_install_distributor.py
+++ b/pulp_smash/tests/pulp2/puppet/api_v2/test_install_distributor.py
@@ -36,7 +36,7 @@ class InstallDistributorTestCase(BaseAPITestCase):
         3. Publish the repository
         4. Check if the puppet_install_distributor config was properly used
         """
-        if (selectors.bug_is_untestable(3314, self.cfg.pulp_version) and
+        if (not selectors.bug_is_fixed(3314, self.cfg.pulp_version) and
                 utils.os_is_f27(self.cfg)):
             self.skipTest('https://pulp.plan.io/issues/3314')
         cli_client = cli.Client(self.cfg)
@@ -90,7 +90,7 @@ class InstallDistributorThrowsOnErrorTestCase(BaseAPITestCase):
         3. Assert that an error is thrown
         4. Assert that no repo is created
         """
-        if selectors.bug_is_untestable(1237, self.cfg.pulp_version):
+        if not selectors.bug_is_fixed(1237, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/1237')
         distributor = gen_install_distributor()
         distributor['distributor_config']['install_path'] = ''

--- a/pulp_smash/tests/pulp2/puppet/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/pulp2/puppet/api_v2/test_sync_publish.py
@@ -104,7 +104,7 @@ class SyncValidFeedTestCase(BaseAPITestCase):
           yields one result.
         * The synced-in module can be downloaded.
         """
-        if selectors.bug_is_untestable(3692, self.cfg.pulp_version):
+        if not selectors.bug_is_fixed(3692, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/3692')
 
         # Create and sync a repository.
@@ -233,7 +233,7 @@ class SyncNoFeedTestCase(BaseAPITestCase):
     def test_all(self):
         """Create and sync a puppet repository with no feed."""
         cfg = config.get_config()
-        if selectors.bug_is_untestable(2628, cfg.pulp_version):
+        if not selectors.bug_is_fixed(2628, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2628')
 
         # Create a repository.
@@ -380,7 +380,7 @@ class PublishTestCase(BaseAPITestCase):
         cls.responses['puppet releases'] = []
         author_name = PUPPET_MODULE_1['author'] + '/' + PUPPET_MODULE_1['name']
         for repo in repos:
-            if selectors.bug_is_untestable(1440, cls.cfg.pulp_version):
+            if not selectors.bug_is_fixed(1440, cls.cfg.pulp_version):
                 continue
             cls.responses['puppet releases'].append(client.get(
                 '/api/v1/releases.json',

--- a/pulp_smash/tests/pulp2/puppet/cli/test_sync.py
+++ b/pulp_smash/tests/pulp2/puppet/cli/test_sync.py
@@ -14,7 +14,7 @@ def setUpModule():  # pylint:disable=invalid-name
     See `Pulp #2574 <https://pulp.plan.io/issues/2574>`_.
     """
     set_up_module()
-    if selectors.bug_is_untestable(2574, config.get_config()):
+    if not selectors.bug_is_fixed(2574, config.get_config()):
         raise unittest.SkipTest('https://pulp.plan.io/issues/2574')
 
 
@@ -72,7 +72,7 @@ class SyncDownloadedContentTestCase(unittest.TestCase):
         non-zero content unit counts.
         """
         cfg = config.get_config()
-        if selectors.bug_is_untestable(1937, cfg.pulp_version):
+        if not selectors.bug_is_fixed(1937, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/1937')
         pulp_admin_login(cfg)
 

--- a/pulp_smash/tests/pulp2/python/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/pulp2/python/api_v2/test_sync_publish.py
@@ -73,7 +73,7 @@ class BaseTestCase(unittest.TestCase):
         completely independent Pulp application.
         """
         if (self.cfg.pulp_version < Version('2.13') or
-                selectors.bug_is_untestable(140, self.cfg.pulp_version)):
+                not selectors.bug_is_fixed(140, self.cfg.pulp_version)):
             self.skipTest('https://pulp.plan.io/issues/140')
         client = api.Client(self.cfg, api.json_handler)
         body = gen_repo()
@@ -128,7 +128,7 @@ class SyncTestCase(BaseTestCase):
         * `Pulp Smash #494 <https://github.com/PulpQE/pulp-smash/issues/494>`_
         """
         if (self.cfg.pulp_version < Version('2.13') or
-                selectors.bug_is_untestable(135, self.cfg.pulp_version)):
+                not selectors.bug_is_fixed(135, self.cfg.pulp_version)):
             self.skipTest('https://pulp.plan.io/issues/135')
         client = api.Client(self.cfg, api.json_handler)
         body = gen_repo()
@@ -161,7 +161,7 @@ class UploadTestCase(BaseTestCase):
         * `Pulp Smash #492 <https://github.com/PulpQE/pulp-smash/issues/492>`_
         """
         if (self.cfg.pulp_version < Version('2.13') or
-                selectors.bug_is_untestable(136, self.cfg.pulp_version)):
+                not selectors.bug_is_fixed(136, self.cfg.pulp_version)):
             self.skipTest('https://pulp.plan.io/issues/136')
         client = api.Client(self.cfg, api.json_handler)
         body = gen_repo()

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_broker.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_broker.py
@@ -104,10 +104,10 @@ class BrokerTestCase(unittest.TestCase):
         * `Pulp #1635 <https://pulp.plan.io/issues/1635>`_
         * `Pulp #2613 <https://pulp.plan.io/issues/2613>`_
         """
-        if selectors.bug_is_untestable(1635, self.cfg.pulp_version):
+        if not selectors.bug_is_fixed(1635, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/1635')
         if (self.cfg.pulp_version >= Version('2.13') and
-                selectors.bug_is_untestable(2613, self.cfg.pulp_version)):
+                not selectors.bug_is_fixed(2613, self.cfg.pulp_version)):
             self.skipTest('https://pulp.plan.io/issues/2613')
         # We assume that the broker and other services are already running. As
         # a result, we skip step 1 and go straight to step 2.

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_character_encoding.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_character_encoding.py
@@ -53,7 +53,7 @@ class UploadNonUtf8TestCase(unittest.TestCase):
     def test_all(self):
         """Test whether one can upload an RPM with non-ascii metadata."""
         cfg = config.get_config()
-        if selectors.bug_is_untestable(1903, cfg.pulp_version):
+        if not selectors.bug_is_fixed(1903, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/1903')
         client = api.Client(cfg, api.json_handler)
         repo = client.post(REPOSITORY_PATH, gen_repo())

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_comps_xml.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_comps_xml.py
@@ -328,7 +328,7 @@ class UploadPackageGroupsTestCase(BaseAPITestCase):
 
     def test_display_order_occurences(self):
         """Assert ``display_order`` occurs once if omitted from the unit."""
-        if selectors.bug_is_untestable(1787, self.cfg.pulp_version):
+        if not selectors.bug_is_fixed(1787, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/1787')
         input_id = self.package_groups['minimal']['id']
         output = _get_groups_by_id(self.root_element)[input_id]
@@ -340,7 +340,7 @@ class UploadPackageGroupsTestCase(BaseAPITestCase):
         This test may be skipped if `Pulp #1787
         <https://pulp.plan.io/issues/1787>`_ is open.
         """
-        if selectors.bug_is_untestable(1787, self.cfg.pulp_version):
+        if not selectors.bug_is_fixed(1787, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/1787')
         input_id = self.package_groups['minimal']['id']
         output = _get_groups_by_id(self.root_element)[input_id]

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_content_sources.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_content_sources.py
@@ -30,7 +30,7 @@ class ValidHeadersTestCase(unittest.TestCase):
     def setUpClass(cls):
         """Create a content source with valid headers."""
         cls.cfg = config.get_config()
-        if selectors.bug_is_untestable(1282, cls.cfg.pulp_version):
+        if not selectors.bug_is_fixed(1282, cls.cfg.pulp_version):
             raise unittest.SkipTest('https://pulp.plan.io/issues/1282')
         cls.cs_kwargs = {
             'source_id': utils.uuid4(),
@@ -88,7 +88,7 @@ class InvalidHeadersTestCase(unittest.TestCase):
     def setUpClass(cls):
         """Create a content source with invalid headers."""
         cls.cfg = config.get_config()
-        if selectors.bug_is_untestable(1282, cls.cfg.pulp_version):
+        if not selectors.bug_is_fixed(1282, cls.cfg.pulp_version):
             raise unittest.SkipTest('https://pulp.plan.io/issues/1282')
         cls.cs_kwargs = {
             'source_id': utils.uuid4(),

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_copy.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_copy.py
@@ -45,7 +45,7 @@ class CopyErrataRecursiveTestCase(unittest.TestCase):
         4. Assert that RPM packages were copied.
         """
         cfg = config.get_config()
-        if selectors.bug_is_untestable(3004, cfg.pulp_version):
+        if not selectors.bug_is_fixed(3004, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/3004')
 
         repos = []
@@ -94,7 +94,7 @@ class MtimeTestCase(unittest.TestCase):
            are the same.
         """
         cfg = config.get_config()
-        if selectors.bug_is_untestable(2783, cfg.pulp_version):
+        if not selectors.bug_is_fixed(2783, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2783')
 
         # Create, sync and publish a repository.

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_crud.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_crud.py
@@ -275,7 +275,7 @@ class LastUnitAddedTestCase(BaseAPITestCase):
         4. Publish the second repository. Assert its ``last_unit_added``
            attribute is non-null.
         """
-        if selectors.bug_is_untestable(2688, self.cfg.pulp_version):
+        if not selectors.bug_is_fixed(2688, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2688')
 
         # create a repo with a feed and sync it

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_download_policies.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_download_policies.py
@@ -41,15 +41,15 @@ def setUpModule():  # pylint:disable=invalid-name
     if cfg.pulp_version < Version('2.8'):
         raise unittest.SkipTest('This module requires Pulp 2.8 or greater.')
     if (utils.os_is_f26(cfg) and
-            selectors.bug_is_untestable(3036, cfg.pulp_version)):
+            not selectors.bug_is_fixed(3036, cfg.pulp_version)):
         raise unittest.SkipTest('https://pulp.plan.io/issues/3036')
     if check_issue_2798(cfg):
         raise unittest.SkipTest('https://pulp.plan.io/issues/2798')
     if check_issue_2387(cfg):
         raise unittest.SkipTest('https://pulp.plan.io/issues/2387')
-    if selectors.bug_is_untestable(2272, cfg.pulp_version):
+    if not selectors.bug_is_fixed(2272, cfg.pulp_version):
         raise unittest.SkipTest('https://pulp.plan.io/issues/2272')
-    if selectors.bug_is_untestable(2144, cfg.pulp_version):
+    if not selectors.bug_is_fixed(2144, cfg.pulp_version):
         raise unittest.SkipTest('https://pulp.plan.io/issues/2144')
 
 
@@ -86,7 +86,7 @@ class BackgroundTestCase(BaseAPITestCase):
         super(BackgroundTestCase, cls).setUpClass()
         if check_issue_3104(cls.cfg):
             raise unittest.SkipTest('https://pulp.plan.io/issues/3104')
-        if (selectors.bug_is_untestable(1905, cls.cfg.pulp_version) and
+        if (not selectors.bug_is_fixed(1905, cls.cfg.pulp_version) and
                 os_is_rhel6(cls.cfg)):
             raise unittest.SkipTest('https://pulp.plan.io/issues/1905')
 
@@ -214,7 +214,7 @@ class OnDemandTestCase(BaseAPITestCase):
 
     def test_rpm_cache_control_header(self):
         """Assert the request has the Cache-Control header set."""
-        if selectors.bug_is_untestable(2587, self.cfg.pulp_version):
+        if not selectors.bug_is_fixed(2587, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2587')
         key = 'Cache-Control'
         headers = self.rpm.headers
@@ -233,7 +233,7 @@ class OnDemandTestCase(BaseAPITestCase):
 
     def test_same_rpm_cache_header(self):
         """Assert the second request resulted in a cache hit from Squid."""
-        if selectors.bug_is_untestable(2587, self.cfg.pulp_version):
+        if not selectors.bug_is_fixed(2587, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2587')
         headers = self.same_rpm.headers
         self.assertIn('HIT', headers['X-Cache-Lookup'], headers)
@@ -257,7 +257,7 @@ class FixFileCorruptionTestCase(BaseAPITestCase):
         7. Trigger a repository download, with unit verification.
         """
         super(FixFileCorruptionTestCase, cls).setUpClass()
-        if (selectors.bug_is_untestable(1905, cls.cfg.pulp_version) and
+        if (not selectors.bug_is_fixed(1905, cls.cfg.pulp_version) and
                 os_is_rhel6(cls.cfg)):
             raise unittest.SkipTest('https://pulp.plan.io/issues/1905')
 
@@ -513,7 +513,7 @@ class SwitchPoliciesTestCase(BaseAPITestCase):
 
     def test_background_to_on_demand(self):
         """Check if switching from background to on_demand works."""
-        if selectors.bug_is_untestable(2587, self.cfg.pulp_version):
+        if not selectors.bug_is_fixed(2587, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2587')
         repo, _ = self.repository_setup('background', 'on_demand')
         self.assert_on_demand(repo)
@@ -525,7 +525,7 @@ class SwitchPoliciesTestCase(BaseAPITestCase):
 
     def test_immediate_to_on_demand(self):
         """Check if switching from immediate to on_demand works."""
-        if selectors.bug_is_untestable(2587, self.cfg.pulp_version):
+        if not selectors.bug_is_fixed(2587, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2587')
         repo, _ = self.repository_setup('immediate', 'on_demand')
         self.assert_on_demand(repo)

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_duplicate_uploads.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_duplicate_uploads.py
@@ -29,7 +29,7 @@ class DuplicateUploadsTestCase(unittest.TestCase):
         * `Pulp Smash #81 <https://github.com/PulpQE/pulp-smash/issues/81>`_
         * `Pulp #1406 <https://pulp.plan.io/issues/1406>`_
         """
-        if selectors.bug_is_untestable(1406, self.cfg.pulp_version):
+        if not selectors.bug_is_fixed(1406, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/1406')
         self.do_test(RPM_UNSIGNED_URL, 'rpm', gen_repo())
 
@@ -41,7 +41,7 @@ class DuplicateUploadsTestCase(unittest.TestCase):
         * `Pulp Smash #582 <https://github.com/PulpQE/pulp-smash/issues/582>`_
         * `Pulp #2274 <https://pulp.plan.io/issues/2274>`_
         """
-        if selectors.bug_is_untestable(2274, self.cfg.pulp_version):
+        if not selectors.bug_is_fixed(2274, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2274')
         body = {
             'id': utils.uuid4(),

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_errata.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_errata.py
@@ -127,7 +127,7 @@ class LargePackageListTestCase(unittest.TestCase):
            errors.
         """
         cfg = config.get_config()
-        if selectors.bug_is_untestable(2681, cfg.pulp_version):
+        if not selectors.bug_is_fixed(2681, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2681')
         repos = []
         client = api.Client(cfg, api.json_handler)

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_export.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_export.py
@@ -421,7 +421,7 @@ class ExportDistributorTestCase(ExportDirMixin, BaseAPITestCase):
         cls.resources.add(cls.repo['_href'])
         sync_repo(cls.cfg, cls.repo)
         if (cls.cfg.pulp_version >= Version('2.9') and
-                selectors.bug_is_untestable(1928, cls.cfg.pulp_version)):
+                not selectors.bug_is_fixed(1928, cls.cfg.pulp_version)):
             cls.distributor = None
         else:
             cls.distributor = _create_distributor(

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_force_full.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_force_full.py
@@ -77,7 +77,7 @@ class ForceFullTestCase(BaseAPITestCase):
         .. _Pulp #1966: https://pulp.plan.io/issues/1966
         """
         if (self.cfg.pulp_version >= Version('2.9') and
-                selectors.bug_is_untestable(1966, self.cfg.pulp_version)):
+                not selectors.bug_is_fixed(1966, self.cfg.pulp_version)):
             self.skipTest('https://pulp.plan.io/issues/1966')
         call_report = publish_repo(self.cfg, self.repo).json()
         last_task = next(api.poll_spawned_tasks(self.cfg, call_report))

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_iso_crud.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_iso_crud.py
@@ -207,7 +207,7 @@ class ReadUpdateDeleteTestCase(BaseAPITestCase):
     def test_read_distributors(self):
         """Assert each read w/distributors contains info about distributors."""
         if (self.cfg.pulp_version < Version('2.8') and
-                selectors.bug_is_untestable(1452, self.cfg.pulp_version)):
+                not selectors.bug_is_fixed(1452, self.cfg.pulp_version)):
             self.skipTest('https://pulp.plan.io/issues/1452')
         for key in {'read_distributors', 'read_details'}:
             with self.subTest(key=key):
@@ -246,7 +246,7 @@ class AddImporterDistributorTestCase(BaseAPITestCase):
         """
         super(AddImporterDistributorTestCase, cls).setUpClass()
         if (cls.cfg.pulp_version >= Version('2.10') and
-                selectors.bug_is_untestable(2082, cls.cfg.pulp_version)):
+                not selectors.bug_is_fixed(2082, cls.cfg.pulp_version)):
             raise SkipTest('https://pulp.plan.io/issues/2082')
 
         # Steps 1 and 2.
@@ -400,7 +400,7 @@ class ISOUpdateTestCase(unittest.TestCase):
         """
         cfg = config.get_config()
         for issue_id in (2773, 3047, 3100):
-            if selectors.bug_is_untestable(issue_id, cfg.pulp_version):
+            if not selectors.bug_is_fixed(issue_id, cfg.pulp_version):
                 self.skipTest('https://pulp.plan.io/issues/' + str(issue_id))
 
         # Step 1

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_iso_sync_publish.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_iso_sync_publish.py
@@ -53,9 +53,9 @@ class ServeHttpsFalseTestCase(TemporaryUserMixin, unittest.TestCase):
 
     def test_all(self):
         """Publish w/an rsync distributor when ``serve_https`` is false."""
-        if selectors.bug_is_untestable(2657, self.cfg.pulp_version):
+        if not selectors.bug_is_fixed(2657, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2657')
-        if (selectors.bug_is_untestable(3313, self.cfg.pulp_version) and
+        if (not selectors.bug_is_fixed(3313, self.cfg.pulp_version) and
                 utils.os_is_f27(self.cfg)):
             self.skipTest('https://pulp.plan.io/issues/3313')
 

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_mirrorlist.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_mirrorlist.py
@@ -50,7 +50,7 @@ def setUpModule():  # pylint:disable=invalid-name
     set_up_module()
     cfg = config.get_config()
     if (cfg.pulp_version >= Version('2.15.1') and
-            selectors.bug_is_untestable(3310, cfg.pulp_version)):
+            not selectors.bug_is_fixed(3310, cfg.pulp_version)):
         raise unittest.SkipTest('https://pulp.plan.io/issues/3310')
 
 
@@ -103,7 +103,7 @@ class UtilsMixin():
         .. _issue #2321: https://pulp.plan.io/issues/2321
         """
         if (cfg.pulp_version >= Version('2.11') and
-                selectors.bug_is_untestable(2321, cfg.pulp_version)):
+                not selectors.bug_is_fixed(2321, cfg.pulp_version)):
             self.skipTest('https://pulp.plan.io/issues/2321')
 
     def check_issue_2326(self, cfg):
@@ -112,7 +112,7 @@ class UtilsMixin():
         .. _issue #2326: https://pulp.plan.io/issues/2326
         """
         if (cfg.pulp_version >= Version('2.11') and
-                selectors.bug_is_untestable(2326, cfg.pulp_version)):
+                not selectors.bug_is_fixed(2326, cfg.pulp_version)):
             self.skipTest('https://pulp.plan.io/issues/2326')
 
     def check_issue_2363(self, cfg):
@@ -121,7 +121,7 @@ class UtilsMixin():
         .. _issue #2363: https://pulp.plan.io/issues/2363
         """
         if (cfg.pulp_version >= Version('2.11') and
-                selectors.bug_is_untestable(2363, cfg.pulp_version)):
+                not selectors.bug_is_fixed(2363, cfg.pulp_version)):
             self.skipTest('https://pulp.plan.io/issues/2363')
 
 

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_orphan_remove.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_orphan_remove.py
@@ -129,7 +129,7 @@ class OrphansTestCase(unittest.TestCase):
         call_report = client.delete(urljoin(ORPHANS_PATH, 'erratum/'))
         orphans_post = client.get(ORPHANS_PATH)
         with self.subTest(comment='verify "result" field'):
-            if selectors.bug_is_untestable(1268, cfg.pulp_version):
+            if not selectors.bug_is_fixed(1268, cfg.pulp_version):
                 self.skipTest('https://pulp.plan.io/issues/1268')
             task = tuple(api.poll_spawned_tasks(cfg, call_report))[-1]
             self.assertIsInstance(task['result'], int)
@@ -147,7 +147,7 @@ class OrphansTestCase(unittest.TestCase):
         """Delete all orphans."""
         cfg = config.get_config()
         call_report = api.Client(cfg).delete(ORPHANS_PATH).json()
-        if selectors.bug_is_untestable(1268, cfg.pulp_version):
+        if not selectors.bug_is_fixed(1268, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/1268')
         task = tuple(api.poll_spawned_tasks(cfg, call_report))[-1]
         self.assertIsInstance(task['result'], dict)

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_package_paths.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_package_paths.py
@@ -83,7 +83,7 @@ class ReuseContentTestCase(unittest.TestCase):
         if check_issue_2354(cfg):
             self.skipTest('https://pulp.plan.io/issues/2354')
         if (utils.os_is_f26(cfg) and
-                selectors.bug_is_untestable(3036, cfg.pulp_version)):
+                not selectors.bug_is_fixed(3036, cfg.pulp_version)):
             # Here, the calls to get_unit() cause pulp_streamer.service to die
             # without logging out anything. In Pulp #3036, certain actions
             # cause pulp_streamer.service to die while logging out a core dump.

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_remove_unit.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_remove_unit.py
@@ -202,7 +202,7 @@ class RemoveCountTestCase(unittest.TestCase):
         """Re-sync a child repository with the ``remove_missing`` enabled."""
         repos = []
         cfg = config.get_config()
-        if selectors.bug_is_untestable(2616, cfg.pulp_version):
+        if not selectors.bug_is_fixed(2616, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2616')
 
         # Create 1st repo, sync and publish it.

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_repomd.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_repomd.py
@@ -107,7 +107,7 @@ class FastForwardIntegrityTestCase(unittest.TestCase):
     def test_all(self):
         """Ensure fast-forward publishes use files referenced by repomd.xml."""
         cfg = config.get_config()
-        if selectors.bug_is_untestable(1088, cfg.pulp_version):
+        if not selectors.bug_is_fixed(1088, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/1088')
         repo = self._create_sync_repo(cfg)
         old_phrase = 'A dummy package of'

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_repoview.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_repoview.py
@@ -76,7 +76,7 @@ class RepoviewTestCase(unittest.TestCase):
             )
 
         # Publish the repo a third time
-        if selectors.bug_is_untestable(2349, cfg.pulp_version):
+        if not selectors.bug_is_fixed(2349, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2349')
         publish_repo(cfg, repo)
         response = client.get(pub_path)

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_republish.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_republish.py
@@ -111,7 +111,7 @@ class RemoveOldRepodataTestCase(unittest.TestCase):
 
         Assert that there are more metadata files after the second publish.
         """
-        if selectors.bug_is_untestable(2788, self.cfg.pulp_version):
+        if not selectors.bug_is_fixed(2788, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2788')
         found = self.do_test({
             'generate_sqlite': True,
@@ -127,7 +127,7 @@ class RemoveOldRepodataTestCase(unittest.TestCase):
         Assert that there are the same number of metadata files after the
         second publish.
         """
-        if selectors.bug_is_untestable(2788, self.cfg.pulp_version):
+        if not selectors.bug_is_fixed(2788, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2788')
         found = self.do_test({
             'generate_sqlite': True,
@@ -141,7 +141,7 @@ class RemoveOldRepodataTestCase(unittest.TestCase):
 
         Assert there are more metadata files after the second publish.
         """
-        if selectors.bug_is_untestable(2788, self.cfg.pulp_version):
+        if not selectors.bug_is_fixed(2788, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2788')
         found = self.do_test({
             'generate_sqlite': True,

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_rsync_distributor.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_rsync_distributor.py
@@ -101,9 +101,9 @@ def setUpModule():  # pylint:disable=invalid-name
     """
     set_up_module()
     cfg = config.get_config()
-    if selectors.bug_is_untestable(1759, cfg.pulp_version):
+    if not selectors.bug_is_fixed(1759, cfg.pulp_version):
         raise unittest.SkipTest('https://pulp.plan.io/issues/1759')
-    if (selectors.bug_is_untestable(3313, cfg.pulp_version) and
+    if (not selectors.bug_is_fixed(3313, cfg.pulp_version) and
             utils.os_is_f27(cfg)):
         raise unittest.SkipTest('https://pulp.plan.io/issues/3313')
     if cfg.pulp_selinux_enabled:
@@ -272,7 +272,7 @@ class PublishBeforeYumDistTestCase(
     def test_all(self):
         """Publish the rpm rsync distributor before the yum distributor."""
         cfg = config.get_config()
-        if selectors.bug_is_untestable(2187, cfg.pulp_version):
+        if not selectors.bug_is_fixed(2187, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2187')
 
         # Create a user and a repository.
@@ -295,7 +295,7 @@ class PublishBeforeYumDistTestCase(
         self.assertNotIn('content', dirs)
 
         # Publish with the rsync distributor again, and verify again.
-        if selectors.bug_is_testable(2722, cfg.pulp_version):
+        if selectors.bug_is_fixed(2722, cfg.pulp_version):
             self.verify_publish_is_skip(cfg, publish_repo(*args).json())
             dirs = self.remote_root_files(cfg,
                                           distribs['rpm_rsync_distributor'])
@@ -373,7 +373,7 @@ class ForceFullTestCase(
 
         # Publish the repo with ``force_full`` set to true. Verify that the RPM
         # rsync distributor placed files.
-        if selectors.bug_is_untestable(2202, cfg.pulp_version):
+        if not selectors.bug_is_fixed(2202, cfg.pulp_version):
             return
         publish_repo(cfg, repo, {
             'id': distribs['rpm_rsync_distributor']['id'],
@@ -435,7 +435,7 @@ class VerifyOptionsTestCase(_RsyncDistUtilsMixin, unittest.TestCase):
 
     def test_predistributor_id(self):
         """Pass a bogus ID as the ``predistributor_id`` config option."""
-        if selectors.bug_is_untestable(2191, self.cfg.pulp_version):
+        if not selectors.bug_is_fixed(2191, self.cfg.pulp_version):
             raise self.skipTest('https://pulp.plan.io/issues/2191')
         api_client = api.Client(self.cfg, api.json_handler)
         body = gen_repo()
@@ -458,7 +458,7 @@ class VerifyOptionsTestCase(_RsyncDistUtilsMixin, unittest.TestCase):
 
     def test_root(self):
         """Pass a relative path to the ``root`` configuration option."""
-        if selectors.bug_is_untestable(2192, self.cfg.pulp_version):
+        if not selectors.bug_is_fixed(2192, self.cfg.pulp_version):
             raise self.skipTest('https://pulp.plan.io/issues/2192')
         remote = self.remote.copy()
         remote['root'] = remote['root'][1:]
@@ -557,7 +557,7 @@ class DeleteTestCase(
     def test_all(self):
         """Use the ``delete`` RPM rsync distributor option."""
         cfg = config.get_config()
-        if selectors.bug_is_untestable(2221, cfg.pulp_version):
+        if not selectors.bug_is_fixed(2221, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2221')
         api_client = api.Client(cfg)
 
@@ -653,7 +653,7 @@ class AddUnitTestCase(
     def test_all(self):
         """Add a content unit to a repo in the middle of several publishes."""
         cfg = config.get_config()
-        if selectors.bug_is_untestable(2532, cfg.pulp_version):
+        if not selectors.bug_is_fixed(2532, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2532')
         rpms = (
             utils.http_get(RPM_UNSIGNED_URL), utils.http_get(RPM2_UNSIGNED_URL)
@@ -706,7 +706,7 @@ class PublishTwiceTestCase(
     def test_all(self):
         """Publish with a yum and rsync distributor twice."""
         cfg = config.get_config()
-        if selectors.bug_is_untestable(2666, cfg.pulp_version):
+        if not selectors.bug_is_fixed(2666, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2666')
         if check_issue_2844(cfg):
             self.skipTest('https://pulp.plan.io/issues/2844')
@@ -789,7 +789,7 @@ class RsyncExtraArgsTestCase(
     def test_all(self):
         """Use the ``rsync_extra_args`` RPM rsync distributor option."""
         cfg = config.get_config()
-        if selectors.bug_is_untestable(3317, cfg.pulp_version):
+        if not selectors.bug_is_fixed(3317, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/3317')
 
         # Create a user and repo with an importer and distribs. Sync the repo.

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_service_resiliency.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_service_resiliency.py
@@ -47,7 +47,7 @@ class MissingWorkersTestCase(unittest.TestCase):
     def setUp(self):
         """Ensure there is only one Pulp worker."""
         self.cfg = config.get_config()
-        if selectors.bug_is_untestable(2835, self.cfg.pulp_version):
+        if not selectors.bug_is_fixed(2835, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2835')
         sudo = '' if utils.is_root(self.cfg) else 'sudo'
         cli.Client(self.cfg).machine.session().run(
@@ -109,7 +109,7 @@ class TaskDispatchTestCase(unittest.TestCase):
            so, and assert that no tasks are left in the ``waiting`` state.
         """
         cfg = config.get_config()
-        if selectors.bug_is_untestable(2770, cfg.pulp_version):
+        if not selectors.bug_is_fixed(2770, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2770')
 
         # Create a repository.

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_signatures_checked_for_copies.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_signatures_checked_for_copies.py
@@ -49,7 +49,7 @@ _UNSIGNED_PACKAGES = {}
 def setUpModule():  # pylint:disable=invalid-name
     """Conditionally skip tests. Create repositories with fixture data."""
     cfg = config.get_config()
-    if selectors.bug_is_untestable(1991, cfg.pulp_version):
+    if not selectors.bug_is_fixed(1991, cfg.pulp_version):
         raise unittest.SkipTest('https://pulp.plan.io/issues/1991')
     set_up_module()
 
@@ -58,7 +58,7 @@ def setUpModule():  # pylint:disable=invalid-name
     _SIGNED_PACKAGES['srpm'] = utils.http_get(SRPM_SIGNED_URL)
     _UNSIGNED_PACKAGES['rpm'] = utils.http_get(RPM_UNSIGNED_URL)
     _UNSIGNED_PACKAGES['srpm'] = utils.http_get(SRPM_UNSIGNED_URL)
-    if selectors.bug_is_testable(1806, cfg.pulp_version):
+    if selectors.bug_is_fixed(1806, cfg.pulp_version):
         _SIGNED_PACKAGES['drpm'] = utils.http_get(DRPM_SIGNED_URL)
         _UNSIGNED_PACKAGES['drpm'] = utils.http_get(DRPM_UNSIGNED_URL)
 

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_signatures_checked_for_syncs.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_signatures_checked_for_syncs.py
@@ -45,9 +45,9 @@ from pulp_smash.tests.pulp2.rpm.utils import set_up_module
 
 def setUpModule():  # pylint:disable=invalid-name
     """Conditionally skip tests."""
-    if selectors.bug_is_untestable(1991, config.get_config().pulp_version):
+    if not selectors.bug_is_fixed(1991, config.get_config().pulp_version):
         raise unittest.SkipTest('https://pulp.plan.io/issues/1991')
-    if selectors.bug_is_untestable(2242, config.get_config().pulp_version):
+    if not selectors.bug_is_fixed(2242, config.get_config().pulp_version):
         raise unittest.SkipTest('https://pulp.plan.io/issues/2242')
     set_up_module()
 

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_signatures_checked_for_uploads.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_signatures_checked_for_uploads.py
@@ -80,7 +80,7 @@ def setUpModule():  # pylint:disable=invalid-name
       version of Pulp under test.
     """
     cfg = config.get_config()
-    if selectors.bug_is_untestable(1991, cfg.pulp_version):
+    if not selectors.bug_is_fixed(1991, cfg.pulp_version):
         raise unittest.SkipTest('https://pulp.plan.io/issues/1991')
     set_up_module()
     try:
@@ -88,7 +88,7 @@ def setUpModule():  # pylint:disable=invalid-name
         _SIGNED_PACKAGES['srpm'] = utils.http_get(SRPM_SIGNED_URL)
         _UNSIGNED_PACKAGES['rpm'] = utils.http_get(RPM_UNSIGNED_URL)
         _UNSIGNED_PACKAGES['srpm'] = utils.http_get(SRPM_UNSIGNED_URL)
-        if selectors.bug_is_testable(1806, cfg.pulp_version):
+        if selectors.bug_is_fixed(1806, cfg.pulp_version):
             _SIGNED_PACKAGES['drpm'] = utils.http_get(DRPM_SIGNED_URL)
             _UNSIGNED_PACKAGES['drpm'] = utils.http_get(DRPM_UNSIGNED_URL)
     except:  # noqa:E722

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_signatures_saved_for_packages.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_signatures_saved_for_packages.py
@@ -68,7 +68,7 @@ class _BaseTestCase(unittest.TestCase):
         if inspect.getmro(cls)[0] == _BaseTestCase:
             raise unittest.SkipTest('Abstract base class.')
         cls.cfg = config.get_config()
-        if selectors.bug_is_untestable(1156, cls.cfg.pulp_version):
+        if not selectors.bug_is_fixed(1156, cls.cfg.pulp_version):
             raise unittest.SkipTest('https://pulp.plan.io/issues/1156')
         cls.client = api.Client(cls.cfg, api.json_handler)
 
@@ -129,7 +129,7 @@ class UploadPackageTestCase(_BaseTestCase):
 
     def test_signed_drpm(self):
         """Import a signed DRPM into Pulp. Verify its signature."""
-        if selectors.bug_is_untestable(1806, self.cfg.pulp_version):
+        if not selectors.bug_is_fixed(1806, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/1806')
         repo_href = self._create_repo_import_unit(DRPM_SIGNED_URL)
         unit = self._find_unit(repo_href, DRPM_SIGNED_URL)
@@ -153,7 +153,7 @@ class UploadPackageTestCase(_BaseTestCase):
 
     def test_unsigned_drpm(self):
         """Import an unsigned DRPM into Pulp. Verify it has no signature."""
-        if selectors.bug_is_untestable(1806, self.cfg.pulp_version):
+        if not selectors.bug_is_fixed(1806, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/1806')
         repo_href = self._create_repo_import_unit(DRPM_UNSIGNED_URL)
         unit = self._find_unit(repo_href, DRPM_UNSIGNED_URL)

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_sync_publish.py
@@ -389,14 +389,14 @@ class ErrorReportTestCase(unittest.TestCase):
         task = context.exception.task
 
         with self.subTest(comment='check task error description'):
-            if selectors.bug_is_untestable(1376, cfg.pulp_version):
+            if not selectors.bug_is_fixed(1376, cfg.pulp_version):
                 self.skipTest('https://pulp.plan.io/issues/1376')
             self.assertNotEqual(
                 'Unsupported scheme: ',
                 task['error']['description']
             )
         with self.subTest(comment='check task traceback'):
-            if selectors.bug_is_untestable(1455, cfg.pulp_version):
+            if not selectors.bug_is_fixed(1455, cfg.pulp_version):
                 self.skipTest('https://pulp.plan.io/issues/1455')
             self.assertIsNotNone(task['traceback'], task)
 

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_tasks.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_tasks.py
@@ -45,11 +45,11 @@ class TasksOperationsTestCase(unittest.TestCase):
         6. Purge tasks.
         """
         cfg = config.get_config()
-        if selectors.bug_is_untestable(1418, cfg.pulp_version):
+        if not selectors.bug_is_fixed(1418, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/1418')
-        if selectors.bug_is_untestable(1483, cfg.pulp_version):
+        if not selectors.bug_is_fixed(1483, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/1483')
-        if selectors.bug_is_untestable(1664, cfg.pulp_version):
+        if not selectors.bug_is_fixed(1664, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/1664')
 
         # Create, sync and publish a repository.

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_unassociate.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_unassociate.py
@@ -100,7 +100,7 @@ class RemoveUnitsTestCase(unittest.TestCase):
             }
             self.assertEqual(removed_ids & remaining_ids, set())
 
-        if selectors.bug_is_testable(2630, self.cfg.pulp_version):
+        if selectors.bug_is_fixed(2630, self.cfg.pulp_version):
             with self.subTest('last removed unit'):
                 lur_before = self.get_repo_last_unit_removed(repo)
                 time.sleep(1)  # ensure last_unit_removed increments
@@ -194,7 +194,7 @@ class RepublishTestCase(BaseAPITestCase):
         publish_repo(self.cfg, repo_before)
         repo_after = self.get_repo()
         with self.subTest(comment='last_unit_added'):
-            if selectors.bug_is_untestable(1847, self.cfg.pulp_version):
+            if not selectors.bug_is_fixed(1847, self.cfg.pulp_version):
                 self.skipTest('https://pulp.plan.io/issues/1847')
             pre = repo_before['last_unit_added']
             post = repo_after['last_unit_added']
@@ -227,7 +227,7 @@ class RepublishTestCase(BaseAPITestCase):
         publish_repo(self.cfg, repo_before)
         repo_after = self.get_repo()
         with self.subTest(comment='last_unit_added'):
-            if selectors.bug_is_untestable(1847, self.cfg.pulp_version):
+            if not selectors.bug_is_fixed(1847, self.cfg.pulp_version):
                 self.skipTest('https://pulp.plan.io/issues/1847')
             pre = parse(repo_before['last_unit_added'])
             post = parse(repo_after['last_unit_added'])

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_updateinfo.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_updateinfo.py
@@ -246,7 +246,7 @@ class UpdateInfoTestCase(BaseAPITestCase):
         .. _Pulp #1782: https://pulp.plan.io/issues/1782
         .. _Pulp #2032: https://pulp.plan.io/issues/2032
         """
-        if selectors.bug_is_untestable(2032, self.cfg.pulp_version):
+        if not selectors.bug_is_fixed(2032, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2032')
         erratum = self.errata['full']
         update_element = (
@@ -437,7 +437,7 @@ class PkglistsTestCase(unittest.TestCase):
         cfg = config.get_config()
         if check_issue_3104(cfg):
             self.skipTest('https://pulp.plan.io/issues/3104')
-        if selectors.bug_is_untestable(2227, cfg.pulp_version):
+        if not selectors.bug_is_fixed(2227, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2277')
 
         # Create, sync and publish a repository.
@@ -606,7 +606,7 @@ class OpenSuseErrataTestCase(unittest.TestCase):
     def test_01_create_sync_publish(self):
         """Create, sync, and publish an openSUSE repository."""
         cfg = config.get_config()
-        if selectors.bug_is_untestable(3377, cfg.pulp_version):
+        if not selectors.bug_is_fixed(3377, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/3377')
 
         # Create, sync, and publish a repository.

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_upload_publish.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_upload_publish.py
@@ -59,7 +59,7 @@ class UploadDrpmTestCase(unittest.TestCase):
     def test_all(self):
         """Import a DRPM into a repository and search it for content units."""
         cfg = config.get_config()
-        if selectors.bug_is_untestable(1806, cfg.pulp_version):
+        if not selectors.bug_is_fixed(1806, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/1806')
         client = api.Client(cfg)
         repo = client.post(REPOSITORY_PATH, gen_repo()).json()
@@ -100,9 +100,9 @@ class UploadDrpmTestCaseWithCheckSumType(BaseAPITestCase):
 
     def test_all(self):
         """Test that uploading DRPM with checksumtype specified works."""
-        if selectors.bug_is_untestable(1806, self.cfg.pulp_version):
+        if not selectors.bug_is_fixed(1806, self.cfg.pulp_version):
             raise unittest.SkipTest('https://pulp.plan.io/issues/1806')
-        if selectors.bug_is_untestable(2627, self.cfg.pulp_version):
+        if not selectors.bug_is_fixed(2627, self.cfg.pulp_version):
             raise unittest.SkipTest('https://pulp.plan.io/issues/2627')
         client = api.Client(self.cfg)
         repo = client.post(REPOSITORY_PATH, gen_repo()).json()
@@ -159,7 +159,7 @@ class UploadedDrpmChecksumTypeTestCase(unittest.TestCase):
         with self.subTest(comment='verify checksumtype'):
             self.assertEqual(units[0]['metadata']['checksumtype'], 'md5')
         with self.subTest(comment='verify checksum'):
-            if selectors.bug_is_untestable(2774, cfg.pulp_version):
+            if not selectors.bug_is_fixed(2774, cfg.pulp_version):
                 self.skipTest('https://pulp.plan.io/issues/2774')
             self.assertEqual(
                 units[0]['metadata']['checksum'],
@@ -336,7 +336,7 @@ class UploadRpmTestCase(BaseAPITestCase):
                 RPM_DATA['metadata']['files'],
             )
 
-        if selectors.bug_is_testable(2754, self.cfg.pulp_version):
+        if selectors.bug_is_fixed(2754, self.cfg.pulp_version):
             # Test that additional fields are available.
             # Affected by Pulp issue #2754
 
@@ -389,7 +389,7 @@ class VendorInfoTestCase(unittest.TestCase):
     def setUpClass(cls):
         """Create class-wide variables."""
         cls.cfg = config.get_config()
-        if selectors.bug_is_untestable(2781, cls.cfg.pulp_version):
+        if not selectors.bug_is_fixed(2781, cls.cfg.pulp_version):
             raise unittest.SkipTest('https://pulp.plan.io/issues/2781')
 
     def test_upload(self):
@@ -498,9 +498,9 @@ class UploadInvalidRPMTestCase(unittest.TestCase):
         3. Verify that the repository contains no RPMs.
         """
         cfg = config.get_config()
-        if selectors.bug_is_untestable(2543, cfg.pulp_version):
+        if not selectors.bug_is_fixed(2543, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2543')
-        if selectors.bug_is_untestable(3090, cfg.pulp_version):
+        if not selectors.bug_is_fixed(3090, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/3090')
         client = api.Client(cfg, api.json_handler)
         repo = client.post(REPOSITORY_PATH, gen_repo())

--- a/pulp_smash/tests/pulp2/rpm/api_v2/utils.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/utils.py
@@ -175,7 +175,7 @@ class DisableSELinuxMixin():  # pylint:disable=too-few-public-methods
         # We cannot execute `PATH=${PATH}:/usr/sbin which getenforce` because
         # Plumbum does a good job of preventing shell expansions. See:
         # https://github.com/PulpQE/pulp-smash/issues/89
-        if selectors.bug_is_testable(pulp_issue_id, cfg.pulp_version):
+        if selectors.bug_is_fixed(pulp_issue_id, cfg.pulp_version):
             return
         client = cli.Client(cfg, cli.echo_handler)
         cmd = 'test -e /usr/sbin/getenforce'.split()

--- a/pulp_smash/tests/pulp2/rpm/cli/test_character_encoding.py
+++ b/pulp_smash/tests/pulp2/rpm/cli/test_character_encoding.py
@@ -73,7 +73,7 @@ class UploadNonUtf8TestCase(unittest.TestCase):
     def test_all(self):
         """Test whether one can upload an RPM with non-utf-8 metadata."""
         cfg = config.get_config()
-        if selectors.bug_is_untestable(1903, cfg.pulp_version):
+        if not selectors.bug_is_fixed(1903, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/1903')
         client = cli.Client(cfg)
 

--- a/pulp_smash/tests/pulp2/rpm/cli/test_copy_units.py
+++ b/pulp_smash/tests/pulp2/rpm/cli/test_copy_units.py
@@ -170,7 +170,7 @@ class CopyLangpacksTestCase(UtilsMixin, unittest.TestCase):
         * A non-zero number of langpacks are present in the target repository.
         """
         cfg = config.get_config()
-        if selectors.bug_is_untestable(1367, cfg.pulp_version):
+        if not selectors.bug_is_fixed(1367, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/1367')
         repo_id = self.create_repo(cfg)
         completed_proc = cli.Client(cfg).run(

--- a/pulp_smash/tests/pulp2/rpm/cli/test_process_recycling.py
+++ b/pulp_smash/tests/pulp2/rpm/cli/test_process_recycling.py
@@ -57,9 +57,9 @@ class MaxTasksPerChildTestCase(unittest.TestCase):
     def test_all(self):
         """Test Pulp's handling of its ``PULP_MAX_TASKS_PER_CHILD`` setting."""
         cfg = config.get_config()
-        if selectors.bug_is_untestable(2172, cfg.pulp_version):
+        if not selectors.bug_is_fixed(2172, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2172')
-        pulp_3540_testable = selectors.bug_is_testable(3540, cfg.pulp_version)
+        pulp_3540_testable = selectors.bug_is_fixed(3540, cfg.pulp_version)
         svc_mgr = cli.GlobalServiceManager(cfg)
         sudo = () if utils.is_root(cfg) else ('sudo',)
         set_cmd = sudo + (

--- a/pulp_smash/tests/pulp2/rpm/cli/test_sync.py
+++ b/pulp_smash/tests/pulp2/rpm/cli/test_sync.py
@@ -107,7 +107,7 @@ class ForceSyncTestCase(_BaseTestCase):
     def test_all(self):
         """Test whether one can force Pulp to perform a full sync."""
         cfg = config.get_config()
-        if selectors.bug_is_untestable(1982, cfg.pulp_version):
+        if not selectors.bug_is_fixed(1982, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/1982')
 
         # Create and sync a repository.

--- a/pulp_smash/tests/pulp2/rpm/cli/test_upload.py
+++ b/pulp_smash/tests/pulp2/rpm/cli/test_upload.py
@@ -36,7 +36,7 @@ class UploadDrpmTestCase(unittest.TestCase):
            ``--skip-existing`` flag during the upload. Verify that Pulp skips
            the upload.
         """
-        if selectors.bug_is_untestable(1806, config.get_config().pulp_version):
+        if not selectors.bug_is_fixed(1806, config.get_config().pulp_version):
             self.skipTest('https://pulp.plan.io/issues/1806')
 
         # Create a repository
@@ -92,7 +92,7 @@ class UploadDrpmTestCase(unittest.TestCase):
            ``--skip-existing`` flag during the upload. Verify that Pulp skips
            the upload.
         """
-        if selectors.bug_is_untestable(2627, config.get_config().pulp_version):
+        if not selectors.bug_is_fixed(2627, config.get_config().pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2627')
 
         # Create a repository

--- a/pulp_smash/tests/pulp2/rpm/utils.py
+++ b/pulp_smash/tests/pulp2/rpm/utils.py
@@ -24,7 +24,7 @@ def check_issue_2277(cfg):
     .. _Pulp #2277: https://pulp.plan.io/issues/2277
     """
     if (cfg.pulp_version >= Version('2.10') and
-            selectors.bug_is_untestable(2277, cfg.pulp_version)):
+            not selectors.bug_is_fixed(2277, cfg.pulp_version)):
         return True
     return False
 
@@ -37,7 +37,7 @@ def check_issue_2387(cfg):
     .. _Pulp #2387: https://pulp.plan.io/issues/2387
     """
     if (cfg.pulp_version >= Version('2.10') and os_is_rhel6(cfg) and
-            selectors.bug_is_untestable(2387, cfg.pulp_version)):
+            not selectors.bug_is_fixed(2387, cfg.pulp_version)):
         return True
     return False
 
@@ -50,7 +50,7 @@ def check_issue_2354(cfg):
     .. _Pulp #2354: https://pulp.plan.io/issues/2354
     """
     if (cfg.pulp_version >= Version('2.10') and
-            selectors.bug_is_untestable(2354, cfg.pulp_version)):
+            not selectors.bug_is_fixed(2354, cfg.pulp_version)):
         return True
     return False
 
@@ -63,7 +63,7 @@ def check_issue_2620(cfg):
     .. _Pulp #2620: https://pulp.plan.io/issues/2620
     """
     if (cfg.pulp_version >= Version('2.12') and
-            selectors.bug_is_untestable(2620, cfg.pulp_version)):
+            not selectors.bug_is_fixed(2620, cfg.pulp_version)):
         return True
     return False
 
@@ -76,7 +76,7 @@ def check_issue_2798(cfg):
     .. _Pulp #2798: https://pulp.plan.io/issues/2798
     """
     return (cfg.pulp_version >= Version('2.14') and
-            selectors.bug_is_untestable(2798, cfg.pulp_version))
+            not selectors.bug_is_fixed(2798, cfg.pulp_version))
 
 
 def check_issue_2844(cfg):
@@ -87,7 +87,7 @@ def check_issue_2844(cfg):
     .. _Pulp #2844: https://pulp.plan.io/issues/2844
     """
     return (cfg.pulp_version >= Version('2.14') and
-            selectors.bug_is_untestable(2844, cfg.pulp_version))
+            not selectors.bug_is_fixed(2844, cfg.pulp_version))
 
 
 def check_issue_3104(cfg):
@@ -98,7 +98,7 @@ def check_issue_3104(cfg):
     .. _Pulp #3104: https://pulp.plan.io/issues/3104
     """
     return (cfg.pulp_version >= Version('2.15') and
-            selectors.bug_is_untestable(3104, cfg.pulp_version))
+            not selectors.bug_is_fixed(3104, cfg.pulp_version))
 
 
 def os_is_rhel6(cfg):

--- a/pulp_smash/tests/pulp3/file/api_v3/test_crd_publications.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_crd_publications.py
@@ -124,7 +124,7 @@ class PublicationsTestCase(unittest.TestCase, utils.SmokeTest):
     @selectors.skip_if(bool, 'publication', False)
     def test_06_delete(self):
         """Delete a publication."""
-        if selectors.bug_is_untestable(3354, self.cfg.pulp_version):
+        if not selectors.bug_is_fixed(3354, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/3354')
         self.client.delete(self.publication['_href'])
         with self.assertRaises(HTTPError):

--- a/pulp_smash/tests/pulp3/file/api_v3/test_download_content.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_download_content.py
@@ -58,7 +58,7 @@ class DownloadContentTestCase(unittest.TestCase, utils.SmokeTest):
         * `Pulp Smash #872 <https://github.com/PulpQE/pulp-smash/issues/872>`_
         """
         cfg = config.get_config()
-        if selectors.bug_is_untestable(3502, cfg.pulp_version):
+        if not selectors.bug_is_fixed(3502, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/3502')
 
         client = api.Client(cfg, api.json_handler)

--- a/pulp_smash/tests/pulp3/file/api_v3/test_repo_version.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_repo_version.py
@@ -57,7 +57,7 @@ class AddRemoveContentTestCase(unittest.TestCase, utils.SmokeTest):
     def setUpClass(cls):
         """Create class-wide variables."""
         cls.cfg = config.get_config()
-        if selectors.bug_is_untestable(3502, cls.cfg.pulp_version):
+        if not selectors.bug_is_fixed(3502, cls.cfg.pulp_version):
             raise unittest.SkipTest('https://pulp.plan.io/issues/3502')
         cls.client = api.Client(cls.cfg, api.json_handler)
         cls.client.request_kwargs['auth'] = get_auth()

--- a/pulp_smash/tests/pulp3/file/api_v3/test_unlinking_repo.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_unlinking_repo.py
@@ -47,7 +47,7 @@ class RemotesPublishersTestCase(unittest.TestCase, utils.SmokeTest):
            are associated with different repositories.
         """
         cfg = config.get_config()
-        if selectors.bug_is_untestable(3502, cfg.pulp_version):
+        if not selectors.bug_is_fixed(3502, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/3502')
 
         # Create an remote and publisher.
@@ -80,7 +80,7 @@ class RemotesPublishersTestCase(unittest.TestCase, utils.SmokeTest):
         publications = []
         for repo in repos:
             publications.append(publish(cfg, publisher, repo))
-            if selectors.bug_is_testable(3354, cfg.pulp_version):
+            if selectors.bug_is_fixed(3354, cfg.pulp_version):
                 self.addCleanup(client.delete, publications[-1]['_href'])
         self.assertEqual(
             publications[0]['publisher'],

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_api_docs.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_api_docs.py
@@ -21,7 +21,7 @@ class ApiDocsTestCase(unittest.TestCase, utils.SmokeTest):
     def setUp(self):
         """Create an API Client."""
         cfg = config.get_config()
-        if selectors.bug_is_untestable(3552, cfg.pulp_version):
+        if not selectors.bug_is_fixed(3552, cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/3552')
         self.client = api.Client(cfg)
 

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_auth.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_auth.py
@@ -50,7 +50,7 @@ class AuthTestCase(unittest.TestCase, utils.SmokeTest):
 
         Assert that a response indicating success is returned.
         """
-        if selectors.bug_is_untestable(3248, self.cfg.pulp_version):
+        if not selectors.bug_is_fixed(3248, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/3248')
         client = api.Client(self.cfg, api.json_handler)
         token = client.post(JWT_PATH, {
@@ -64,7 +64,7 @@ class AuthTestCase(unittest.TestCase, utils.SmokeTest):
 
         Assert that a response indicating failure is returned.
         """
-        if selectors.bug_is_untestable(3248, self.cfg.pulp_version):
+        if not selectors.bug_is_fixed(3248, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/3248')
         with self.assertRaises(HTTPError):
             api.Client(self.cfg, api.json_handler).post(
@@ -83,7 +83,7 @@ class JWTResetTestCase(unittest.TestCase):
         """
         # Create a user.
         self.cfg = config.get_config()
-        if selectors.bug_is_untestable(3248, self.cfg.pulp_version):
+        if not selectors.bug_is_fixed(3248, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/3248')
         auth = {'username': utils.uuid4(), 'password': utils.uuid4()}
         client = api.Client(self.cfg, api.json_handler)

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_distributions.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_distributions.py
@@ -40,7 +40,7 @@ class CRUDDistributionsTestCase(unittest.TestCase, utils.SmokeTest):
     @selectors.skip_if(bool, 'distribution', False)
     def test_02_read_distributions(self):
         """Read a distribution using query parameters."""
-        if selectors.bug_is_untestable(3082, self.cfg.pulp_version):
+        if not selectors.bug_is_fixed(3082, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/3082')
         for params in (
                 {'name': self.distribution['name']},

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_repos.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_repos.py
@@ -50,7 +50,7 @@ class CRUDRepoTestCase(unittest.TestCase, utils.SmokeTest):
     @selectors.skip_if(bool, 'repo', False)
     def test_02_read_all_repos(self):
         """Ensure name is displayed when listing repositories."""
-        if selectors.bug_is_untestable(2824, self.cfg.pulp_version):
+        if not selectors.bug_is_fixed(2824, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2824')
         for repo in self.client.get(REPO_PATH)['results']:
             self.assertIsNotNone(repo['name'])
@@ -58,7 +58,7 @@ class CRUDRepoTestCase(unittest.TestCase, utils.SmokeTest):
     @selectors.skip_if(bool, 'repo', False)
     def test_03_fully_update_name(self):
         """Update a repository's name using HTTP PUT."""
-        if selectors.bug_is_untestable(3101, self.cfg.pulp_version):
+        if not selectors.bug_is_fixed(3101, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/3101')
         self.do_fully_update_attr('name')
 
@@ -85,7 +85,7 @@ class CRUDRepoTestCase(unittest.TestCase, utils.SmokeTest):
     @selectors.skip_if(bool, 'repo', False)
     def test_03_partially_update_name(self):
         """Update a repository's name using HTTP PATCH."""
-        if selectors.bug_is_untestable(3101, self.cfg.pulp_version):
+        if not selectors.bug_is_fixed(3101, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/3101')
         self.do_partially_update_attr('name')
 

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_users.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_users.py
@@ -46,7 +46,7 @@ class UsersCRUDTestCase(unittest.TestCase, utils.SmokeTest):
     @selectors.skip_if(bool, 'user', False)
     def test_02_read_username(self):
         """Read a user by its username."""
-        if selectors.bug_is_untestable(3142, self.cfg.pulp_version):
+        if not selectors.bug_is_fixed(3142, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/3142')
         page = self.client.get(USER_PATH, params={
             'username': self.user['username']
@@ -71,7 +71,7 @@ class UsersCRUDTestCase(unittest.TestCase, utils.SmokeTest):
     def test_03_fully_update_user(self):
         """Update a user info using HTTP PUT."""
         attrs = _gen_verbose_user_attrs()
-        if selectors.bug_is_untestable(3125, self.cfg.pulp_version):
+        if not selectors.bug_is_fixed(3125, self.cfg.pulp_version):
             attrs['username'] = self.user['username']
         self.client.put(self.user['_href'], attrs)
         user = self.client.get(self.user['_href'])
@@ -86,7 +86,7 @@ class UsersCRUDTestCase(unittest.TestCase, utils.SmokeTest):
     def test_03_partially_update_user(self):
         """Update a user info using HTTP PATCH."""
         attrs = _gen_verbose_user_attrs()
-        if selectors.bug_is_untestable(3125, self.cfg.pulp_version):
+        if not selectors.bug_is_fixed(3125, self.cfg.pulp_version):
             del attrs['username']
         self.client.patch(self.user['_href'], attrs)
         user = self.client.get(self.user['_href'])

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_workers.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_workers.py
@@ -70,7 +70,7 @@ class WorkersTestCase(unittest.TestCase, utils.SmokeTest):
     @selectors.skip_if(bool, 'worker', False)
     def test_03_positive_filters(self):
         """Read a worker using a set of query parameters."""
-        if selectors.bug_is_untestable(3586, self.cfg.pulp_version):
+        if not selectors.bug_is_fixed(3586, self.cfg.pulp_version):
             raise unittest.SkipTest('https://pulp.plan.io/issues/3586')
         page = self.client.get(WORKER_PATH, params={
             'last_heartbeat__gte': self.worker['last_heartbeat'],

--- a/tests/test_selectors.py
+++ b/tests/test_selectors.py
@@ -70,8 +70,8 @@ class GetBugTestCase(unittest.TestCase):
             selectors._get_bug('1')
 
 
-class BugIsTestableTestCase(unittest.TestCase):
-    """Test :meth:`pulp_smash.selectors.bug_is_testable` and its partner."""
+class BugIsFixedTestCase(unittest.TestCase):
+    """Test :meth:`pulp_smash.selectors.bug_is_fixed`."""
 
     def test_testable_status(self):
         """Assert the method correctly handles "testable" bug statuses."""
@@ -80,8 +80,7 @@ class BugIsTestableTestCase(unittest.TestCase):
             bug = selectors._Bug(bug_status, ver)
             with mock.patch.object(selectors, '_get_bug', return_value=bug):
                 with self.subTest(bug_status=bug_status):
-                    self.assertTrue(selectors.bug_is_testable(None, ver))
-                    self.assertFalse(selectors.bug_is_untestable(None, ver))
+                    self.assertTrue(selectors.bug_is_fixed(None, ver))
 
     def test_untestable_status(self):
         """Assert the method correctly handles "untestable" bug statuses."""
@@ -90,8 +89,7 @@ class BugIsTestableTestCase(unittest.TestCase):
             bug = selectors._Bug(bug_status, ver)
             with mock.patch.object(selectors, '_get_bug', return_value=bug):
                 with self.subTest(bug_status=bug_status):
-                    self.assertFalse(selectors.bug_is_testable(None, ver))
-                    self.assertTrue(selectors.bug_is_untestable(None, ver))
+                    self.assertFalse(selectors.bug_is_fixed(None, ver))
 
     def test_unknown_status(self):
         """Assert the method correctly handles an unknown bug status."""
@@ -99,7 +97,7 @@ class BugIsTestableTestCase(unittest.TestCase):
         bug = selectors._Bug('foo', ver)
         with mock.patch.object(selectors, '_get_bug', return_value=bug):
             with self.assertRaises(exceptions.BugStatusUnknownError):
-                selectors.bug_is_testable(None, ver)
+                selectors.bug_is_fixed(None, ver)
 
     def test_connection_error(self):
         """Make the dependent function raise a connection error."""
@@ -107,6 +105,4 @@ class BugIsTestableTestCase(unittest.TestCase):
         with mock.patch.object(selectors, '_get_bug') as get_bug:
             get_bug.side_effect = requests.exceptions.ConnectionError
             with self.assertWarns(RuntimeWarning):
-                selectors.bug_is_testable(None, ver)
-            with self.assertWarns(RuntimeWarning):
-                selectors.bug_is_untestable(None, ver)
+                selectors.bug_is_fixed(None, ver)


### PR DESCRIPTION
Drop `selectors.bug_is_testable` and `selectors.bug_is_untestable` in
favor of `selectors.bug_is_fixed`. This change has the following
benefits:

* The API is smaller. There's just one method to maintain instead of
  two. This one method can be used for both purposes by using the `not`
  operator.
* The method name may be more obvious.