### PR TITLE
Move require_selinux to pulp_smash namespace.

### DIFF
--- a/pulp_smash/tests/pulp2/platform/cli/test_selinux.py
+++ b/pulp_smash/tests/pulp2/platform/cli/test_selinux.py
@@ -5,7 +5,7 @@ import unittest
 from collections import namedtuple
 
 from pulp_smash import cli, config, selectors, utils
-from pulp_smash.tests.pulp2.platform.utils import set_up_module, require_selinux
+from pulp_smash.tests.pulp2.platform.utils import set_up_module
 
 
 CELERY_LABEL = ':system_r:celery_t:s0'
@@ -38,7 +38,7 @@ def setUpModule():  # pylint:disable=invalid-name
     selinux is disabled by user config.
     """
     set_up_module()
-    require_selinux()
+    utils.require_selinux()
 
 
 class ProcessLabelsTestCase(unittest.TestCase):

--- a/pulp_smash/tests/pulp2/platform/utils.py
+++ b/pulp_smash/tests/pulp2/platform/utils.py
@@ -1,8 +1,5 @@
 # coding=utf-8
 """Utilities for platform tests."""
-import unittest
-
-from pulp_smash import config
 from pulp_smash.pulp2 import utils
 
 
@@ -10,16 +7,3 @@ def set_up_module():
     """Skip tests if Pulp 2 isn't under test."""
     utils.require_pulp_2()
     utils.require_issue_3159()
-
-
-def require_selinux():
-    """Test if selinux is disabled in config.
-
-    Note: We expect selinux tests are always run. However some test
-    environments (such as OSX + Container) selinux is unsupported. Tests should
-    be skipped in this case.  See :class:`pulp_smash.config.PulpSmashConfig`.
-    """
-    cfg = config.get_config()
-    assert cfg.pulp_selinux_enabled is not None, 'pulp_selinux_enabled must be True or False'
-    if not cfg.pulp_selinux_enabled:
-        raise unittest.SkipTest("Selinux tests disabled by user's settings.json")

--- a/pulp_smash/utils.py
+++ b/pulp_smash/utils.py
@@ -5,12 +5,13 @@ This module may make use of :mod:`pulp_smash.api` and :mod:`pulp_smash.cli`,
 but the reverse should not be done.
 """
 import hashlib
+import unittest
 import uuid
 from urllib.parse import urlparse
 
 import requests
 
-from pulp_smash import cli
+from pulp_smash import cli, config
 from pulp_smash.cli import _is_root as is_root  # pylint:disable=unused-import
 
 # A mapping between URLs and SHA 256 checksums. Used by get_sha256_checksum().
@@ -103,3 +104,16 @@ def os_is_f27(cfg, pulp_host=None):
 def uuid4():
     """Return a random UUID4 as a string."""
     return str(uuid.uuid4())
+
+
+def require_selinux():
+    """Test if selinux is disabled in config.
+
+    Note: We expect selinux tests are always run. However some test
+    environments (such as OSX + Container) selinux is unsupported. Tests should
+    be skipped in this case.  See :class:`pulp_smash.config.PulpSmashConfig`.
+    """
+    cfg = config.get_config()
+    assert cfg.pulp_selinux_enabled is not None, 'pulp_selinux_enabled must be True or False'
+    if not cfg.pulp_selinux_enabled:
+        raise unittest.SkipTest("Selinux tests disabled by user's settings.json")


### PR DESCRIPTION
Function `require_selinux` can be re-used in other tests later on.
Besides that, the function is not related to a specific Pulp
version.