### PR TITLE
Update OPENSUSE_FEED_URL

### DIFF
--- a/pulp_smash/constants.py
+++ b/pulp_smash/constants.py
@@ -134,7 +134,7 @@ FILE2_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'file2/')
 FILE2_URL = urljoin(FILE2_FEED_URL, '1.iso')
 """The URL to an ISO file at :data:`FILE2_FEED_URL`."""
 
-OPENSUSE_FEED_URL = 'https://download.opensuse.org/update/openSUSE-stable/'
+OPENSUSE_FEED_URL = 'https://download.opensuse.org/update/leap/42.3/oss/'
 """The URL to an openSUSE repository.
 
 The repository contains at least one erratum.


### PR DESCRIPTION
The repodata available at `OPENSUSE_FEED_URL` has changed, and none of
the packages listed in `*updateinfo.xml*` include
`<relogin_suggested>True</relogin_suggested>` or
`<restart_suggested>True</restart_suggested>` tags. As a result,
`pulp_smash.tests.pulp2.rpm.api_v2.test_updateinfo.OpenSuseErrataTestCase`
fails.

Update URL to point at a new OpenSUSE repository that does have those
tags. This is a band-aid solution. The new repository URL will likely
become invalid or change in the future. A more permanent fix is to add
something to the Pulp Fixtures repository.