### PR TITLE
Update URL to Puppet forge

### DIFF
--- a/pulp_smash/constants.py
+++ b/pulp_smash/constants.py
@@ -194,7 +194,7 @@ response to a certain HTTP GET request. However:
 .. _Puppet Forge API: https://forgeapi.puppetlabs.com/
 """
 
-PUPPET_FEED_2 = 'http://forge.puppetlabs.com'
+PUPPET_FEED_2 = 'https://forge.puppet.com'
 """The URL to a repository of Puppet modules."""
 
 PUPPET_MODULE_2 = {'author': 'pulp', 'name': 'pulp', 'version': '1.0.0'}


### PR DESCRIPTION
The Puppet forge has moved from forge.puppetlabs.com to
forge.puppet.com. Update the corresponding constant appropriately. In
addition, using HTTPS instead of HTTP is a good idea in general.