### PR TITLE
Simplify api.Client hostname warning

### DIFF
--- a/pulp_smash/api.py
+++ b/pulp_smash/api.py
@@ -331,19 +331,19 @@ class Client():
         #
         #     request(method, url, **kwargs)
         #
+        intended_host = self.pulp_host.hostname
         request_kwargs = self.request_kwargs.copy()
         request_kwargs['url'] = urljoin(request_kwargs['url'], url)
         request_kwargs.update(kwargs)
-        cfg_host = urlparse(self._cfg.get_base_url(self.pulp_host)).hostname
-        request_host = urlparse(request_kwargs['url']).hostname
-        if request_host != cfg_host:
+        actual_host = urlparse(request_kwargs['url']).hostname
+        if intended_host != actual_host:
             warnings.warn(
-                'This client was originally created for communicating with '
-                '{0}, but a request is being made to {1}. The request will be '
-                'made, but beware that information intended for {0} (such as '
+                'This client should be used to communicate with {0}, but a '
+                'request is being made to {1}. The request will be made, but '
+                'beware that information intended for {0} (such as '
                 "authentication tokens) may now be sent to {1}. Here's the "
                 'full list of options being sent with this request: {2}'
-                .format(cfg_host, request_host, request_kwargs),
+                .format(intended_host, actual_host, request_kwargs),
                 RuntimeWarning
             )
         return self.response_handler(


### PR DESCRIPTION
An `api.Client` object should only be used to communicate with one host.
Its value proposition is that it trades off some flexibility for
convenience: when repeatedly communicating with a single host, certain
options and behaviours can be repeatedly sent with little effort.

If an `api.Client` object is used to communicate with some other host, a
warning is raised. Unfortunately, the logic used to generate this
warning is baroque. It goes like this:

1. Take `self.pulp_host`, a `PulpHost` object, and build a base URL by
   passing it to a URL building method on `self._cfg`, a
   `PulpSmashConfig` object.
2. Parse this URL, and extract the hostname.
3. Compare the extracted hostname to the hostname of the host a request
   is being made to.

This logic is correct, but it's unnecessarily convoluted. Simplify it.
Do the following instead: Compare the hostname of `self.pulp_host`
against the hostname of the host a request is being made to.