### PR TITLE
Ensure only certain content is in Pulp

### DIFF
--- a/pulp_smash/tests/pulp3/file/api_v3/test_auto_distribution.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_auto_distribution.py
@@ -19,6 +19,7 @@ from pulp_smash.tests.pulp3.file.api_v3.utils import gen_publisher
 from pulp_smash.tests.pulp3.file.utils import populate_pulp
 from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_smash.pulp3.utils import (
+    delete_orphans,
     gen_distribution,
     gen_remote,
     gen_repo,
@@ -40,6 +41,7 @@ class AutoDistributionTestCase(unittest.TestCase):
         Add content to Pulp.
         """
         cls.cfg = config.get_config()
+        delete_orphans(cls.cfg)
         cls.client = api.Client(cls.cfg, api.json_handler)
         cls.client.request_kwargs['auth'] = get_auth()
         populate_pulp(cls.cfg)


### PR DESCRIPTION
Among other things, the `AutoDistributionTestCase` adds content to Pulp,
randomly selects one of the content units in Pulp, and fetches that
content unit from the current Pulp Fixtures host with roughly the
following logic:

    urljoin(FILE_URL, relative_path_of_chosen_unit)

This works well *if* the chosen unit is available at `FILE_URL`. But
what if some content is chosen, where that content isn't available at
`FILE_URL`? A 404 will result!

As it happens, this is entirely possible. The test case doesn't bother
to clean existing orphans before adding known valid content to Pulp. As
a result, this test case might choose some content that isn't available
at `FILE_URL`. Fix this issue by deleting orphans near the beginning of
the test case.