### PR TITLE
Rewrite response handlers

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,23 +6,26 @@ from unittest import mock
 from pulp_smash import api, config
 
 
+_HANDLER_ARGS = ('client', 'response')
+
+
 class EchoHandlerTestCase(unittest.TestCase):
     """Tests for :func:`pulp_smash.api.echo_handler`."""
 
     def test_return(self):
         """Assert the passed-in ``response`` is returned."""
-        kwargs = {key: mock.Mock() for key in ('cfg', 'response')}
+        kwargs = {key: mock.Mock() for key in _HANDLER_ARGS}
         self.assertIs(kwargs['response'], api.echo_handler(**kwargs))
 
     def test_raise_for_status(self):
         """Assert ``response.raise_for_status()`` is not called."""
-        kwargs = {key: mock.Mock() for key in ('cfg', 'response')}
+        kwargs = {key: mock.Mock() for key in _HANDLER_ARGS}
         api.echo_handler(**kwargs)
         self.assertEqual(kwargs['response'].raise_for_status.call_count, 0)
 
     def test_202_check_skipped(self):
         """Assert HTTP 202 responses are not treated specially."""
-        kwargs = {key: mock.Mock() for key in ('cfg', 'response')}
+        kwargs = {key: mock.Mock() for key in _HANDLER_ARGS}
         with mock.patch.object(api, '_handle_202') as handle_202:
             api.echo_handler(**kwargs)
         self.assertEqual(handle_202.call_count, 0)
@@ -33,18 +36,18 @@ class CodeHandlerTestCase(unittest.TestCase):
 
     def test_return(self):
         """Assert the passed-in ``response`` is returned."""
-        kwargs = {key: mock.Mock() for key in ('cfg', 'response')}
+        kwargs = {key: mock.Mock() for key in _HANDLER_ARGS}
         self.assertIs(kwargs['response'], api.code_handler(**kwargs))
 
     def test_raise_for_status(self):
         """Assert ``response.raise_for_status()`` is called."""
-        kwargs = {key: mock.Mock() for key in ('cfg', 'response')}
+        kwargs = {key: mock.Mock() for key in _HANDLER_ARGS}
         api.code_handler(**kwargs)
         self.assertEqual(kwargs['response'].raise_for_status.call_count, 1)
 
     def test_202_check_skipped(self):
         """Assert HTTP 202 responses are not treated specially."""
-        kwargs = {key: mock.Mock() for key in ('cfg', 'response')}
+        kwargs = {key: mock.Mock() for key in _HANDLER_ARGS}
         with mock.patch.object(api, '_handle_202') as handle_202:
             api.code_handler(**kwargs)
         self.assertEqual(handle_202.call_count, 0)
@@ -55,18 +58,18 @@ class SafeHandlerTestCase(unittest.TestCase):
 
     def test_return(self):
         """Assert the passed-in ``response`` is returned."""
-        kwargs = {key: mock.Mock() for key in ('cfg', 'response')}
+        kwargs = {key: mock.Mock() for key in _HANDLER_ARGS}
         self.assertIs(kwargs['response'], api.safe_handler(**kwargs))
 
     def test_raise_for_status(self):
         """Assert ``response.raise_for_status()`` is called."""
-        kwargs = {key: mock.Mock() for key in ('cfg', 'response')}
+        kwargs = {key: mock.Mock() for key in _HANDLER_ARGS}
         api.safe_handler(**kwargs)
         self.assertEqual(kwargs['response'].raise_for_status.call_count, 1)
 
     def test_202_check_run(self):
         """Assert HTTP 202 responses are treated specially."""
-        kwargs = {key: mock.Mock() for key in ('cfg', 'response')}
+        kwargs = {key: mock.Mock() for key in _HANDLER_ARGS}
         with mock.patch.object(api, '_handle_202') as handle_202:
             api.safe_handler(**kwargs)
         self.assertEqual(handle_202.call_count, 1)
@@ -77,26 +80,26 @@ class JsonHandlerTestCase(unittest.TestCase):
 
     def test_return(self):
         """Assert the JSON-decoded body of ``response`` is returned."""
-        kwargs = {key: mock.Mock() for key in ('cfg', 'response')}
+        kwargs = {key: mock.Mock() for key in _HANDLER_ARGS}
         out = api.json_handler(**kwargs)
         self.assertEqual(kwargs['response'].json.return_value, out)
 
     def test_raise_for_status(self):
         """Assert ``response.raise_for_status()`` is called."""
-        kwargs = {key: mock.Mock() for key in ('cfg', 'response')}
+        kwargs = {key: mock.Mock() for key in _HANDLER_ARGS}
         api.json_handler(**kwargs)
         self.assertEqual(kwargs['response'].raise_for_status.call_count, 1)
 
     def test_202_check_run(self):
         """Assert HTTP 202 responses are treated specially."""
-        kwargs = {key: mock.Mock() for key in ('cfg', 'response')}
+        kwargs = {key: mock.Mock() for key in _HANDLER_ARGS}
         with mock.patch.object(api, '_handle_202') as handle_202:
             api.json_handler(**kwargs)
         self.assertEqual(handle_202.call_count, 1)
 
     def test_204_check_run(self):
         """Assert HTTP 204 responses are treated specially."""
-        kwargs = {key: mock.Mock() for key in ('cfg', 'response')}
+        kwargs = {key: mock.Mock() for key in _HANDLER_ARGS}
         kwargs['response'].status_code = 204
         with mock.patch.object(api, '_handle_202'):
             api.json_handler(**kwargs)


### PR DESCRIPTION
Currently, API response handlers accept two arguments: a
`PulpSmashConfig` object and a `requests.Response` object. Here's a
typical method signature:

    pulp_smash.api.json_handler(cfg, response)

This mostly works fine. But it does mean that the response handlers lose
some context about the state of the calling `pulp_smash.api.Client`
objects. For example, response handlers don't know if the calling API
client has been instructed to poll a specific
`pulp_smash.config.PulpHost`, as defined by the parent's `pulp_host`
attribute.

Re-write the API response handlers, so that the API client object which
is calling them is now passed to them. As an example of how this is
useful, the `_handle_202` function now knows which Pulp host it should
communicate with when polling asynchronous tasks.

This improved level of access also means that response handlers have a
greater ability to screw things up. Rewrite and expand the docstring on
`pulp_smash.api.Client`, in an attempt to ensure that users know
everything they need to know.