### PR TITLE
Add test to assert that repository has unique `name` attribute

### DIFF
--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_repos.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_repos.py
@@ -29,6 +29,18 @@ class CRUDRepoTestCase(unittest.TestCase, utils.SmokeTest):
         type(self).repo = self.client.post(REPO_PATH, gen_repo())
 
     @selectors.skip_if(bool, 'repo', False)
+    def test_02_create_same_name(self):
+        """Try to create a second repository with an identical name.
+
+        See: `Pulp Smash #1055
+        <https://github.com/PulpQE/pulp-smash/issues/1055>`_.
+        """
+        body = gen_repo()
+        body['name'] = self.repo['name']
+        with self.assertRaises(HTTPError):
+            self.client.post(REPO_PATH, body)
+
+    @selectors.skip_if(bool, 'repo', False)
     def test_02_read_repo(self):
         """Read a repository by its href."""
         repo = self.client.get(self.repo['_href'])


### PR DESCRIPTION
Assuming that in Pulp 3 repository `name` is a unique attribute,
this test tries to create a new repository reusing the same name of one created before and
expects for HTTPError meaning the repository cannot be created if name is not unique.

Related to #1055