### PR TITLE
Add test to assert that distribution has unique `name` attribute

### DIFF
--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_distributions.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_distributions.py
@@ -30,6 +30,18 @@ class CRUDDistributionsTestCase(unittest.TestCase, utils.SmokeTest):
                 self.assertEqual(self.distribution[key], val)
 
     @selectors.skip_if(bool, 'distribution', False)
+    def test_02_create_same_name(self):
+        """Try to create a second distribution with an identical name.
+
+        See: `Pulp Smash #1055
+        <https://github.com/PulpQE/pulp-smash/issues/1055>`_.
+        """
+        body = gen_distribution()
+        body['name'] = self.distribution['name']
+        with self.assertRaises(HTTPError):
+            self.client.post(DISTRIBUTION_PATH, body)
+
+    @selectors.skip_if(bool, 'distribution', False)
     def test_02_read_distribution(self):
         """Read a distribution by its _href."""
         distribution = self.client.get(self.distribution['_href'])


### PR DESCRIPTION
Assuming that in Pulp 3 distribution name is a unique attribute, this test
tries to create a new distribution reusing the same name of one created before
and expects for HTTPError meaning the distribution cannot be created if name is
not unique.

See #1055