### PR TITLE
Assert that publisher has unique `name` attribute.

### DIFF
--- a/pulp_smash/tests/pulp3/file/api_v3/test_crud_publishers.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_crud_publishers.py
@@ -40,6 +40,18 @@ class CRUDPublishersTestCase(unittest.TestCase, utils.SmokeTest):
                 self.assertEqual(self.publisher[key], val)
 
     @selectors.skip_if(bool, 'publisher', False)
+    def test_02_create_same_name(self):
+        """Try to create a second publisher with an identical name.
+
+        See: `Pulp Smash #1055
+        <https://github.com/PulpQE/pulp-smash/issues/1055>`_.
+        """
+        body = gen_publisher()
+        body['name'] = self.publisher['name']
+        with self.assertRaises(HTTPError):
+            self.client.post(FILE_PUBLISHER_PATH, body)
+
+    @selectors.skip_if(bool, 'publisher', False)
     def test_02_read_publisher(self):
         """Read a publisher by its href."""
         publisher = self.client.get(self.publisher['_href'])


### PR DESCRIPTION
Attempt to create a publisher using the same name as a previous created
publisher, and assert that an HTTP exception is raised.

Closes:#1055