### PR TITLE
Make all `gen_` functions to accept `**kwargs`

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -167,6 +167,7 @@ developers, not a gospel.
     api/tests.test_cli
     api/tests.test_config
     api/tests.test_pulp2_utils
+    api/tests.test_pulp3_utils
     api/tests.test_pulp_smash_cli
     api/tests.test_selectors
     api/tests.test_utils

--- a/docs/api/tests.test_pulp3_utils.rst
+++ b/docs/api/tests.test_pulp3_utils.rst
@@ -1,0 +1,6 @@
+`tests.test_pulp3_utils`
+========================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/tests.test_pulp3_utils`
+
+.. automodule:: tests.test_pulp3_utils

--- a/pulp_smash/pulp3/utils.py
+++ b/pulp_smash/pulp3/utils.py
@@ -311,19 +311,25 @@ def delete_version(repo, version_href=None):
     return tuple(api.poll_spawned_tasks(cfg, call_report))
 
 
-def gen_distribution():
+def gen_distribution(**kwargs):
     """Return a semi-random dict for use in creating a distribution."""
-    return {'base_path': utils.uuid4(), 'name': utils.uuid4()}
+    data = {'base_path': utils.uuid4(), 'name': utils.uuid4()}
+    data.update(kwargs)
+    return data
 
 
-def gen_remote(url):
+def gen_remote(url, **kwargs):
     """Return a semi-random dict for use in creating an remote.
 
     :param url: The URL of an external content source.
     """
-    return {'name': utils.uuid4(), 'url': url}
+    data = {'name': utils.uuid4(), 'url': url}
+    data.update(kwargs)
+    return data
 
 
-def gen_repo():
+def gen_repo(**kwargs):
     """Return a semi-random dict for use in creating a repository."""
-    return {'name': utils.uuid4(), 'notes': {}}
+    data = {'name': utils.uuid4(), 'notes': {}}
+    data.update(kwargs)
+    return data

--- a/pulp_smash/tests/pulp2/docker/api_v2/utils.py
+++ b/pulp_smash/tests/pulp2/docker/api_v2/utils.py
@@ -7,24 +7,28 @@ from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.pulp2.utils import publish_repo, sync_repo
 
 
-def gen_repo():
+def gen_repo(**kwargs):
     """Return a semi-random dict that used for creating a Docker repo."""
-    return {
+    data = {
         'id': utils.uuid4(),
         'importer_config': {},
         'importer_type_id': 'docker_importer',
-        'notes': {'_repo-type': 'docker-repo'},
+        'notes': {'_repo-type': 'docker-repo'}
     }
+    data.update(kwargs)
+    return data
 
 
-def gen_distributor():
+def gen_distributor(**kwargs):
     """Return a semi-random dict for use in creating a Docker distributor."""
-    return {
+    data = {
         'auto_publish': False,
         'distributor_config': {},
         'distributor_id': utils.uuid4(),
-        'distributor_type_id': 'docker_distributor_web',
+        'distributor_type_id': 'docker_distributor_web'
     }
+    data.update(kwargs)
+    return data
 
 
 class SyncPublishMixin():

--- a/pulp_smash/tests/pulp2/ostree/utils.py
+++ b/pulp_smash/tests/pulp2/ostree/utils.py
@@ -12,18 +12,20 @@ def set_up_module():
     utils.require_unit_types({'ostree'})
 
 
-def gen_repo():
+def gen_repo(**kwargs):
     """Return a semi-random dict for use in creating an OSTree repository."""
-    return {
+    data = {
         'id': uuid4(),
         'importer_type_id': 'ostree_web_importer',
         'importer_config': {},
         'distributors': [],
-        'notes': {'_repo-type': 'OSTREE'},
+        'notes': {'_repo-type': 'OSTREE'}
     }
+    data.update(kwargs)
+    return data
 
 
-def gen_distributor():
+def gen_distributor(**kwargs):
     """Return a semi-random dict for use in creating an OSTree distributor.
 
     For more information, see the generic `repository CRUD`_ documentation and
@@ -39,7 +41,9 @@ def gen_distributor():
         http://docs.pulpproject.org/plugins/pulp_ostree/tech-reference/distributor.html
     .. _Pulp #2254: https://pulp.plan.io/issues/2254
     """
-    return {
+    data = {
         'distributor_id': uuid4(),
-        'distributor_type_id': 'ostree_web_distributor',
+        'distributor_type_id': 'ostree_web_distributor'
     }
+    data.update(kwargs)
+    return data

--- a/pulp_smash/tests/pulp2/puppet/api_v2/utils.py
+++ b/pulp_smash/tests/pulp2/puppet/api_v2/utils.py
@@ -3,35 +3,41 @@
 from pulp_smash import utils
 
 
-def gen_repo():
+def gen_repo(**kwargs):
     """Return a semi-random dict that used for creating a puppet repo."""
-    return {
+    data = {
         'id': utils.uuid4(),
         'importer_config': {},
         'importer_type_id': 'puppet_importer',
-        'notes': {'_repo-type': 'puppet-repo'},
+        'notes': {'_repo-type': 'puppet-repo'}
     }
+    data.update(kwargs)
+    return data
 
 
-def gen_distributor():
+def gen_distributor(**kwargs):
     """Return a semi-random dict for use in creating a Puppet distributor."""
-    return {
+    data = {
         'auto_publish': False,
         'distributor_config': {'serve_http': True, 'serve_https': True},
         'distributor_id': utils.uuid4(),
-        'distributor_type_id': 'puppet_distributor',
+        'distributor_type_id': 'puppet_distributor'
     }
+    data.update(kwargs)
+    return data
 
 
-def gen_install_distributor():
+def gen_install_distributor(**kwargs):
     """Return a semi-random dict used for creating a Puppet install distributor.
 
     The caller must fill the install_path distributor_config option otherwise
     Pulp will throw an error when creating the distributor.
     """
-    return {
+    data = {
         'auto_publish': False,
         'distributor_config': {},
         'distributor_id': utils.uuid4(),
-        'distributor_type_id': 'puppet_install_distributor',
+        'distributor_type_id': 'puppet_install_distributor'
     }
+    data.update(kwargs)
+    return data

--- a/pulp_smash/tests/pulp2/python/api_v2/utils.py
+++ b/pulp_smash/tests/pulp2/python/api_v2/utils.py
@@ -3,19 +3,23 @@
 from pulp_smash import utils
 
 
-def gen_repo():
+def gen_repo(**kwargs):
     """Return a semi-random dict for use in creating a Python repository."""
-    return {
+    data = {
         'id': utils.uuid4(),
         'importer_config': {},
         'importer_type_id': 'python_importer',
-        'notes': {'_repo-type': 'PYTHON'},
+        'notes': {'_repo-type': 'PYTHON'}
     }
+    data.update(kwargs)
+    return data
 
 
-def gen_distributor():
+def gen_distributor(**kwargs):
     """Return a semi-random dict for use in creating a Python distributor."""
-    return {
+    data = {
         'distributor_id': utils.uuid4(),
-        'distributor_type_id': 'python_distributor',
+        'distributor_type_id': 'python_distributor'
     }
+    data.update(kwargs)
+    return data

--- a/pulp_smash/tests/pulp2/rpm/api_v2/utils.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/utils.py
@@ -15,26 +15,28 @@ from pulp_smash.constants import RPM_NAMESPACES
 from pulp_smash.pulp2.utils import search_units
 
 
-def gen_repo():
+def gen_repo(**kwargs):
     """Return a semi-random dict for use in creating an RPM repository."""
-    return {
+    data = {
         'id': utils.uuid4(),
         'importer_config': {},
         'importer_type_id': 'yum_importer',
-        'notes': {'_repo-type': 'rpm-repo'},
+        'notes': {'_repo-type': 'rpm-repo'}
     }
+    data.update(kwargs)
+    return data
 
 
-def gen_repo_group():
+def gen_repo_group(**kwargs):
     """Return a semi-random dict for use in creating a RPM repository group."""
-    return {
-        'id': utils.uuid4(),
-    }
+    data = {'id': utils.uuid4()}
+    data.update(kwargs)
+    return data
 
 
-def gen_distributor():
+def gen_distributor(**kwargs):
     """Return a semi-random dict for use in creating a YUM distributor."""
-    return {
+    data = {
         'auto_publish': False,
         'distributor_id': utils.uuid4(),
         'distributor_type_id': 'yum_distributor',
@@ -42,8 +44,10 @@ def gen_distributor():
             'http': True,
             'https': True,
             'relative_url': utils.uuid4() + '/',
-        },
+        }
     }
+    data.update(kwargs)
+    return data
 
 
 def get_repodata_repomd_xml(cfg, distributor, response_handler=None):

--- a/pulp_smash/tests/pulp3/file/api_v3/utils.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/utils.py
@@ -4,9 +4,11 @@ from pulp_smash import utils
 from pulp_smash.pulp3.utils import get_content
 
 
-def gen_publisher():
+def gen_publisher(**kwargs):
     """Return a semi-random dict for use in creating a publisher."""
-    return {'name': utils.uuid4()}
+    data = {'name': utils.uuid4()}
+    data.update(kwargs)
+    return data
 
 
 def get_content_unit_paths(repo):

--- a/tests/test_pulp3_utils.py
+++ b/tests/test_pulp3_utils.py
@@ -1,0 +1,38 @@
+"""Unit tests for pulp_smash.pulp3.utils."""
+
+import unittest
+
+from pulp_smash.pulp3.utils import gen_distribution, gen_remote, gen_repo
+
+
+class GenTestCase(unittest.TestCase):
+    """Tests the `gen_` functions."""
+
+    def test_gen_distribution(self):
+        """Asserts the generation of distibution dict."""
+        self.assertIn('base_path', gen_distribution())
+        self.assertIn('name', gen_distribution())
+
+        dist = gen_distribution(name='foodist')
+        self.assertIn('base_path', dist)
+        self.assertEqual('foodist', dist['name'])
+
+    def test_gen_remote(self):
+        """Asserts the generation of remote dict."""
+        self.assertIn('url', gen_remote('http://foo.com'))
+        self.assertIn('name', gen_remote('http://foo.com'))
+        self.assertEqual('http://foo.com', gen_remote('http://foo.com')['url'])
+
+        rem = gen_remote('http://fooremote', name='fooremote')
+        self.assertIn('url', rem)
+        self.assertEqual('http://fooremote', rem['url'])
+        self.assertEqual('fooremote', rem['name'])
+
+    def test_gen_repo(self):
+        """Asserts the generation of repository dict."""
+        self.assertIn('notes', gen_repo())
+        self.assertIn('name', gen_repo())
+
+        repo = gen_repo(name='foorepo')
+        self.assertIn('notes', repo)
+        self.assertEqual('foorepo', repo['name'])


### PR DESCRIPTION
Making `gen_` functions to accept `kwargs` allows the customization
of generated dict. e.g: `repo = gen_repo(name='foo')`