### PR TITLE
Let get_versions() handle pagination

### DIFF
--- a/pulp_smash/pulp3/utils.py
+++ b/pulp_smash/pulp3/utils.py
@@ -272,8 +272,8 @@ def get_versions(repo, params=None):
     """
     versions = (
         api
-        .Client(config.get_config(), api.json_handler)
-        .get(repo['_versions_href'], params=params)['results'])
+        .Client(config.get_config(), api.page_handler)
+        .get(repo['_versions_href'], params=params))
     versions.sort(
         key=lambda version: int(urlsplit(version['_href']).path.split('/')[-2])
     )


### PR DESCRIPTION
Let the function return all repository versions, even if there is more
than can fit in one page of results.

See: https://github.com/PulpQE/pulp-smash/issues/918