### PR TITLE
Let get_content() handle pagination

### DIFF
--- a/pulp_smash/pulp3/utils.py
+++ b/pulp_smash/pulp3/utils.py
@@ -205,13 +205,13 @@ def get_content(repo, version_href=None):
     :param repo: A dict of information about the repository.
     :param version_href: The repository version to read. If none, read the
         latest repository version.
-    :returns: A dict of information about the content units present in a given
+    :returns: A list of information about the content units present in a given
         repository version.
     """
     if version_href is None:
         version_href = repo['_latest_version_href']
     return (api
-            .Client(config.get_config(), api.json_handler)
+            .Client(config.get_config(), api.page_handler)
             .get(urljoin(version_href, 'content/')))
 
 
@@ -287,10 +287,8 @@ def get_artifact_paths(repo, version_href=None):
     :param version_href: The repository version to read.
     :returns: A set with the paths of units present in a given repository.
     """
-    return {
-        content_unit['artifact']  # file path and name
-        for content_unit in get_content(repo, version_href)['results']
-    }
+    # content['artifact'] consists of a file path and name.
+    return {content['artifact'] for content in get_content(repo, version_href)}
 
 
 def delete_version(repo, version_href=None):

--- a/pulp_smash/tests/pulp3/file/api_v3/test_crud_content_unit.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_crud_content_unit.py
@@ -137,10 +137,7 @@ class DeleteContentUnitRepoVersionTestCase(unittest.TestCase, utils.SmokeTest):
         self.addCleanup(client.delete, repo['_href'])
         sync(cfg, remote, repo)
         repo = client.get(repo['_href'])
-        content = get_content(repo)['results']
+        content = get_content(repo)
         with self.assertRaises(HTTPError):
             client.delete(choice(content)['_href'])
-        self.assertEqual(
-            len(content),
-            len(get_content(repo)['results'])
-        )
+        self.assertEqual(len(content), len(get_content(repo)))

--- a/pulp_smash/tests/pulp3/file/api_v3/test_orphans.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_orphans.py
@@ -73,7 +73,7 @@ class DeleteOrphansTestCase(unittest.TestCase, utils.SmokeTest):
         self.addCleanup(self.api_client.delete, remote['_href'])
         sync(self.cfg, remote, repo)
         repo = self.api_client.get(repo['_href'])
-        content = choice(get_content(repo)['results'])
+        content = choice(get_content(repo))
 
         # Create an orphan content unit.
         self.api_client.post(

--- a/pulp_smash/tests/pulp3/file/api_v3/test_repo_version.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_repo_version.py
@@ -112,7 +112,7 @@ class AddRemoveContentTestCase(unittest.TestCase, utils.SmokeTest):
         self.assertIsNotNone(repo['_latest_version_href'])
 
         content = get_content(repo)
-        self.assertEqual(len(content['results']), FILE_FEED_COUNT)
+        self.assertEqual(len(content), FILE_FEED_COUNT)
 
         added_content = get_added_content(repo)
         self.assertEqual(len(added_content['results']), 3, added_content)
@@ -130,7 +130,7 @@ class AddRemoveContentTestCase(unittest.TestCase, utils.SmokeTest):
         Make roughly the same assertions as :meth:`test_02_sync_content`.
         """
         repo = self.client.get(self.repo['_href'])
-        self.content.update(choice(get_content(repo)['results']))
+        self.content.update(choice(get_content(repo)))
         self.client.post(
             repo['_versions_href'],
             {'remove_content_units': [self.content['_href']]}
@@ -143,7 +143,7 @@ class AddRemoveContentTestCase(unittest.TestCase, utils.SmokeTest):
         self.assertIsNotNone(repo['_latest_version_href'])
 
         content = get_content(repo)
-        self.assertEqual(len(content['results']), FILE_FEED_COUNT - 1)
+        self.assertEqual(len(content), FILE_FEED_COUNT - 1)
 
         added_content = get_added_content(repo)
         self.assertEqual(len(added_content['results']), 0, added_content)
@@ -173,7 +173,7 @@ class AddRemoveContentTestCase(unittest.TestCase, utils.SmokeTest):
         self.assertIsNotNone(repo['_latest_version_href'])
 
         content = get_content(repo)
-        self.assertEqual(len(content['results']), FILE_FEED_COUNT)
+        self.assertEqual(len(content), FILE_FEED_COUNT)
 
         added_content = get_added_content(repo)
         self.assertEqual(len(added_content['results']), 1, added_content)
@@ -374,7 +374,7 @@ class FilterRepoVersionTestCase(unittest.TestCase):
         for repo_version in repo_versions:
             self.assertIn(
                 self.client.get(content['_href']),
-                get_content(self.repo, repo_version['_href'])['results']
+                get_content(self.repo, repo_version['_href'])
             )
 
     def test_filter_invalid_date(self):

--- a/pulp_smash/tests/pulp3/file/api_v3/test_sync.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_sync.py
@@ -141,4 +141,4 @@ class MultiResourceLockingTestCase(unittest.TestCase, utils.SmokeTest):
         repo = client.get(repo['_href'])
         remote = client.get(remote['_href'])
         self.assertEqual(remote['url'], url['url'])
-        self.assertEqual(len(get_content(repo)['results']), FILE_FEED_COUNT)
+        self.assertEqual(len(get_content(repo)), FILE_FEED_COUNT)

--- a/pulp_smash/tests/pulp3/file/api_v3/test_unlinking_repo.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_unlinking_repo.py
@@ -70,7 +70,7 @@ class RemotesPublishersTestCase(unittest.TestCase, utils.SmokeTest):
         # Compare contents of repositories.
         contents = []
         for repo in repos:
-            contents.append(get_content(repo)['results'])
+            contents.append(get_content(repo))
         self.assertEqual(
             {content['_href'] for content in contents[0]},
             {content['_href'] for content in contents[1]},

--- a/pulp_smash/tests/pulp3/file/api_v3/utils.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/utils.py
@@ -15,7 +15,5 @@ def get_content_unit_paths(repo):
     :param repo: A dict of information about the repository.
     :returns: A list with the paths of units present in a given repository.
     """
-    return [
-        content_unit['relative_path']  # file path and name
-        for content_unit in get_content(repo)['results']
-    ]
+    # The "relative_path" is actually a file path and name
+    return [content_unit['relative_path'] for content_unit in get_content(repo)]


### PR DESCRIPTION
Let the function return all content, even if there is more than can fit
in one page of results.

See: https://github.com/PulpQE/pulp-smash/issues/918