### PR TITLE
Let get_added_content() handle pagination

### DIFF
--- a/pulp_smash/pulp3/utils.py
+++ b/pulp_smash/pulp3/utils.py
@@ -221,13 +221,13 @@ def get_added_content(repo, version_href=None):
     :param repo: A dict of information about a repository.
     :param version_href: The repository version to read. If none, read the
         latest repository version.
-    :returns: A dict of information about the content added since the previous
+    :returns: A list of information about the content added since the previous
         repository version.
     """
     if version_href is None:
         version_href = repo['_latest_version_href']
     return (api
-            .Client(config.get_config(), api.json_handler)
+            .Client(config.get_config(), api.page_handler)
             .get(urljoin(version_href, 'added_content/')))
 
 

--- a/pulp_smash/tests/pulp3/file/api_v3/test_auto_distribution.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_auto_distribution.py
@@ -117,7 +117,7 @@ class AutoDistributionTestCase(unittest.TestCase):
         # Assert that distribution was updated as per step 8.
         self.assertEqual(distribution['publication'], publication['_href'])
         unit_path = get_added_content(
-            repo, last_version_href)['results'][0]['relative_path']
+            repo, last_version_href)[0]['relative_path']
         unit_url = self.cfg.get_hosts('api')[0].roles['api']['scheme']
         unit_url += '://' + distribution['base_url'] + '/'
         unit_url = urljoin(unit_url, unit_path)

--- a/pulp_smash/tests/pulp3/file/api_v3/test_repo_version.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_repo_version.py
@@ -115,7 +115,7 @@ class AddRemoveContentTestCase(unittest.TestCase, utils.SmokeTest):
         self.assertEqual(len(content), FILE_FEED_COUNT)
 
         added_content = get_added_content(repo)
-        self.assertEqual(len(added_content['results']), 3, added_content)
+        self.assertEqual(len(added_content), 3, added_content)
 
         removed_content = get_removed_content(repo)
         self.assertEqual(len(removed_content['results']), 0, removed_content)
@@ -146,7 +146,7 @@ class AddRemoveContentTestCase(unittest.TestCase, utils.SmokeTest):
         self.assertEqual(len(content), FILE_FEED_COUNT - 1)
 
         added_content = get_added_content(repo)
-        self.assertEqual(len(added_content['results']), 0, added_content)
+        self.assertEqual(len(added_content), 0, added_content)
 
         removed_content = get_removed_content(repo)
         self.assertEqual(len(removed_content['results']), 1, removed_content)
@@ -176,7 +176,7 @@ class AddRemoveContentTestCase(unittest.TestCase, utils.SmokeTest):
         self.assertEqual(len(content), FILE_FEED_COUNT)
 
         added_content = get_added_content(repo)
-        self.assertEqual(len(added_content['results']), 1, added_content)
+        self.assertEqual(len(added_content), 1, added_content)
 
         removed_content = get_removed_content(repo)
         self.assertEqual(len(removed_content['results']), 0, removed_content)


### PR DESCRIPTION
Let the function return all added content, even if there is more than
can fit in one page of results.

See: https://github.com/PulpQE/pulp-smash/issues/918