### PR TITLE
Let get_removed_content() handle pagination

### DIFF
--- a/pulp_smash/pulp3/utils.py
+++ b/pulp_smash/pulp3/utils.py
@@ -237,13 +237,13 @@ def get_removed_content(repo, version_href=None):
     :param repo: A dict of information about the repository.
     :param version_href: The repository version to read. If none, read the
         latest repository version.
-    :returns: A dict of information about the content removed since the
+    :returns: A list of information about the content removed since the
         previous repository version.
     """
     if version_href is None:
         version_href = repo['_latest_version_href']
     return (api
-            .Client(config.get_config(), api.json_handler)
+            .Client(config.get_config(), api.page_handler)
             .get(urljoin(version_href, 'removed_content/')))
 
 

--- a/pulp_smash/tests/pulp3/file/api_v3/test_repo_version.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_repo_version.py
@@ -118,7 +118,7 @@ class AddRemoveContentTestCase(unittest.TestCase, utils.SmokeTest):
         self.assertEqual(len(added_content), 3, added_content)
 
         removed_content = get_removed_content(repo)
-        self.assertEqual(len(removed_content['results']), 0, removed_content)
+        self.assertEqual(len(removed_content), 0, removed_content)
 
         content_summary = self.get_content_summary(repo)
         self.assertEqual(content_summary, {'file': FILE_FEED_COUNT})
@@ -149,7 +149,7 @@ class AddRemoveContentTestCase(unittest.TestCase, utils.SmokeTest):
         self.assertEqual(len(added_content), 0, added_content)
 
         removed_content = get_removed_content(repo)
-        self.assertEqual(len(removed_content['results']), 1, removed_content)
+        self.assertEqual(len(removed_content), 1, removed_content)
 
         content_summary = self.get_content_summary(repo)
         self.assertEqual(content_summary, {'file': FILE_FEED_COUNT - 1})
@@ -179,7 +179,7 @@ class AddRemoveContentTestCase(unittest.TestCase, utils.SmokeTest):
         self.assertEqual(len(added_content), 1, added_content)
 
         removed_content = get_removed_content(repo)
-        self.assertEqual(len(removed_content['results']), 0, removed_content)
+        self.assertEqual(len(removed_content), 0, removed_content)
 
         content_summary = self.get_content_summary(repo)
         self.assertEqual(content_summary, {'file': FILE_FEED_COUNT})


### PR DESCRIPTION
Let the function return all content, even if there is more than can fit
in one page of results.

See: https://github.com/PulpQE/pulp-smash/issues/918