### PR TITLE
Add try/finally to contextmanager.

### DIFF
--- a/pulp_smash/cli.py
+++ b/pulp_smash/cli.py
@@ -288,9 +288,11 @@ class BaseServiceManager(metaclass=ABCMeta):
         sudo = ('sudo',) if sudo else ()
         if self._on_jenkins:
             client.run(sudo + ('setenforce', '0'))
-        yield
-        if self._on_jenkins:
-            client.run(sudo + ('setenforce', '1'))
+        try:
+            yield
+        finally:
+            if self._on_jenkins:
+                client.run(sudo + ('setenforce', '1'))
 
     @staticmethod
     def _start_sysv(client, sudo, services):


### PR DESCRIPTION
Add a try/finally around the `yield` of `_disable_selinux` method, since
we never know what exceptions can happen inside the `with` block.

See also: https://www.python.org/dev/peps/pep-0343/#generator-decorator