### PR TITLE
Drop `pulp-smash smoke-tests`, plus backing code

### DIFF
--- a/pulp_smash/pulp_smash_cli.py
+++ b/pulp_smash/pulp_smash_cli.py
@@ -1,11 +1,10 @@
 # coding=utf-8
 """The entry point for Pulp Smash's command line interface."""
 import json
-import unittest
 
 import click
 
-from pulp_smash import config, exceptions, utils
+from pulp_smash import config, exceptions
 from pulp_smash.config import PulpSmashConfig
 
 
@@ -212,58 +211,6 @@ def settings_validate(ctx):
         result = click.ClickException(message)
         result.exit_code = -1
         raise result
-
-
-@pulp_smash.command('smoke-tests')
-def smoke_tests():
-    """Print smoke tests, one per line.
-
-    Sample usage:
-
-        python -m unittest $(pulp-smash smoke-tests)
-    """
-    test_suite = unittest.TestSuite()
-    test_suite.addTests(unittest.TestLoader().discover('pulp_smash.tests'))
-    for smoke_test_name in _get_unique_smoke_test_names(test_suite):
-        print(smoke_test_name)
-
-
-def _get_unique_smoke_test_names(test_suite):
-    """Recursively search for smoke tests, and return their unique names.
-
-    :param test_suite: A ``unittest.TestSuite`` to recursively search through.
-    :returns: A set of strings, each identifying a
-        :class:`pulp_smash.utils.SmokeTest` within the given test suite.
-    """
-    return {
-        '.'.join((type(test_case).__module__, type(test_case).__qualname__))
-        for test_case in _get_smoke_tests(test_suite)
-    }
-
-
-def _get_smoke_tests(test_suite):
-    """Recursively search for smoke tests, and yield them.
-
-    :param test_suite: A ``unittest.TestSuite`` to recursively search through.
-    :returns: :class:`pulp_smash.utils.SmokeTest` objects within the given test
-        suite.
-    """
-    for test_case in _get_test_cases(test_suite):
-        if isinstance(test_case, utils.SmokeTest):
-            yield test_case
-
-
-def _get_test_cases(test_suite):
-    """Recursively search for ``unittest.TestCase`` objects, and yield them.
-
-    :param test_suite: A ``unittest.TestSuite`` to recursively search through.
-    :returns: ``unittest.TestCase`` objects within the given test suite.
-    """
-    for test_case_or_suite in test_suite:
-        if isinstance(test_case_or_suite, unittest.TestCase):
-            yield test_case_or_suite
-        else:
-            yield from _get_test_cases(test_case_or_suite)
 
 
 if __name__ == '__main__':

--- a/pulp_smash/tests/pulp3/file/api_v3/test_crd_publications.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_crd_publications.py
@@ -5,7 +5,7 @@ from urllib.parse import urljoin
 
 from requests.exceptions import HTTPError
 
-from pulp_smash import api, config, selectors, utils
+from pulp_smash import api, config, selectors
 from pulp_smash.constants import FILE_FEED_URL
 from pulp_smash.pulp3.constants import (
     DISTRIBUTION_PATH,
@@ -26,7 +26,7 @@ from pulp_smash.pulp3.utils import (
 )
 
 
-class PublicationsTestCase(unittest.TestCase, utils.SmokeTest):
+class PublicationsTestCase(unittest.TestCase):
     """Perform actions over publications."""
 
     @classmethod

--- a/pulp_smash/tests/pulp3/file/api_v3/test_crud_content_unit.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_crud_content_unit.py
@@ -25,7 +25,7 @@ from pulp_smash.pulp3.utils import (
 )
 
 
-class ContentUnitTestCase(unittest.TestCase, utils.SmokeTest):
+class ContentUnitTestCase(unittest.TestCase):
     """CRUD content unit.
 
     This test targets the following issues:
@@ -107,7 +107,7 @@ def _gen_content_unit_attrs(artifact):
     return {'artifact': artifact['_href'], 'relative_path': utils.uuid4()}
 
 
-class DeleteContentUnitRepoVersionTestCase(unittest.TestCase, utils.SmokeTest):
+class DeleteContentUnitRepoVersionTestCase(unittest.TestCase):
     """Test whether content unit used by a repo version can be deleted.
 
     This test targets the following issues:

--- a/pulp_smash/tests/pulp3/file/api_v3/test_crud_publishers.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_crud_publishers.py
@@ -4,14 +4,14 @@ import unittest
 
 from requests.exceptions import HTTPError
 
-from pulp_smash import api, config, selectors, utils
+from pulp_smash import api, config, selectors
 from pulp_smash.pulp3.constants import FILE_PUBLISHER_PATH, REPO_PATH
 from pulp_smash.tests.pulp3.file.api_v3.utils import gen_publisher
 from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_smash.pulp3.utils import gen_repo, get_auth
 
 
-class CRUDPublishersTestCase(unittest.TestCase, utils.SmokeTest):
+class CRUDPublishersTestCase(unittest.TestCase):
     """CRUD publishers."""
 
     @classmethod

--- a/pulp_smash/tests/pulp3/file/api_v3/test_crud_remotes.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_crud_remotes.py
@@ -12,7 +12,7 @@ from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # py
 from pulp_smash.pulp3.utils import gen_remote, gen_repo, get_auth
 
 
-class CRUDRemotesTestCase(unittest.TestCase, utils.SmokeTest):
+class CRUDRemotesTestCase(unittest.TestCase):
     """CRUD remotes."""
 
     @classmethod

--- a/pulp_smash/tests/pulp3/file/api_v3/test_download_content.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_download_content.py
@@ -28,7 +28,7 @@ from pulp_smash.pulp3.utils import (
 )
 
 
-class DownloadContentTestCase(unittest.TestCase, utils.SmokeTest):
+class DownloadContentTestCase(unittest.TestCase):
     """Verify whether content served by pulp can be downloaded."""
 
     def test_all(self):

--- a/pulp_smash/tests/pulp3/file/api_v3/test_orphans.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_orphans.py
@@ -30,7 +30,7 @@ from pulp_smash.pulp3.utils import (
 )
 
 
-class DeleteOrphansTestCase(unittest.TestCase, utils.SmokeTest):
+class DeleteOrphansTestCase(unittest.TestCase):
     """Test whether orphans files can be clean up.
 
     An orphan artifact is an artifact that is not in any content units.

--- a/pulp_smash/tests/pulp3/file/api_v3/test_publish.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_publish.py
@@ -6,7 +6,7 @@ from urllib.parse import urljoin
 
 from requests.exceptions import HTTPError
 
-from pulp_smash import api, config, utils
+from pulp_smash import api, config
 from pulp_smash.constants import FILE_FEED_URL
 from pulp_smash.pulp3.constants import (
     FILE_CONTENT_PATH,
@@ -26,7 +26,7 @@ from pulp_smash.pulp3.utils import (
 )
 
 
-class PublishAnyRepoVersionTestCase(unittest.TestCase, utils.SmokeTest):
+class PublishAnyRepoVersionTestCase(unittest.TestCase):
     """Test whether a particular repository version can be published.
 
     This test targets the following issues:

--- a/pulp_smash/tests/pulp3/file/api_v3/test_repo_version.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_repo_version.py
@@ -37,7 +37,7 @@ from pulp_smash.pulp3.utils import (
 )
 
 
-class AddRemoveContentTestCase(unittest.TestCase, utils.SmokeTest):
+class AddRemoveContentTestCase(unittest.TestCase):
     """Add and remove content to a repository. Verify side-effects.
 
     A new repository version is automatically created each time content is
@@ -196,7 +196,7 @@ class AddRemoveContentTestCase(unittest.TestCase, utils.SmokeTest):
         return content_summaries[0]
 
 
-class AddRemoveRepoVersionTestCase(unittest.TestCase, utils.SmokeTest):
+class AddRemoveRepoVersionTestCase(unittest.TestCase):
     """Create and delete repository versions.
 
     This test targets the following issues:

--- a/pulp_smash/tests/pulp3/file/api_v3/test_sync.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_sync.py
@@ -4,7 +4,7 @@ import unittest
 from random import randint
 from urllib.parse import urljoin, urlsplit
 
-from pulp_smash import api, config, utils
+from pulp_smash import api, config
 from pulp_smash.constants import (
     FILE_FEED_COUNT,
     FILE_FEED_URL,
@@ -21,7 +21,7 @@ from pulp_smash.pulp3.utils import (
 )
 
 
-class SyncFileRepoTestCase(unittest.TestCase, utils.SmokeTest):
+class SyncFileRepoTestCase(unittest.TestCase):
     """Sync repositories with the file plugin."""
 
     @classmethod
@@ -105,7 +105,7 @@ class SyncChangeRepoVersionTestCase(unittest.TestCase):
         self.assertEqual(latest_repo_version, number_of_syncs)
 
 
-class MultiResourceLockingTestCase(unittest.TestCase, utils.SmokeTest):
+class MultiResourceLockingTestCase(unittest.TestCase):
     """Verify multi-resourcing locking.
 
     This test targets the following issues:

--- a/pulp_smash/tests/pulp3/file/api_v3/test_unlinking_repo.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_unlinking_repo.py
@@ -4,7 +4,7 @@
 import unittest
 from urllib.parse import urljoin
 
-from pulp_smash import api, config, selectors, utils
+from pulp_smash import api, config, selectors
 from pulp_smash.constants import FILE_FEED_URL
 from pulp_smash.pulp3.constants import (
     FILE_REMOTE_PATH,
@@ -23,7 +23,7 @@ from pulp_smash.pulp3.utils import (
 )
 
 
-class RemotesPublishersTestCase(unittest.TestCase, utils.SmokeTest):
+class RemotesPublishersTestCase(unittest.TestCase):
     """Verify publisher and remote can be used with different repos."""
 
     def test_all(self):

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_api_docs.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_api_docs.py
@@ -4,12 +4,12 @@ import unittest
 
 from requests.exceptions import HTTPError
 
-from pulp_smash import api, config, selectors, utils
+from pulp_smash import api, config, selectors
 from pulp_smash.pulp3.constants import API_DOCS_PATH
 from pulp_smash.tests.pulp3.pulpcore.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
-class ApiDocsTestCase(unittest.TestCase, utils.SmokeTest):
+class ApiDocsTestCase(unittest.TestCase):
     """Test whether API auto generated docs are available.
 
     This test targets the following issues:

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_auth.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_auth.py
@@ -16,7 +16,7 @@ from pulp_smash.tests.pulp3.pulpcore.utils import set_up_module as setUpModule  
 from pulp_smash.pulp3.utils import JWTAuth
 
 
-class AuthTestCase(unittest.TestCase, utils.SmokeTest):
+class AuthTestCase(unittest.TestCase):
     """Test Pulp3 Authentication."""
 
     @classmethod

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crd_artifacts.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crd_artifacts.py
@@ -14,7 +14,7 @@ from pulp_smash.tests.pulp3.pulpcore.utils import set_up_module as setUpModule  
 from pulp_smash.pulp3.utils import delete_orphans, get_auth
 
 
-class ArtifactTestCase(unittest.TestCase, utils.SmokeTest):
+class ArtifactTestCase(unittest.TestCase):
     """Create an artifact by uploading a file.
 
     This test targets the following issues:
@@ -107,7 +107,7 @@ class ArtifactTestCase(unittest.TestCase, utils.SmokeTest):
                 self._do_upload_invalid_attrs(data)
 
 
-class ArtifactsDeleteFileSystemTestCase(unittest.TestCase, utils.SmokeTest):
+class ArtifactsDeleteFileSystemTestCase(unittest.TestCase):
     """Delete an artifact, it is removed from the filesystem.
 
     This test targets the following issues:

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_distributions.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_distributions.py
@@ -10,7 +10,7 @@ from pulp_smash.pulp3.utils import gen_distribution, get_auth
 from pulp_smash.tests.pulp3.pulpcore.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
-class CRUDDistributionsTestCase(unittest.TestCase, utils.SmokeTest):
+class CRUDDistributionsTestCase(unittest.TestCase):
     """CRUD distributions."""
 
     @classmethod

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_repos.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_repos.py
@@ -10,7 +10,7 @@ from pulp_smash.tests.pulp3.pulpcore.utils import set_up_module as setUpModule  
 from pulp_smash.pulp3.utils import gen_repo, get_auth
 
 
-class CRUDRepoTestCase(unittest.TestCase, utils.SmokeTest):
+class CRUDRepoTestCase(unittest.TestCase):
     """CRUD repositories."""
 
     @classmethod

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_users.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_users.py
@@ -10,7 +10,7 @@ from pulp_smash.tests.pulp3.pulpcore.utils import set_up_module as setUpModule  
 from pulp_smash.pulp3.utils import get_auth
 
 
-class UsersCRUDTestCase(unittest.TestCase, utils.SmokeTest):
+class UsersCRUDTestCase(unittest.TestCase):
     """CRUD users."""
 
     @classmethod

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_status.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_status.py
@@ -5,7 +5,7 @@ import unittest
 from jsonschema import validate
 from requests.exceptions import HTTPError
 
-from pulp_smash import api, config, utils
+from pulp_smash import api, config
 from pulp_smash.pulp3.constants import STATUS_PATH
 from pulp_smash.tests.pulp3.pulpcore.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
@@ -47,7 +47,7 @@ STATUS = {
 }
 
 
-class StatusTestCase(unittest.TestCase, utils.SmokeTest):
+class StatusTestCase(unittest.TestCase):
     """Tests related to the status page.
 
     This test explores the following issues:

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_tasks.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_tasks.py
@@ -17,7 +17,7 @@ _DYNAMIC_TASKS_ATTRS = ('finished_at',)
 """Task attributes that are dynamically set by Pulp, not set by a user."""
 
 
-class TasksTestCase(unittest.TestCase, utils.SmokeTest):
+class TasksTestCase(unittest.TestCase):
     """Perform different operation over tasks.
 
     This test targets the following issues:

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_workers.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_workers.py
@@ -6,7 +6,7 @@ from random import choice
 
 from requests.exceptions import HTTPError
 
-from pulp_smash import api, config, selectors, utils
+from pulp_smash import api, config, selectors
 from pulp_smash.pulp3.constants import WORKER_PATH
 from pulp_smash.tests.pulp3.pulpcore.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_smash.pulp3.utils import get_auth
@@ -15,7 +15,7 @@ _DYNAMIC_WORKER_ATTRS = ('last_heartbeat',)
 """Worker attributes that are dynamically set by Pulp, not set by a user."""
 
 
-class WorkersTestCase(unittest.TestCase, utils.SmokeTest):
+class WorkersTestCase(unittest.TestCase):
     """Test actions over workers.
 
     This test targets the following issues:

--- a/pulp_smash/utils.py
+++ b/pulp_smash/utils.py
@@ -16,19 +16,6 @@ from pulp_smash import cli
 _CHECKSUM_CACHE = {}
 
 
-class SmokeTest():  # pylint:disable=too-few-public-methods
-    """A class for identifying smoke tests.
-
-    Classes that inherit from this class are considered smoke tests, and may be
-    returned by Pulp Smash's CLI. (See :mod:`pulp_smash.pulp_smash_cli`.)
-    """
-    # Which test cases should be marked as smoke tests? For Pulp 3, a sane
-    # solution is to include test cases that belong to the Pulp 3 smoke tests
-    # milestone. [1] For Pulp 2, no similar milestone exists.
-    #
-    # [1] https://github.com/PulpQE/pulp-smash/milestone/22
-
-
 def get_sha256_checksum(url):
     """Return the sha256 checksum of the file at the given URL.
 

--- a/tests/test_pulp_smash_cli.py
+++ b/tests/test_pulp_smash_cli.py
@@ -1,6 +1,5 @@
 # coding=utf-8
 """Unit tests for :mod:`pulp_smash.pulp_smash_cli`."""
-import importlib
 import json
 import os
 import unittest
@@ -329,34 +328,3 @@ class SettingsValidateTestCase(
                 'required property.',
                 result.output,
             )
-
-
-class SmokeTestsTestCase(BasePulpSmashCliTestCase):
-    """Test ``pulp_smash.pulp_smash_cli.smoke_tests`` command."""
-
-    def test_all(self):
-        """Execute the CLI command.
-
-        Assert that each line of output names a test case, and each of those
-        test cases inherits from :class:`pulp_smash.utils.SmokeTest`.
-        """
-        result = self.cli_runner.invoke(pulp_smash_cli.smoke_tests, [])
-        self.assertEqual(result.exit_code, 0)
-        # Each line printed to stdout is a fully qualified test case name, e.g.
-        # `pulp_smash.tests.….TestFoo`.
-        fq_names = result.output.strip().splitlines()
-        self.assertGreater(len(fq_names), 0)
-        for fq_name in fq_names:
-            # By default, deprecation warnings are suppressed. However,
-            # unittest undoes that filtering. In addition, Click's CliRunner
-            # captures both stdout and stderr, and combines them into a single
-            # `output` stream, with no apparent way to separate them. As a
-            # result, the normally invisible warning raised by BaseAPITestCase
-            # makes its way to here and can cause this test to fail.
-            if 'DeprecationWarning' in fq_name:
-                continue
-            with self.subTest(fq_name=fq_name):
-                module_name, _, class_name = fq_name.rpartition('.')
-                module = importlib.import_module(module_name)
-                klass = getattr(module, class_name)
-                self.assertTrue(issubclass(klass, utils.SmokeTest))


### PR DESCRIPTION
The `pulp-smash smoke-tests` command searches through test cases
packaged with Pulp Smash itself, and prints the dotted path to all test
cases that inherit from the `SmokeTest` class. This is useful, because a
user can run a constant subset of all tests, no matter how large the
test suite grows:

    python -m unittest $(pulp-smash smoke-tests)

This works so long as tests live within a known namespace, and so long
as tests inherit from `unittest.TestCase`. However, Pulp Smash is being
turned into a toolkit, where tests will live in namespaces that the
toolkit doesn't know about, and where test cases may be compatible with
any number of test runner frameworks. Thus, it doesn't make sense to
keep this command around. Drop it.

See: https://github.com/PulpQE/pulp-smash/issues/1033