### PR TITLE
Decouple @require and @skip_if from unittest

### DIFF
--- a/pulp_smash/selectors.py
+++ b/pulp_smash/selectors.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 """Tools for selecting and deselecting tests."""
+import unittest
 import warnings
 from collections import namedtuple
 from functools import wraps
@@ -170,55 +171,52 @@ def bug_is_fixed(bug_id, pulp_version):
     return False
 
 
-def require(version_string):
+def require(ver, exc=unittest.SkipTest):
     """Optionally skip a test method, based on a version string.
 
     This decorator concisely encapsulates a common pattern for skipping tests.
-    It can be used like so:
+    An attribute named ``cfg`` **must** be accessible from the decorator. It
+    can be used like so:
 
-    >>> from pulp_smash.config import get_config
-    >>> from pulp_smash.utils import require
-    >>> from unittest import TestCase
-    >>> class MyTestCase(TestCase):
+    >>> import unittest
+    >>> from packaging.version import Version
+    >>> from pulp_smash import config, selectors
+    >>> class MyTestCase(unittest.TestCase):
     ...
     ...     @classmethod
-    ...     def setUpClass(cls):
-    ...         cls.cfg = get_config()
+    ...     def setUp(cls):
+    ...         cls.cfg = config.get_config()
     ...
-    ...     @require('2.7')  # References `self.cfg`
+    ...     @selectors.require('2.7')
     ...     def test_foo(self):
-    ...         pass  # Add a test for Pulp 2.7+ here.
+    ...         self.assertGreaterEqual(self.cfg.pulp_version, Version('2.7'))
 
-    Notice that ``cls.cfg`` is assigned to. This is a **requirement**.
-
-    :param version_string: A PEP 440 compatible version string.
+    :param ver: A PEP 440 compatible version string.
+    :param exc: A class to instantiate and raise as an exception. Its
+        constructor must accept one string argument.
     """
-    # Running the test suite can take a long time. Let's parse the version
-    # string now instead of waiting until the test is running.
-    min_version = Version(version_string)
-
     def plain_decorator(test_method):
         """Decorate function ``test_method``."""
         @wraps(test_method)
         def new_test_method(self, *args, **kwargs):
             """Wrap a (unittest test) method."""
-            if self.cfg.pulp_version < min_version:
-                self.skipTest(
+            if self.cfg.pulp_version < Version(ver):
+                raise exc(
                     'This test requires Pulp {} or later, but Pulp {} is '
                     'being tested. If this seems wrong, try checking the '
                     '"settings" option in the Pulp Smash configuration file.'
-                    .format(version_string, self.cfg.pulp_version)
+                    .format(ver, self.cfg.pulp_version)
                 )
             return test_method(self, *args, **kwargs)
         return new_test_method
     return plain_decorator
 
 
-def skip_if(func, var_name, result):
+def skip_if(func, var_name, result, exc=unittest.SkipTest):
     """Optionally skip a test method, based on a condition.
 
     This decorator checks to see if ``func(getattr(self, var_name))`` equals
-    ``result``. If so, a ``unittest.SkipTest`` exception is raised. Otherwise,
+    ``result``. If so, an exception of type ``exc`` is raised. Otherwise,
     nothing happens, and the decorated test method continues as normal. Here's
     an example:
 
@@ -242,6 +240,9 @@ def skip_if(func, var_name, result):
     ...         pass
 
     :param var_name: A valid variable name.
+    :param result: A value to compare to ``func(getattr(self, var_name))``.
+    :param exc: A class to instantiate and raise as an exception. Its
+        constructor must accept one string argument.
     """
     def plain_decorator(test_method):
         """Decorate function ``test_method``."""
@@ -250,7 +251,7 @@ def skip_if(func, var_name, result):
             """Wrap a (unittest test) method."""
             var_value = getattr(self, var_name)
             if func(var_value) == result:
-                self.skipTest('{}({}) != {}'.format(func, var_value, result))
+                raise exc('{}({}) != {}'.format(func, var_value, result))
             return test_method(self, *args, **kwargs)
         return new_test_method
     return plain_decorator


### PR DESCRIPTION
The `@require` decorator raises a `unittest.SkipTest` exception if the
Pulp application under test appears to be too old. Similarly, the
`@skip_if` decorator raises a `unittest.SkipIf` exception if a certain
test evaluates to true. These behaviours are great when the test runner
being used is unittest, or something largely compatible with unittest.
But Pulp Smash should be compatible with any test runner, not just
unittest.

Add a new argument to both `@require` and `@skip_if`, where the new
argument is the name of an exception to be raised. Let it default to
`unittest.SkipTest`, which should be fine in most cases.

See: https://github.com/PulpQE/pulp-smash/issues/1033