### PR TITLE
Let sphinx build docs in parallel

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -j auto
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build


### PR DESCRIPTION
On the author's development machines, compiling documentation is a
CPU-bound task. In addition, all modern CPUs support parallelism. Thus,
letting Sphinx compile documentation using multiple workers has an
immediate and beneficial impact on documentation build times.