### PR TITLE
Drop unittest from @require

### DIFF
--- a/pulp_smash/tests/pulp2/platform/api_v2/test_repository.py
+++ b/pulp_smash/tests/pulp2/platform/api_v2/test_repository.py
@@ -14,6 +14,7 @@ The assumptions explored in this module have the following dependencies::
 .. _repository:
     https://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/repo/index.html
 """
+import unittest
 from urllib.parse import urljoin, urlparse
 
 from packaging.version import Version
@@ -55,7 +56,8 @@ class CreateSuccessTestCase(BaseAPITestCase):
             with self.subTest(body=body):
                 self.assertEqual(response.status_code, 201)
 
-    @selectors.require('2.7')  # https://pulp.plan.io/issues/695
+    # https://pulp.plan.io/issues/695
+    @selectors.require('2.7', unittest.SkipTest)
     def test_location_header(self):
         """Assert the Location header is correctly set in each response.
 


### PR DESCRIPTION
The `@require` decorator is designed to skip tests under certain
circumstances. This is easiest to do if some assumptions are made about
which test runner is being used. For example, if one assumes that a
unittest-compatible test runner is likely to be used, then it makes
sense for the function to raise `unittest.SkipTest`.

However, Pulp Smash is being turned into a library that should be
compatible with other test runners. An effective way to help prevent
bias toward unittest is to avoid any references to unittest within the
code base. Add an `exc` parameter to the function, which is the
exception to be instantiated and raised.

See: https://github.com/PulpQE/pulp-smash/issues/1033