### PR TITLE
Drop unittest from @skip_if

### DIFF
--- a/pulp_smash/selectors.py
+++ b/pulp_smash/selectors.py
@@ -214,13 +214,13 @@ def require(version_string):
     return plain_decorator
 
 
-def skip_if(func, var_name, result):
+def skip_if(func, var_name, result, exc):
     """Optionally skip a test method, based on a condition.
 
     This decorator checks to see if ``func(getattr(self, var_name))`` equals
-    ``result``. If so, a ``unittest.SkipTest`` exception is raised. Otherwise,
+    ``result``. If so, an exception of type ``exc`` is raised. Otherwise,
     nothing happens, and the decorated test method continues as normal. Here's
-    an example:
+    an example of how to use this method:
 
     >>> import unittest
     >>> from pulp_smash.selectors import skip_if
@@ -230,18 +230,32 @@ def skip_if(func, var_name, result):
     ...     def setUpClass(cls):
     ...         cls.my_var = False
     ...
-    ...     @skip_if(bool, 'my_var', False)
+    ...     @skip_if(bool, 'my_var', False, unittest.SkipTest)
     ...     def test_01_skips(self):
     ...         pass
     ...
     ...     def test_02_runs(self):
     ...         type(self).my_var = True
     ...
-    ...     @skip_if(bool, 'my_var', False)
+    ...     @skip_if(bool, 'my_var', False, unittest.SkipTest)
     ...     def test_03_runs(self):
     ...         pass
 
+    If the same exception should be passed each time this method is called,
+    consider using `functools.partial`_:
+
+    >>> from functools import partial
+    >>> from unittest import SkipTest
+    >>> from pulp_smash.selectors import skip_if
+    >>> unittest_skip_if = partial(skip_if, exc=SkipTest)
+
     :param var_name: A valid variable name.
+    :param result: A value to compare to ``func(getattr(self, var_name))``.
+    :param exc: A class to instantiate and raise as an exception. Its
+        constructor must accept one string argument.
+
+    .. _functools.partial:
+        https://docs.python.org/3/library/functools.html#functools.partial
     """
     def plain_decorator(test_method):
         """Decorate function ``test_method``."""
@@ -250,7 +264,7 @@ def skip_if(func, var_name, result):
             """Wrap a (unittest test) method."""
             var_value = getattr(self, var_name)
             if func(var_value) == result:
-                self.skipTest('{}({}) != {}'.format(func, var_value, result))
+                raise exc('{}({}) != {}'.format(func, var_value, result))
             return test_method(self, *args, **kwargs)
         return new_test_method
     return plain_decorator

--- a/pulp_smash/tests/pulp2/docker/api_v2/test_copy.py
+++ b/pulp_smash/tests/pulp2/docker/api_v2/test_copy.py
@@ -8,7 +8,7 @@ from pulp_smash.constants import DOCKER_V1_FEED_URL, DOCKER_V2_FEED_URL
 from pulp_smash.pulp2.constants import REPOSITORY_PATH
 from pulp_smash.pulp2.utils import sync_repo
 from pulp_smash.tests.pulp2.docker.api_v2.utils import gen_repo
-from pulp_smash.tests.pulp2.docker.utils import get_upstream_name
+from pulp_smash.tests.pulp2.docker.utils import get_upstream_name, skip_if
 from pulp_smash.tests.pulp2.docker.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 
@@ -46,7 +46,7 @@ class CopyV1ContentTestCase(unittest.TestCase):
             params={'details': True}
         )
 
-    @selectors.skip_if(bool, 'repo', False)
+    @skip_if(bool, 'repo', False)
     def test_02_copy_images(self):
         """Copy tags from one repository to another.
 
@@ -100,7 +100,7 @@ class CopyV2ContentTestCase(unittest.TestCase):
             params={'details': True}
         )
 
-    @selectors.skip_if(bool, 'repo', False)
+    @skip_if(bool, 'repo', False)
     def test_02_copy_tags(self):
         """Copy tags from one repository to another.
 
@@ -119,7 +119,7 @@ class CopyV2ContentTestCase(unittest.TestCase):
             repo['content_unit_counts'].get('docker_tag', 0),
         )
 
-    @selectors.skip_if(bool, 'repo', False)
+    @skip_if(bool, 'repo', False)
     def test_02_copy_manifests(self):
         """Copy manifests from one repository to another.
 
@@ -138,7 +138,7 @@ class CopyV2ContentTestCase(unittest.TestCase):
             repo['content_unit_counts'].get('docker_manifest', 0),
         )
 
-    @selectors.skip_if(bool, 'repo', False)
+    @skip_if(bool, 'repo', False)
     def test_02_copy_manifest_lists(self):
         """Copy manifest lists from one repository to another.
 

--- a/pulp_smash/tests/pulp2/docker/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/pulp2/docker/api_v2/test_sync_publish.py
@@ -14,7 +14,7 @@ from pulp_smash.tests.pulp2.docker.api_v2.utils import (
     gen_distributor,
     gen_repo,
 )
-from pulp_smash.tests.pulp2.docker.utils import get_upstream_name
+from pulp_smash.tests.pulp2.docker.utils import get_upstream_name, skip_if
 from pulp_smash.tests.pulp2.docker.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 
 # Variable name derived from HTTP content-type.
@@ -180,7 +180,7 @@ class V1RegistryTestCase(SyncPublishMixin, unittest.TestCase):
             'upstream_name': get_upstream_name(self.cfg),
         })
 
-    @selectors.skip_if(bool, 'repo', False)
+    @skip_if(bool, 'repo', False)
     def test_get_crane_repositories(self):
         """Issue an HTTP GET request to ``/crane/repositories``.
 
@@ -192,7 +192,7 @@ class V1RegistryTestCase(SyncPublishMixin, unittest.TestCase):
         self.assertIn(repo_id, repos.keys())
         self.verify_v1_repo(repos[repo_id])
 
-    @selectors.skip_if(bool, 'repo', False)
+    @skip_if(bool, 'repo', False)
     def test_get_crane_repositories_v1(self):
         """Issue an HTTP GET request to ``/crane/repositories/v1``.
 
@@ -243,7 +243,7 @@ class V2RegistryTestCase(SyncPublishMixin, unittest.TestCase):
             'upstream_name': get_upstream_name(self.cfg),
         })
 
-    @selectors.skip_if(bool, 'repo', False)
+    @skip_if(bool, 'repo', False)
     def test_get_crane_repositories_v2(self):
         """Issue an HTTP GET request to ``/crane/repositories/v2``.
 
@@ -258,7 +258,7 @@ class V2RegistryTestCase(SyncPublishMixin, unittest.TestCase):
         self.assertIn(repo_id, repos.keys())
         self.assertFalse(repos[repo_id]['protected'])
 
-    @selectors.skip_if(bool, 'repo', False)
+    @skip_if(bool, 'repo', False)
     def test_get_manifest_v1(self):
         """Issue an HTTP GET request to ``/v2/{repo_id}/manifests/latest``.
 
@@ -291,7 +291,7 @@ class V2RegistryTestCase(SyncPublishMixin, unittest.TestCase):
                 )
                 validate(manifest, MANIFEST_V1)
 
-    @selectors.skip_if(bool, 'repo', False)
+    @skip_if(bool, 'repo', False)
     def test_get_manifest_v2(self):
         """Issue an HTTP GET request to ``/v2/{repo_id}/manifests/latest``.
 
@@ -314,7 +314,7 @@ class V2RegistryTestCase(SyncPublishMixin, unittest.TestCase):
         )
         validate(manifest, MANIFEST_V2)
 
-    @selectors.skip_if(bool, 'repo', False)
+    @skip_if(bool, 'repo', False)
     def test_get_manifest_list(self):
         """Issue an HTTP GET request to ``/v2/{repo_id}/manifests/latest``.
 
@@ -467,7 +467,7 @@ class NoAmd64LinuxTestCase(SyncPublishMixin, unittest.TestCase):
         # Make Crane read metadata. (Now!)
         cli.GlobalServiceManager(self.cfg).restart(('httpd',))
 
-    @selectors.skip_if(bool, 'repo', False)
+    @skip_if(bool, 'repo', False)
     def test_02_get_manifest_list(self):
         """Get a manifest list.
 
@@ -509,7 +509,7 @@ class NoAmd64LinuxTestCase(SyncPublishMixin, unittest.TestCase):
                 manifest_list
             )
 
-    @selectors.skip_if(bool, 'repo', False)
+    @skip_if(bool, 'repo', False)
     def test_02_get_manifest_v2(self):
         """Get a v2 manifest. Assert that an HTTP 404 is returned."""
         client = api.Client(self.cfg, api.echo_handler, {'headers': {
@@ -523,7 +523,7 @@ class NoAmd64LinuxTestCase(SyncPublishMixin, unittest.TestCase):
         )
         self.assertEqual(response.status_code, 404, response.content)
 
-    @selectors.skip_if(bool, 'repo', False)
+    @skip_if(bool, 'repo', False)
     def test_02_get_manifest_v1(self):
         """Get a v1 manifest. Assert that an HTTP 404 is returned."""
         client = api.Client(self.cfg, api.echo_handler, {'headers': {

--- a/pulp_smash/tests/pulp2/docker/utils.py
+++ b/pulp_smash/tests/pulp2/docker/utils.py
@@ -2,10 +2,12 @@
 """Utilities for Docker tests."""
 import os
 import json
+from functools import partial
+from unittest import SkipTest
 
 from packaging.version import Version
 
-from pulp_smash import cli, utils
+from pulp_smash import cli, selectors, utils
 from pulp_smash.constants import (
     DOCKER_UPSTREAM_NAME,
     DOCKER_UPSTREAM_NAME_NOLIST,
@@ -57,3 +59,11 @@ def write_manifest_list(cfg, manifest_list):
         )
     )
     return file_path, dir_path
+
+
+skip_if = partial(selectors.skip_if, exc=SkipTest)  # pylint:disable=invalid-name
+"""The ``@skip_if`` decorator, customized for unittest.
+
+:func:`pulp_smash.selectors.skip_if` is test runner agnostic. This function is
+identical, except that ``exc`` has been set to ``unittest.SkipTest``.
+"""

--- a/pulp_smash/tests/pulp2/python/api_v2/test_sync_publish.py
+++ b/pulp_smash/tests/pulp2/python/api_v2/test_sync_publish.py
@@ -20,6 +20,7 @@ from pulp_smash.tests.pulp2.python.api_v2.utils import (
     gen_repo,
 )
 from pulp_smash.tests.pulp2.python.utils import set_up_module as setUpModule  # pylint:disable=unused-import
+from pulp_smash.tests.pulp2.python.utils import skip_if
 
 
 class BaseTestCase(unittest.TestCase):
@@ -59,7 +60,7 @@ class BaseTestCase(unittest.TestCase):
         """
         raise NotImplementedError
 
-    @selectors.skip_if(len, 'repos', 0)  # require first repo
+    @skip_if(len, 'repos', 0)  # require first repo
     def test_02_second_repo(self):
         """Create a second Python repository, and sync it from the first.
 

--- a/pulp_smash/tests/pulp2/python/utils.py
+++ b/pulp_smash/tests/pulp2/python/utils.py
@@ -1,5 +1,9 @@
 # coding=utf-8
 """Utilities for Python tests."""
+from functools import partial
+from unittest import SkipTest
+
+from pulp_smash import selectors
 from pulp_smash.pulp2 import utils
 
 
@@ -9,3 +13,11 @@ def set_up_module():
     utils.require_issue_3159()
     utils.require_issue_3687()
     utils.require_unit_types({'python_package'})
+
+
+skip_if = partial(selectors.skip_if, exc=SkipTest)  # pylint:disable=invalid-name
+"""The ``@skip_if`` decorator, customized for unittest.
+
+:func:`pulp_smash.selectors.skip_if` is test runner agnostic. This function is
+identical, except that ``exc`` has been set to ``unittest.SkipTest``.
+"""

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_orphan_remove.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_orphan_remove.py
@@ -22,6 +22,7 @@ from pulp_smash.pulp2.constants import ORPHANS_PATH, REPOSITORY_PATH
 from pulp_smash.pulp2.utils import sync_repo
 from pulp_smash.tests.pulp2.rpm.api_v2.utils import gen_repo
 from pulp_smash.tests.pulp2.rpm.utils import set_up_module as setUpModule  # pylint:disable=unused-import
+from pulp_smash.tests.pulp2.rpm.utils import skip_if
 
 
 def _count_orphans(orphans):
@@ -75,7 +76,7 @@ class OrphansTestCase(unittest.TestCase):
         self.assertEqual(actual_count, expected_count, orphans)
         type(self).orphans_available = True
 
-    @selectors.skip_if(bool, 'orphans_available', False)
+    @skip_if(bool, 'orphans_available', False)
     def test_01_get_by_href(self):
         """Get an orphan by its href."""
         client = api.Client(config.get_config())
@@ -87,14 +88,14 @@ class OrphansTestCase(unittest.TestCase):
         with self.subTest(comment='verify href'):
             self.assertEqual(orphan['_href'], response.json()['_href'])
 
-    @selectors.skip_if(bool, 'orphans_available', False)
+    @skip_if(bool, 'orphans_available', False)
     def test_01_get_by_invalid_type(self):
         """Get orphans by content type. Specify a non-existent content type."""
         client = api.Client(config.get_config(), api.echo_handler)
         response = client.get(urljoin(ORPHANS_PATH, 'foo/'))
         self.assertEqual(response.status_code, 404)
 
-    @selectors.skip_if(bool, 'orphans_available', False)
+    @skip_if(bool, 'orphans_available', False)
     def test_02_delete_by_href(self):
         """Delete an orphan by its href."""
         client = api.Client(config.get_config(), api.json_handler)
@@ -104,7 +105,7 @@ class OrphansTestCase(unittest.TestCase):
         orphans_post = client.get(ORPHANS_PATH)
         self.check_one_orphan_deleted(orphans_pre, orphans_post, orphan)
 
-    @selectors.skip_if(bool, 'orphans_available', False)
+    @skip_if(bool, 'orphans_available', False)
     def test_02_delete_by_type_and_id(self):
         """Delete an orphan by its ID and type.
 
@@ -120,7 +121,7 @@ class OrphansTestCase(unittest.TestCase):
         orphans_post = client.get(ORPHANS_PATH)
         self.check_one_orphan_deleted(orphans_pre, orphans_post, orphan)
 
-    @selectors.skip_if(bool, 'orphans_available', False)
+    @skip_if(bool, 'orphans_available', False)
     def test_03_delete_by_content_type(self):
         """Delete orphans by their content type."""
         cfg = config.get_config()

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_updateinfo.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_updateinfo.py
@@ -78,6 +78,7 @@ from pulp_smash.tests.pulp2.rpm.utils import (
     check_issue_2620,
     check_issue_3104,
     set_up_module,
+    skip_if,
 )
 
 
@@ -626,7 +627,7 @@ class OpenSuseErrataTestCase(unittest.TestCase):
             get_repodata(cfg, repo['distributors'][0], 'updateinfo')
         )
 
-    @selectors.skip_if(bool, 'updates_element', False)
+    @skip_if(bool, 'updates_element', False)
     def test_02_update_issued_dates(self):
         """Assert 'date' attributes are formatted as seconds since epoch.
 
@@ -637,7 +638,7 @@ class OpenSuseErrataTestCase(unittest.TestCase):
         for element in self.updates_element.findall('update/issued'):
             self.assertIsNotNone(matcher.match(element.get('date')))
 
-    @selectors.skip_if(bool, 'updates_element', False)
+    @skip_if(bool, 'updates_element', False)
     def test_02_restart_suggested(self):
         """Assert ``restart_suggested`` element are present."""
         num_restart_suggested = len(self.updates_element.findall(
@@ -645,7 +646,7 @@ class OpenSuseErrataTestCase(unittest.TestCase):
         ))
         self.assertGreater(num_restart_suggested, 0)
 
-    @selectors.skip_if(bool, 'updates_element', False)
+    @skip_if(bool, 'updates_element', False)
     def test_02_relogin_suggested(self):
         """Assert ``relogin_suggested`` element are present."""
         num_relogin_suggested = len(self.updates_element.findall(
@@ -653,7 +654,7 @@ class OpenSuseErrataTestCase(unittest.TestCase):
         ))
         self.assertGreater(num_relogin_suggested, 0)
 
-    @selectors.skip_if(bool, 'updates_element', False)
+    @skip_if(bool, 'updates_element', False)
     def test_02_updated(self):
         """Assert ``<updated>`` elements are absent.
 

--- a/pulp_smash/tests/pulp2/rpm/utils.py
+++ b/pulp_smash/tests/pulp2/rpm/utils.py
@@ -1,7 +1,9 @@
 # coding=utf-8
 """Utilities for RPM tests."""
 import os
+from functools import partial
 from io import StringIO
+from unittest import SkipTest
 
 from packaging.version import Version
 
@@ -146,3 +148,11 @@ def gen_yum_config_file(cfg, repositoryid, **kwargs):
             )
         )
     return path
+
+
+skip_if = partial(selectors.skip_if, exc=SkipTest)  # pylint:disable=invalid-name
+"""The ``@skip_if`` decorator, customized for unittest.
+
+:func:`pulp_smash.selectors.skip_if` is test runner agnostic. This function is
+identical, except that ``exc`` has been set to ``unittest.SkipTest``.
+"""

--- a/pulp_smash/tests/pulp3/file/api_v3/test_crd_publications.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_crd_publications.py
@@ -16,6 +16,7 @@ from pulp_smash.pulp3.constants import (
 )
 from pulp_smash.tests.pulp3.file.api_v3.utils import gen_publisher
 from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
+from pulp_smash.tests.pulp3.file.utils import skip_if
 from pulp_smash.pulp3.utils import (
     gen_distribution,
     gen_remote,
@@ -64,7 +65,7 @@ class PublicationsTestCase(unittest.TestCase):
             publish(self.cfg, self.publisher, self.repo)
         )
 
-    @selectors.skip_if(bool, 'publication', False)
+    @skip_if(bool, 'publication', False)
     def test_02_read_publication(self):
         """Read a publication by its href."""
         publication = self.client.get(self.publication['_href'])
@@ -72,7 +73,7 @@ class PublicationsTestCase(unittest.TestCase):
             with self.subTest(key=key):
                 self.assertEqual(publication[key], val)
 
-    @selectors.skip_if(bool, 'publication', False)
+    @skip_if(bool, 'publication', False)
     def test_02_read_publications(self):
         """Read a publication by its repository version."""
         publications = self.client.get(PUBLICATIONS_PATH, params={
@@ -83,7 +84,7 @@ class PublicationsTestCase(unittest.TestCase):
             with self.subTest(key=key):
                 self.assertEqual(publications[0][key], val)
 
-    @selectors.skip_if(bool, 'publication', False)
+    @skip_if(bool, 'publication', False)
     def test_03_read_publications(self):
         """Read a publication by its publisher."""
         publications = self.client.get(PUBLICATIONS_PATH, params={
@@ -94,7 +95,7 @@ class PublicationsTestCase(unittest.TestCase):
             with self.subTest(key=key):
                 self.assertEqual(publications[0][key], val)
 
-    @selectors.skip_if(bool, 'publication', False)
+    @skip_if(bool, 'publication', False)
     def test_04_read_publications(self):
         """Read a publication by its created time."""
         publications = self.client.get(PUBLICATIONS_PATH, params={
@@ -105,7 +106,7 @@ class PublicationsTestCase(unittest.TestCase):
             with self.subTest(key=key):
                 self.assertEqual(publications[0][key], val)
 
-    @selectors.skip_if(bool, 'publication', False)
+    @skip_if(bool, 'publication', False)
     def test_05_read_publications(self):
         """Read a publication by its distribution."""
         body = gen_distribution()
@@ -121,7 +122,7 @@ class PublicationsTestCase(unittest.TestCase):
             with self.subTest(key=key):
                 self.assertEqual(publications[0][key], val)
 
-    @selectors.skip_if(bool, 'publication', False)
+    @skip_if(bool, 'publication', False)
     def test_06_delete(self):
         """Delete a publication."""
         if not selectors.bug_is_fixed(3354, self.cfg.pulp_version):

--- a/pulp_smash/tests/pulp3/file/api_v3/test_crud_content_unit.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_crud_content_unit.py
@@ -6,7 +6,7 @@ from urllib.parse import urljoin
 
 from requests.exceptions import HTTPError
 
-from pulp_smash import api, config, selectors, utils
+from pulp_smash import api, config, utils
 from pulp_smash.constants import FILE_FEED_URL, FILE_URL
 from pulp_smash.pulp3.constants import (
     ARTIFACTS_PATH,
@@ -15,6 +15,7 @@ from pulp_smash.pulp3.constants import (
     REPO_PATH,
 )
 from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
+from pulp_smash.tests.pulp3.file.utils import skip_if
 from pulp_smash.pulp3.utils import (
     delete_orphans,
     gen_remote,
@@ -58,7 +59,7 @@ class ContentUnitTestCase(unittest.TestCase):
             with self.subTest(key=key):
                 self.assertEqual(self.content_unit[key], val)
 
-    @selectors.skip_if(bool, 'content_unit', False)
+    @skip_if(bool, 'content_unit', False)
     def test_02_read_content_unit(self):
         """Read a content unit by its href."""
         content_unit = self.client.get(self.content_unit['_href'])
@@ -66,7 +67,7 @@ class ContentUnitTestCase(unittest.TestCase):
             with self.subTest(key=key):
                 self.assertEqual(content_unit[key], val)
 
-    @selectors.skip_if(bool, 'content_unit', False)
+    @skip_if(bool, 'content_unit', False)
     def test_02_read_content_units(self):
         """Read a content unit by its relative_path."""
         page = self.client.get(FILE_CONTENT_PATH, params={
@@ -77,7 +78,7 @@ class ContentUnitTestCase(unittest.TestCase):
             with self.subTest(key=key):
                 self.assertEqual(page['results'][0][key], val)
 
-    @selectors.skip_if(bool, 'content_unit', False)
+    @skip_if(bool, 'content_unit', False)
     def test_03_partially_update(self):
         """Attempt to update a content unit using HTTP PATCH.
 
@@ -87,7 +88,7 @@ class ContentUnitTestCase(unittest.TestCase):
         with self.assertRaises(HTTPError):
             self.client.patch(self.content_unit['_href'], attrs)
 
-    @selectors.skip_if(bool, 'content_unit', False)
+    @skip_if(bool, 'content_unit', False)
     def test_03_fully_update(self):
         """Attempt to update a content unit using HTTP PUT.
 

--- a/pulp_smash/tests/pulp3/file/api_v3/test_crud_publishers.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_crud_publishers.py
@@ -4,11 +4,12 @@ import unittest
 
 from requests.exceptions import HTTPError
 
-from pulp_smash import api, config, selectors
+from pulp_smash import api, config
 from pulp_smash.pulp3.constants import FILE_PUBLISHER_PATH, REPO_PATH
+from pulp_smash.pulp3.utils import gen_repo, get_auth
 from pulp_smash.tests.pulp3.file.api_v3.utils import gen_publisher
 from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
-from pulp_smash.pulp3.utils import gen_repo, get_auth
+from pulp_smash.tests.pulp3.file.utils import skip_if
 
 
 class CRUDPublishersTestCase(unittest.TestCase):
@@ -39,7 +40,7 @@ class CRUDPublishersTestCase(unittest.TestCase):
             with self.subTest(key=key):
                 self.assertEqual(self.publisher[key], val)
 
-    @selectors.skip_if(bool, 'publisher', False)
+    @skip_if(bool, 'publisher', False)
     def test_02_create_same_name(self):
         """Try to create a second publisher with an identical name.
 
@@ -51,7 +52,7 @@ class CRUDPublishersTestCase(unittest.TestCase):
         with self.assertRaises(HTTPError):
             self.client.post(FILE_PUBLISHER_PATH, body)
 
-    @selectors.skip_if(bool, 'publisher', False)
+    @skip_if(bool, 'publisher', False)
     def test_02_read_publisher(self):
         """Read a publisher by its href."""
         publisher = self.client.get(self.publisher['_href'])
@@ -59,7 +60,7 @@ class CRUDPublishersTestCase(unittest.TestCase):
             with self.subTest(key=key):
                 self.assertEqual(publisher[key], val)
 
-    @selectors.skip_if(bool, 'publisher', False)
+    @skip_if(bool, 'publisher', False)
     def test_02_read_publishers(self):
         """Read a publisher by its name."""
         page = self.client.get(FILE_PUBLISHER_PATH, params={
@@ -70,7 +71,7 @@ class CRUDPublishersTestCase(unittest.TestCase):
             with self.subTest(key=key):
                 self.assertEqual(page['results'][0][key], val)
 
-    @selectors.skip_if(bool, 'publisher', False)
+    @skip_if(bool, 'publisher', False)
     def test_03_partially_update(self):
         """Update a publisher using HTTP PATCH."""
         body = gen_publisher()
@@ -80,7 +81,7 @@ class CRUDPublishersTestCase(unittest.TestCase):
             with self.subTest(key=key):
                 self.assertEqual(self.publisher[key], val)
 
-    @selectors.skip_if(bool, 'publisher', False)
+    @skip_if(bool, 'publisher', False)
     def test_04_fully_update(self):
         """Update a publisher using HTTP PUT."""
         body = gen_publisher()
@@ -90,7 +91,7 @@ class CRUDPublishersTestCase(unittest.TestCase):
             with self.subTest(key=key):
                 self.assertEqual(self.publisher[key], val)
 
-    @selectors.skip_if(bool, 'publisher', False)
+    @skip_if(bool, 'publisher', False)
     def test_05_delete(self):
         """Delete a publisher."""
         self.client.delete(self.publisher['_href'])

--- a/pulp_smash/tests/pulp3/file/api_v3/test_crud_remotes.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_crud_remotes.py
@@ -5,11 +5,12 @@ import unittest
 
 from requests.exceptions import HTTPError
 
-from pulp_smash import api, config, selectors, utils
+from pulp_smash import api, config, utils
 from pulp_smash.constants import FILE_FEED_URL, FILE2_FEED_URL
 from pulp_smash.pulp3.constants import FILE_REMOTE_PATH, REPO_PATH
-from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_smash.pulp3.utils import gen_remote, gen_repo, get_auth
+from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
+from pulp_smash.tests.pulp3.file.utils import skip_if
 
 
 class CRUDRemotesTestCase(unittest.TestCase):
@@ -42,7 +43,7 @@ class CRUDRemotesTestCase(unittest.TestCase):
             with self.subTest(key=key):
                 self.assertEqual(self.remote[key], val)
 
-    @selectors.skip_if(bool, 'remote', False)
+    @skip_if(bool, 'remote', False)
     def test_02_create_same_name(self):
         """Try to create a second remote with an identical name.
 
@@ -54,7 +55,7 @@ class CRUDRemotesTestCase(unittest.TestCase):
         with self.assertRaises(HTTPError):
             self.client.post(FILE_REMOTE_PATH, body)
 
-    @selectors.skip_if(bool, 'remote', False)
+    @skip_if(bool, 'remote', False)
     def test_02_read_remote(self):
         """Read an remote by its href."""
         remote = self.client.get(self.remote['_href'])
@@ -62,7 +63,7 @@ class CRUDRemotesTestCase(unittest.TestCase):
             with self.subTest(key=key):
                 self.assertEqual(remote[key], val)
 
-    @selectors.skip_if(bool, 'remote', False)
+    @skip_if(bool, 'remote', False)
     def test_02_read_remotes(self):
         """Read an remote by its name."""
         page = self.client.get(FILE_REMOTE_PATH, params={
@@ -73,7 +74,7 @@ class CRUDRemotesTestCase(unittest.TestCase):
             with self.subTest(key=key):
                 self.assertEqual(page['results'][0][key], val)
 
-    @selectors.skip_if(bool, 'remote', False)
+    @skip_if(bool, 'remote', False)
     def test_03_partially_update(self):
         """Update an remote using HTTP PATCH."""
         body = _gen_verbose_remote()
@@ -85,7 +86,7 @@ class CRUDRemotesTestCase(unittest.TestCase):
             with self.subTest(key=key):
                 self.assertEqual(self.remote[key], val)
 
-    @selectors.skip_if(bool, 'remote', False)
+    @skip_if(bool, 'remote', False)
     def test_04_fully_update(self):
         """Update an remote using HTTP PUT."""
         body = _gen_verbose_remote()
@@ -97,7 +98,7 @@ class CRUDRemotesTestCase(unittest.TestCase):
             with self.subTest(key=key):
                 self.assertEqual(self.remote[key], val)
 
-    @selectors.skip_if(bool, 'remote', False)
+    @skip_if(bool, 'remote', False)
     def test_05_delete(self):
         """Delete an remote."""
         self.client.delete(self.remote['_href'])

--- a/pulp_smash/tests/pulp3/file/api_v3/test_repo_version.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_repo_version.py
@@ -20,7 +20,7 @@ from pulp_smash.pulp3.constants import (
     REPO_PATH,
 )
 from pulp_smash.tests.pulp3.file.api_v3.utils import gen_publisher
-from pulp_smash.tests.pulp3.file.utils import populate_pulp
+from pulp_smash.tests.pulp3.file.utils import populate_pulp, skip_if
 from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_smash.pulp3.utils import (
     delete_version,
@@ -88,7 +88,7 @@ class AddRemoveContentTestCase(unittest.TestCase):
 
         self.assertIsNone(self.repo['_latest_version_href'])
 
-    @selectors.skip_if(bool, 'repo', False)
+    @skip_if(bool, 'repo', False)
     def test_02_sync_content(self):
         """Sync content into the repository.
 
@@ -123,7 +123,7 @@ class AddRemoveContentTestCase(unittest.TestCase):
         content_summary = self.get_content_summary(repo)
         self.assertEqual(content_summary, {'file': FILE_FEED_COUNT})
 
-    @selectors.skip_if(bool, 'repo', False)
+    @skip_if(bool, 'repo', False)
     def test_03_remove_content(self):
         """Remove content from the repository.
 
@@ -154,7 +154,7 @@ class AddRemoveContentTestCase(unittest.TestCase):
         content_summary = self.get_content_summary(repo)
         self.assertEqual(content_summary, {'file': FILE_FEED_COUNT - 1})
 
-    @selectors.skip_if(bool, 'repo', False)
+    @skip_if(bool, 'repo', False)
     def test_04_add_content(self):
         """Add content to the repository.
 

--- a/pulp_smash/tests/pulp3/file/utils.py
+++ b/pulp_smash/tests/pulp3/file/utils.py
@@ -1,8 +1,10 @@
 # coding=utf-8
 """Utilities for tests for the file plugin."""
+from functools import partial
+from unittest import SkipTest
 from urllib.parse import urljoin
 
-from pulp_smash import api
+from pulp_smash import api, selectors
 from pulp_smash.constants import FILE_FEED_URL
 from pulp_smash.pulp3.constants import (
     FILE_CONTENT_PATH,
@@ -49,3 +51,11 @@ def set_up_module():
     """Skip tests Pulp 3 isn't under test or if pulp-file isn't installed."""
     require_pulp_3()
     require_pulp_plugins({'pulp_file'})
+
+
+skip_if = partial(selectors.skip_if, exc=SkipTest)  # pylint:disable=invalid-name
+"""The ``@skip_if`` decorator, customized for unittest.
+
+:func:`pulp_smash.selectors.skip_if` is test runner agnostic. This function is
+identical, except that ``exc`` has been set to ``unittest.SkipTest``.
+"""

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_distributions.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_distributions.py
@@ -8,6 +8,7 @@ from pulp_smash import api, config, selectors, utils
 from pulp_smash.pulp3.constants import DISTRIBUTION_PATH
 from pulp_smash.pulp3.utils import gen_distribution, get_auth
 from pulp_smash.tests.pulp3.pulpcore.utils import set_up_module as setUpModule  # pylint:disable=unused-import
+from pulp_smash.tests.pulp3.pulpcore.utils import skip_if
 
 
 class CRUDDistributionsTestCase(unittest.TestCase):
@@ -29,7 +30,7 @@ class CRUDDistributionsTestCase(unittest.TestCase):
             with self.subTest(key=key):
                 self.assertEqual(self.distribution[key], val)
 
-    @selectors.skip_if(bool, 'distribution', False)
+    @skip_if(bool, 'distribution', False)
     def test_02_create_same_name(self):
         """Try to create a second distribution with an identical name.
 
@@ -41,7 +42,7 @@ class CRUDDistributionsTestCase(unittest.TestCase):
         with self.assertRaises(HTTPError):
             self.client.post(DISTRIBUTION_PATH, body)
 
-    @selectors.skip_if(bool, 'distribution', False)
+    @skip_if(bool, 'distribution', False)
     def test_02_read_distribution(self):
         """Read a distribution by its _href."""
         distribution = self.client.get(self.distribution['_href'])
@@ -49,7 +50,7 @@ class CRUDDistributionsTestCase(unittest.TestCase):
             with self.subTest(key=key):
                 self.assertEqual(distribution[key], val)
 
-    @selectors.skip_if(bool, 'distribution', False)
+    @skip_if(bool, 'distribution', False)
     def test_02_read_distributions(self):
         """Read a distribution using query parameters."""
         if not selectors.bug_is_fixed(3082, self.cfg.pulp_version):
@@ -64,7 +65,7 @@ class CRUDDistributionsTestCase(unittest.TestCase):
                     with self.subTest(key=key):
                         self.assertEqual(page['results'][0][key], val)
 
-    @selectors.skip_if(bool, 'distribution', False)
+    @skip_if(bool, 'distribution', False)
     def test_03_partially_update(self):
         """Update a distribution using HTTP PATCH."""
         body = gen_distribution()
@@ -74,7 +75,7 @@ class CRUDDistributionsTestCase(unittest.TestCase):
             with self.subTest(key=key):
                 self.assertEqual(self.distribution[key], val)
 
-    @selectors.skip_if(bool, 'distribution', False)
+    @skip_if(bool, 'distribution', False)
     def test_04_fully_update(self):
         """Update a distribution using HTTP PUT."""
         body = gen_distribution()
@@ -84,7 +85,7 @@ class CRUDDistributionsTestCase(unittest.TestCase):
             with self.subTest(key=key):
                 self.assertEqual(self.distribution[key], val)
 
-    @selectors.skip_if(bool, 'distribution', False)
+    @skip_if(bool, 'distribution', False)
     def test_05_delete(self):
         """Delete a distribution."""
         self.client.delete(self.distribution['_href'])

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_repos.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_repos.py
@@ -7,6 +7,7 @@ from requests.exceptions import HTTPError
 from pulp_smash import api, config, selectors, utils
 from pulp_smash.pulp3.constants import REPO_PATH
 from pulp_smash.tests.pulp3.pulpcore.utils import set_up_module as setUpModule  # pylint:disable=unused-import
+from pulp_smash.tests.pulp3.pulpcore.utils import skip_if
 from pulp_smash.pulp3.utils import gen_repo, get_auth
 
 
@@ -28,7 +29,7 @@ class CRUDRepoTestCase(unittest.TestCase):
         """Create repository."""
         type(self).repo = self.client.post(REPO_PATH, gen_repo())
 
-    @selectors.skip_if(bool, 'repo', False)
+    @skip_if(bool, 'repo', False)
     def test_02_create_same_name(self):
         """Try to create a second repository with an identical name.
 
@@ -40,7 +41,7 @@ class CRUDRepoTestCase(unittest.TestCase):
         with self.assertRaises(HTTPError):
             self.client.post(REPO_PATH, body)
 
-    @selectors.skip_if(bool, 'repo', False)
+    @skip_if(bool, 'repo', False)
     def test_02_read_repo(self):
         """Read a repository by its href."""
         repo = self.client.get(self.repo['_href'])
@@ -48,7 +49,7 @@ class CRUDRepoTestCase(unittest.TestCase):
             with self.subTest(key=key):
                 self.assertEqual(repo[key], val)
 
-    @selectors.skip_if(bool, 'repo', False)
+    @skip_if(bool, 'repo', False)
     def test_02_read_repos(self):
         """Read the repository by its name."""
         page = self.client.get(REPO_PATH, params={
@@ -59,7 +60,7 @@ class CRUDRepoTestCase(unittest.TestCase):
             with self.subTest(key=key):
                 self.assertEqual(page['results'][0][key], val)
 
-    @selectors.skip_if(bool, 'repo', False)
+    @skip_if(bool, 'repo', False)
     def test_02_read_all_repos(self):
         """Ensure name is displayed when listing repositories."""
         if not selectors.bug_is_fixed(2824, self.cfg.pulp_version):
@@ -67,14 +68,14 @@ class CRUDRepoTestCase(unittest.TestCase):
         for repo in self.client.get(REPO_PATH)['results']:
             self.assertIsNotNone(repo['name'])
 
-    @selectors.skip_if(bool, 'repo', False)
+    @skip_if(bool, 'repo', False)
     def test_03_fully_update_name(self):
         """Update a repository's name using HTTP PUT."""
         if not selectors.bug_is_fixed(3101, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/3101')
         self.do_fully_update_attr('name')
 
-    @selectors.skip_if(bool, 'repo', False)
+    @skip_if(bool, 'repo', False)
     def test_03_fully_update_desc(self):
         """Update a repository's description using HTTP PUT."""
         self.do_fully_update_attr('description')
@@ -94,14 +95,14 @@ class CRUDRepoTestCase(unittest.TestCase):
         repo = self.client.get(repo['_href'])
         self.assertEqual(string, repo[attr])
 
-    @selectors.skip_if(bool, 'repo', False)
+    @skip_if(bool, 'repo', False)
     def test_03_partially_update_name(self):
         """Update a repository's name using HTTP PATCH."""
         if not selectors.bug_is_fixed(3101, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/3101')
         self.do_partially_update_attr('name')
 
-    @selectors.skip_if(bool, 'repo', False)
+    @skip_if(bool, 'repo', False)
     def test_03_partially_update_desc(self):
         """Update a repository's description using HTTP PATCH."""
         self.do_partially_update_attr('description')
@@ -119,7 +120,7 @@ class CRUDRepoTestCase(unittest.TestCase):
         repo = self.client.get(self.repo['_href'])
         self.assertEqual(repo[attr], string)
 
-    @selectors.skip_if(bool, 'repo', False)
+    @skip_if(bool, 'repo', False)
     def test_04_delete_repo(self):
         """Delete a repository."""
         self.client.delete(self.repo['_href'])

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_users.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_crud_users.py
@@ -6,8 +6,9 @@ from requests.exceptions import HTTPError
 
 from pulp_smash import api, config, selectors, utils
 from pulp_smash.pulp3.constants import USER_PATH
-from pulp_smash.tests.pulp3.pulpcore.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_smash.pulp3.utils import get_auth
+from pulp_smash.tests.pulp3.pulpcore.utils import set_up_module as setUpModule  # pylint:disable=unused-import
+from pulp_smash.tests.pulp3.pulpcore.utils import skip_if
 
 
 class UsersCRUDTestCase(unittest.TestCase):
@@ -35,7 +36,7 @@ class UsersCRUDTestCase(unittest.TestCase):
                 else:
                     self.assertEqual(self.user[key], val)
 
-    @selectors.skip_if(bool, 'user', False)
+    @skip_if(bool, 'user', False)
     def test_02_read_user(self):
         """Read a user byt its _href."""
         user = self.client.get(self.user['_href'])
@@ -43,7 +44,7 @@ class UsersCRUDTestCase(unittest.TestCase):
             with self.subTest(key=key):
                 self.assertEqual(val, self.user[key])
 
-    @selectors.skip_if(bool, 'user', False)
+    @skip_if(bool, 'user', False)
     def test_02_read_username(self):
         """Read a user by its username."""
         if not selectors.bug_is_fixed(3142, self.cfg.pulp_version):
@@ -55,7 +56,7 @@ class UsersCRUDTestCase(unittest.TestCase):
             with self.subTest(key=key):
                 self.assertEqual(page['results'][0][key], val)
 
-    @selectors.skip_if(bool, 'user', False)
+    @skip_if(bool, 'user', False)
     def test_02_read_users(self):
         """Read all users. Verify that the created user is in the results."""
         users = [
@@ -67,7 +68,7 @@ class UsersCRUDTestCase(unittest.TestCase):
             with self.subTest(key=key):
                 self.assertEqual(val, self.user[key])
 
-    @selectors.skip_if(bool, 'user', False)
+    @skip_if(bool, 'user', False)
     def test_03_fully_update_user(self):
         """Update a user info using HTTP PUT."""
         attrs = _gen_verbose_user_attrs()
@@ -82,7 +83,7 @@ class UsersCRUDTestCase(unittest.TestCase):
                 else:
                     self.assertEqual(user[key], val)
 
-    @selectors.skip_if(bool, 'user', False)
+    @skip_if(bool, 'user', False)
     def test_03_partially_update_user(self):
         """Update a user info using HTTP PATCH."""
         attrs = _gen_verbose_user_attrs()
@@ -97,7 +98,7 @@ class UsersCRUDTestCase(unittest.TestCase):
                 else:
                     self.assertEqual(user[key], val)
 
-    @selectors.skip_if(bool, 'user', False)
+    @skip_if(bool, 'user', False)
     def test_04_delete_user(self):
         """Delete an user."""
         self.client.delete(self.user['_href'])

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_tasks.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_tasks.py
@@ -4,7 +4,7 @@ import unittest
 
 from requests import HTTPError
 
-from pulp_smash import api, config, selectors, utils
+from pulp_smash import api, config, utils
 from pulp_smash.pulp3.constants import (
     P3_TASK_END_STATES,
     REPO_PATH,
@@ -12,6 +12,7 @@ from pulp_smash.pulp3.constants import (
 )
 from pulp_smash.pulp3.utils import gen_repo, get_auth
 from pulp_smash.tests.pulp3.pulpcore.utils import set_up_module as setUpModule  # pylint:disable=unused-import
+from pulp_smash.tests.pulp3.pulpcore.utils import skip_if
 
 _DYNAMIC_TASKS_ATTRS = ('finished_at',)
 """Task attributes that are dynamically set by Pulp, not set by a user."""
@@ -42,7 +43,7 @@ class TasksTestCase(unittest.TestCase):
         response = self.client.patch(repo['_href'], attrs)
         self.task.update(self.client.get(response['_href']))
 
-    @selectors.skip_if(bool, 'task', False)
+    @skip_if(bool, 'task', False)
     def test_02_read_href(self):
         """Read a task by its _href."""
         task = self.client.get(self.task['_href'])
@@ -52,13 +53,13 @@ class TasksTestCase(unittest.TestCase):
             with self.subTest(key=key):
                 self.assertEqual(task[key], val, task)
 
-    @selectors.skip_if(bool, 'task', False)
+    @skip_if(bool, 'task', False)
     def test_02_read_invalid_worker(self):
         """Read a task using an invalid worker name."""
         with self.assertRaises(HTTPError):
             self.filter_tasks({'worker': utils.uuid4()})
 
-    @selectors.skip_if(bool, 'task', False)
+    @skip_if(bool, 'task', False)
     def test_02_read_valid_worker(self):
         """Read a task using a valid worker name."""
         page = self.filter_tasks({'worker': self.task['worker']})
@@ -71,13 +72,13 @@ class TasksTestCase(unittest.TestCase):
             'started_at': utils.uuid4()})
         self.assertEqual(len(page['results']), 0, page['results'])
 
-    @selectors.skip_if(bool, 'task', False)
+    @skip_if(bool, 'task', False)
     def test_02_read_valid_date(self):
         """Read a task by a valid date."""
         page = self.filter_tasks({'started_at': self.task['started_at']})
         self.assertGreaterEqual(len(page['results']), 1, page['results'])
 
-    @selectors.skip_if(bool, 'task', False)
+    @skip_if(bool, 'task', False)
     def test_03_delete_tasks(self):
         """Delete a task."""
         # If this assertion fails, then either Pulp's tasking system or Pulp

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/test_workers.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/test_workers.py
@@ -8,8 +8,9 @@ from requests.exceptions import HTTPError
 
 from pulp_smash import api, config, selectors
 from pulp_smash.pulp3.constants import WORKER_PATH
-from pulp_smash.tests.pulp3.pulpcore.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_smash.pulp3.utils import get_auth
+from pulp_smash.tests.pulp3.pulpcore.utils import set_up_module as setUpModule  # pylint:disable=unused-import
+from pulp_smash.tests.pulp3.pulpcore.utils import skip_if
 
 _DYNAMIC_WORKER_ATTRS = ('last_heartbeat',)
 """Worker attributes that are dynamically set by Pulp, not set by a user."""
@@ -44,7 +45,7 @@ class WorkersTestCase(unittest.TestCase):
                     self.assertIsNotNone(val)
         self.worker.update(choice(workers))
 
-    @selectors.skip_if(bool, 'worker', False)
+    @skip_if(bool, 'worker', False)
     def test_02_read_worker(self):
         """Read a worker by its _href."""
         worker = self.client.get(self.worker['_href'])
@@ -54,7 +55,7 @@ class WorkersTestCase(unittest.TestCase):
             with self.subTest(key=key):
                 self.assertEqual(worker[key], val)
 
-    @selectors.skip_if(bool, 'worker', False)
+    @skip_if(bool, 'worker', False)
     def test_02_read_workers(self):
         """Read a worker by its name."""
         page = self.client.get(WORKER_PATH, params={
@@ -67,7 +68,7 @@ class WorkersTestCase(unittest.TestCase):
             with self.subTest(key=key):
                 self.assertEqual(page['results'][0][key], val)
 
-    @selectors.skip_if(bool, 'worker', False)
+    @skip_if(bool, 'worker', False)
     def test_03_positive_filters(self):
         """Read a worker using a set of query parameters."""
         if not selectors.bug_is_fixed(3586, self.cfg.pulp_version):
@@ -87,7 +88,7 @@ class WorkersTestCase(unittest.TestCase):
             with self.subTest(key=key):
                 self.assertEqual(page['results'][0][key], val)
 
-    @selectors.skip_if(bool, 'worker', False)
+    @skip_if(bool, 'worker', False)
     def test_04_negative_filters(self):
         """Read a worker with a query that does not match any worker."""
         if not selectors.bug_is_fixed(3586, self.cfg.pulp_version):
@@ -100,7 +101,7 @@ class WorkersTestCase(unittest.TestCase):
         })
         self.assertEqual(len(page['results']), 0)
 
-    @selectors.skip_if(bool, 'worker', False)
+    @skip_if(bool, 'worker', False)
     def test_05_http_method(self):
         """Use an HTTP method different than GET.
 

--- a/pulp_smash/tests/pulp3/pulpcore/utils.py
+++ b/pulp_smash/tests/pulp3/pulpcore/utils.py
@@ -1,5 +1,9 @@
 # coding=utf-8
 """Utilities for Pulpcore tests."""
+from functools import partial
+from unittest import SkipTest
+
+from pulp_smash import selectors
 from pulp_smash.pulp3.utils import require_pulp_3, require_pulp_plugins
 
 
@@ -7,3 +11,11 @@ def set_up_module():
     """Skip tests Pulp 3 isn't under test or if pulpcore isn't installed."""
     require_pulp_3()
     require_pulp_plugins({'pulpcore'})
+
+
+skip_if = partial(selectors.skip_if, exc=SkipTest)  # pylint:disable=invalid-name
+"""The ``@skip_if`` decorator, customized for unittest.
+
+:func:`pulp_smash.selectors.skip_if` is test runner agnostic. This function is
+identical, except that ``exc`` has been set to ``unittest.SkipTest``.
+"""


### PR DESCRIPTION
The `@skip_if` decorator is designed to skip tests under certain
circumstances. This is easiest to do if some assumptions are made about
which test runner is being used. For example, if one assumes that a
unittest-compatible test runner is likely to be used, then it makes
sense for the function to raise `unittest.SkipTest`.

However, Pulp Smash is being turned into a library that should be
compatible with other test runners. An effective way to help prevent
bias toward unittest is to avoid any references to unittest within the
code base. Add an `exc` parameter to the function, which is the
exception to be instantiated and raised.

See: https://github.com/PulpQE/pulp-smash/issues/1033