### PR TITLE
Drop unittest from Pulp 2 require_* utils

### DIFF
--- a/pulp_smash/pulp2/utils.py
+++ b/pulp_smash/pulp2/utils.py
@@ -308,46 +308,58 @@ def pulp_admin_login(cfg):
     ))
 
 
-def require_issue_3159():
+def require_issue_3159(exc):
     """Skip tests if Fedora 27 is under test and `Pulp #3159`_ is open.
+
+    :param exc: A class to instantiate and raise as an exception. Its
+        constructor must accept one string argument.
 
     .. _Pulp #3159: https://pulp.plan.io/issues/3159
     """
     cfg = config.get_config()
     if (not selectors.bug_is_fixed(3159, cfg.pulp_version) and
             utils.os_is_f27(cfg)):
-        raise unittest.SkipTest('https://pulp.plan.io/issues/3159')
+        raise exc('https://pulp.plan.io/issues/3159')
 
 
-def require_issue_3687():
+def require_issue_3687(exc):
     """Skip tests if Fedora 27 is under test and `Pulp #3687`_ is open.
+
+    :param exc: A class to instantiate and raise as an exception. Its
+        constructor must accept one string argument.
 
     .. _Pulp #3687: https://pulp.plan.io/issues/3687
     """
     cfg = config.get_config()
     if (not selectors.bug_is_fixed(3687, cfg.pulp_version) and
             utils.os_is_f27(cfg)):
-        raise unittest.SkipTest('https://pulp.plan.io/issues/3687')
+        raise exc('https://pulp.plan.io/issues/3687')
 
 
-def require_pulp_2():
-    """Skip tests if Pulp 2 isn't under test."""
+def require_pulp_2(exc):
+    """Skip tests if Pulp 2 isn't under test.
+
+    :param exc: A class to instantiate and raise as an exception. Its
+        constructor must accept one string argument.
+    """
     cfg = config.get_config()
     if cfg.pulp_version < Version('2') or cfg.pulp_version >= Version('3'):
-        raise unittest.SkipTest(
+        raise exc(
             'These tests are for Pulp 2, but Pulp {} is under test.'
             .format(cfg.pulp_version)
         )
 
 
-def require_unit_types(required_unit_types):
+def require_unit_types(required_unit_types, exc):
     """Skip tests if one or more unit types aren't supported.
 
     :param required_unit_types: A set of unit types IDs, e.g. ``{'ostree'}``.
+    :param exc: A class to instantiate and raise as an exception. Its
+        constructor must accept one string argument.
     """
     missing_unit_types = required_unit_types - get_unit_types()
     if missing_unit_types:
-        raise unittest.SkipTest(
+        raise exc(
             "The following unit types aren't supported by the Pulp "
             'application under test: {}'.format(missing_unit_types)
         )

--- a/pulp_smash/tests/pulp2/docker/utils.py
+++ b/pulp_smash/tests/pulp2/docker/utils.py
@@ -17,10 +17,10 @@ from pulp_smash.pulp2 import utils as pulp2_utils
 
 def set_up_module():
     """Skip tests if Pulp 2 isn't under test or if Docker isn't installed."""
-    pulp2_utils.require_pulp_2()
-    pulp2_utils.require_issue_3159()
-    pulp2_utils.require_issue_3687()
-    pulp2_utils.require_unit_types({'docker_image'})
+    pulp2_utils.require_pulp_2(SkipTest)
+    pulp2_utils.require_issue_3159(SkipTest)
+    pulp2_utils.require_issue_3687(SkipTest)
+    pulp2_utils.require_unit_types({'docker_image'}, SkipTest)
 
 
 def get_upstream_name(cfg):

--- a/pulp_smash/tests/pulp2/ostree/utils.py
+++ b/pulp_smash/tests/pulp2/ostree/utils.py
@@ -1,15 +1,17 @@
 # coding=utf-8
 """Utilities for interacting with OS tree."""
+from unittest import SkipTest
+
 from pulp_smash.pulp2 import utils
 from pulp_smash.utils import uuid4
 
 
 def set_up_module():
     """Skip tests if Pulp 2 isn't under test or if OSTree isn't installed."""
-    utils.require_pulp_2()
-    utils.require_issue_3159()
-    utils.require_issue_3687()
-    utils.require_unit_types({'ostree'})
+    utils.require_pulp_2(SkipTest)
+    utils.require_issue_3159(SkipTest)
+    utils.require_issue_3687(SkipTest)
+    utils.require_unit_types({'ostree'}, SkipTest)
 
 
 def gen_repo(**kwargs):

--- a/pulp_smash/tests/pulp2/platform/utils.py
+++ b/pulp_smash/tests/pulp2/platform/utils.py
@@ -8,9 +8,9 @@ from pulp_smash.pulp2 import utils
 
 def set_up_module():
     """Skip tests if Pulp 2 isn't under test."""
-    utils.require_pulp_2()
-    utils.require_issue_3159()
-    utils.require_issue_3687()
+    utils.require_pulp_2(unittest.SkipTest)
+    utils.require_issue_3159(unittest.SkipTest)
+    utils.require_issue_3687(unittest.SkipTest)
 
 
 def require_selinux():

--- a/pulp_smash/tests/pulp2/puppet/utils.py
+++ b/pulp_smash/tests/pulp2/puppet/utils.py
@@ -1,11 +1,13 @@
 # coding=utf-8
 """Utilities for Puppet tests."""
+from unittest import SkipTest
+
 from pulp_smash.pulp2 import utils
 
 
 def set_up_module():
     """Skip tests if Pulp 2 isn't under test or if Puppet isn't installed."""
-    utils.require_pulp_2()
-    utils.require_issue_3159()
-    utils.require_issue_3687()
-    utils.require_unit_types({'puppet_module'})
+    utils.require_pulp_2(SkipTest)
+    utils.require_issue_3159(SkipTest)
+    utils.require_issue_3687(SkipTest)
+    utils.require_unit_types({'puppet_module'}, SkipTest)

--- a/pulp_smash/tests/pulp2/python/utils.py
+++ b/pulp_smash/tests/pulp2/python/utils.py
@@ -9,10 +9,10 @@ from pulp_smash.pulp2 import utils
 
 def set_up_module():
     """Skip tests if Pulp 2 isn't under test or if Python isn't installed."""
-    utils.require_pulp_2()
-    utils.require_issue_3159()
-    utils.require_issue_3687()
-    utils.require_unit_types({'python_package'})
+    utils.require_pulp_2(SkipTest)
+    utils.require_issue_3159(SkipTest)
+    utils.require_issue_3687(SkipTest)
+    utils.require_unit_types({'python_package'}, SkipTest)
 
 
 skip_if = partial(selectors.skip_if, exc=SkipTest)  # pylint:disable=invalid-name

--- a/pulp_smash/tests/pulp2/rpm/utils.py
+++ b/pulp_smash/tests/pulp2/rpm/utils.py
@@ -13,10 +13,10 @@ from pulp_smash.pulp2 import utils as pulp2_utils
 
 def set_up_module():
     """Skip tests if Pulp 2 isn't under test or if RPM isn't installed."""
-    pulp2_utils.require_pulp_2()
-    pulp2_utils.require_issue_3159()
-    pulp2_utils.require_issue_3687()
-    pulp2_utils.require_unit_types({'rpm'})
+    pulp2_utils.require_pulp_2(SkipTest)
+    pulp2_utils.require_issue_3159(SkipTest)
+    pulp2_utils.require_issue_3687(SkipTest)
+    pulp2_utils.require_unit_types({'rpm'}, SkipTest)
 
 
 def check_issue_2277(cfg):


### PR DESCRIPTION
The various `require_*` methods in `pulp_smash.pulp2.utils` are designed
to skip tests under certain circumstances. This is easiest to do if some
assumptions are made about which test runner is being used. For example,
if one assumes that a unittest-compatible test runner is likely to be
used, then it makes sense for the functions to raise
`unittest.SkipTest`.

However, Pulp Smash is being turned into a library that should be
compatible with other test runners. An effective way to help prevent
bias toward unittest is to avoid any references to unittest within the
code base. Add an `exc` parameter to the functions, which is the
exception to be instantiated and raised.

See: https://github.com/PulpQE/pulp-smash/issues/1033