### PR TITLE
Drop unittest from @require_pulp_plugins

### DIFF
--- a/pulp_smash/pulp3/utils.py
+++ b/pulp_smash/pulp3/utils.py
@@ -55,14 +55,22 @@ def require_pulp_3():
         )
 
 
-def require_pulp_plugins(required_plugins):
-    """Skip tests if one or more plugins are missing.
+def require_pulp_plugins(required_plugins, exc):
+    """Raise an exception if one or more plugins are missing.
+
+    If the same exception should be pased each time this method is called,
+    consider using `functools.partial`_.
 
     :param required_plugins: A set of plugin names, e.g. ``{'pulp-file'}``.
+    :param exc: A class to instantiate and raise as an exception. Its
+        constructor must accept one string argument.
+
+    .. _functools.partial:
+        https://docs.python.org/3/library/functools.html#functools.partial
     """
     missing_plugins = required_plugins - get_plugins()
     if missing_plugins:
-        raise unittest.SkipTest(
+        raise exc(
             'The following plugins are required but not installed: {}'
             .format(missing_plugins)
         )

--- a/pulp_smash/tests/pulp3/file/utils.py
+++ b/pulp_smash/tests/pulp3/file/utils.py
@@ -50,7 +50,7 @@ def populate_pulp(cfg, url=None):
 def set_up_module():
     """Skip tests Pulp 3 isn't under test or if pulp-file isn't installed."""
     require_pulp_3()
-    require_pulp_plugins({'pulp_file'})
+    require_pulp_plugins({'pulp_file'}, SkipTest)
 
 
 skip_if = partial(selectors.skip_if, exc=SkipTest)  # pylint:disable=invalid-name

--- a/pulp_smash/tests/pulp3/pulpcore/utils.py
+++ b/pulp_smash/tests/pulp3/pulpcore/utils.py
@@ -10,7 +10,7 @@ from pulp_smash.pulp3.utils import require_pulp_3, require_pulp_plugins
 def set_up_module():
     """Skip tests Pulp 3 isn't under test or if pulpcore isn't installed."""
     require_pulp_3()
-    require_pulp_plugins({'pulpcore'})
+    require_pulp_plugins({'pulpcore'}, SkipTest)
 
 
 skip_if = partial(selectors.skip_if, exc=SkipTest)  # pylint:disable=invalid-name


### PR DESCRIPTION
The `@require_pulp_plugins` decorator is designed to skip tests under
certain circumstances. This is easiest to do if some assumptions are
made about which test runner is being used. For example, if one assumes
that a unittest-compatible test runner is likely to be used, then it
makes sense for the function to raise `unittest.SkipTest`.

However, Pulp Smash is being turned into a library that should be
compatible with other test runners. An effective way to help prevent
bias toward unittest is to avoid any references to unittest within the
code base. Add an `exc` parameter to the function, which is the
exception to be instantiated and raised.

See: https://github.com/PulpQE/pulp-smash/issues/1033