### PR TITLE
Drop unittest from @require_pulp_3

### DIFF
--- a/pulp_smash/pulp3/utils.py
+++ b/pulp_smash/pulp3/utils.py
@@ -1,7 +1,6 @@
 # coding=utf-8
 """Utility functions for Pulp 3 tests."""
 import random
-import unittest
 import warnings
 from copy import deepcopy
 from urllib.parse import urljoin, urlsplit
@@ -45,11 +44,21 @@ class JWTAuth(AuthBase):  # pylint:disable=too-few-public-methods
         return request
 
 
-def require_pulp_3():
-    """Skip tests if Pulp 3 isn't under test."""
+def require_pulp_3(exc):
+    """Raise an exception if Pulp 3 isn't under test.
+
+    If the same exception should be pased each time this method is called,
+    consider using `functools.partial`_.
+
+    :param exc: A class to instantiate and raise as an exception. Its
+        constructor must accept one string argument.
+
+    .. _functools.partial:
+        https://docs.python.org/3/library/functools.html#functools.partial
+    """
     cfg = config.get_config()
     if cfg.pulp_version < Version('3') or cfg.pulp_version >= Version('4'):
-        raise unittest.SkipTest(
+        raise exc(
             'These tests are for Pulp 3, but Pulp {} is under test.'
             .format(cfg.pulp_version)
         )

--- a/pulp_smash/tests/pulp3/file/utils.py
+++ b/pulp_smash/tests/pulp3/file/utils.py
@@ -49,7 +49,7 @@ def populate_pulp(cfg, url=None):
 
 def set_up_module():
     """Skip tests Pulp 3 isn't under test or if pulp-file isn't installed."""
-    require_pulp_3()
+    require_pulp_3(SkipTest)
     require_pulp_plugins({'pulp_file'}, SkipTest)
 
 

--- a/pulp_smash/tests/pulp3/pulpcore/utils.py
+++ b/pulp_smash/tests/pulp3/pulpcore/utils.py
@@ -9,7 +9,7 @@ from pulp_smash.pulp3.utils import require_pulp_3, require_pulp_plugins
 
 def set_up_module():
     """Skip tests Pulp 3 isn't under test or if pulpcore isn't installed."""
-    require_pulp_3()
+    require_pulp_3(SkipTest)
     require_pulp_plugins({'pulpcore'}, SkipTest)
 
 


### PR DESCRIPTION
The `@require_pulp_3` decorator is designed to skip tests under certain
circumstances. This is easiest to do if some assumptions are made about
which test runner is being used. For example, if one assumes that a
unittest-compatible test runner is likely to be used, then it makes
sense for the function to raise `unittest.SkipTest`.

However, Pulp Smash is being turned into a library that should be
compatible with other test runners. An effective way to help prevent
bias toward unittest is to avoid any references to unittest within the
code base. Add an `exc` parameter to the function, which is the
exception to be instantiated and raised.

See: https://github.com/PulpQE/pulp-smash/issues/1033