### PR TITLE
Add basic test coverage to pagination.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -142,6 +142,7 @@ developers, not a gospel.
     api/pulp_smash.tests.pulp3.file.api_v3.test_crud_remotes
     api/pulp_smash.tests.pulp3.file.api_v3.test_download_content
     api/pulp_smash.tests.pulp3.file.api_v3.test_orphans
+    api/pulp_smash.tests.pulp3.file.api_v3.test_pagination
     api/pulp_smash.tests.pulp3.file.api_v3.test_publish
     api/pulp_smash.tests.pulp3.file.api_v3.test_repo_version
     api/pulp_smash.tests.pulp3.file.api_v3.test_sync

--- a/docs/api/pulp_smash.tests.pulp3.file.api_v3.test_pagination.rst
+++ b/docs/api/pulp_smash.tests.pulp3.file.api_v3.test_pagination.rst
@@ -1,0 +1,6 @@
+`pulp_smash.tests.pulp3.file.api_v3.test_pagination`
+====================================================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.pulp3.file.api_v3.test_pagination`
+
+.. automodule:: pulp_smash.tests.pulp3.file.api_v3.test_pagination

--- a/pulp_smash/constants.py
+++ b/pulp_smash/constants.py
@@ -125,6 +125,9 @@ FILE_LARGE_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'file-large/')
 FILE_MANY_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'file-many/')
 """The URL to a file repository containing many files."""
 
+FILE_MANY_FEED_COUNT = 250
+"""The number of packages available at :data:`FILE_MANY_FEED_URL`."""
+
 FILE_MIXED_FEED_URL = urljoin(PULP_FIXTURES_BASE_URL, 'file-mixed/')
 """The URL to a file repository containing invalid and valid entries."""
 

--- a/pulp_smash/tests/pulp3/file/api_v3/test_pagination.py
+++ b/pulp_smash/tests/pulp3/file/api_v3/test_pagination.py
@@ -1,0 +1,64 @@
+# coding=utf-8
+"""Tests related to pagination."""
+import unittest
+from random import randint, sample
+from urllib.parse import urljoin
+
+from pulp_smash import api, config
+from pulp_smash.constants import FILE_MANY_FEED_COUNT, FILE_MANY_FEED_URL
+from pulp_smash.tests.pulp3.file.utils import populate_pulp
+from pulp_smash.pulp3.constants import FILE_CONTENT_PATH, REPO_PATH
+from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
+from pulp_smash.pulp3.utils import (
+    gen_repo,
+    get_added_content,
+    get_auth,
+    get_content,
+    get_removed_content,
+    get_versions,
+)
+
+
+class PaginationTestCase(unittest.TestCase):
+    """Test pagination."""
+
+    # pylint:disable=unsubscriptable-object
+    @classmethod
+    def setUpClass(cls):
+        """Create class-wide variables."""
+        cls.cfg = config.get_config()
+        cls.client = api.Client(cls.cfg, api.page_handler)
+        cls.client.request_kwargs['auth'] = get_auth(cls.cfg)
+        populate_pulp(cls.cfg, urljoin(FILE_MANY_FEED_URL, 'PULP_MANIFEST'))
+
+    def test_repos(self):
+        """Test pagination for repositories."""
+        number_of_repos = randint(100, 150)
+        for _ in range(number_of_repos):
+            repo = self.client.post(REPO_PATH, gen_repo())
+            self.addCleanup(self.client.delete, repo['_href'])
+        repos = self.client.get(REPO_PATH)
+        self.assertEqual(len(repos), number_of_repos, repos)
+
+    def test_content(self):
+        """Test pagination for different endpoints.
+
+        Test pagination for repository versions, added and removed content.
+        """
+        repo = self.client.post(REPO_PATH, gen_repo())
+        self.addCleanup(self.client.delete, repo['_href'])
+        contents = sample(self.client.get(FILE_CONTENT_PATH), FILE_MANY_FEED_COUNT)
+        for content in contents:
+            self.client.post(
+                repo['_versions_href'],
+                {'add_content_units': [content['_href']]}
+            )
+        repo = self.client.get(repo['_href'])
+        repo_versions = get_versions(repo)
+        self.assertEqual(len(repo_versions), FILE_MANY_FEED_COUNT, repo_versions)
+        content = get_content(repo)
+        self.assertEqual(len(content), FILE_MANY_FEED_COUNT, content)
+        added_content = get_added_content(repo)
+        self.assertEqual(len(added_content), 1, added_content)
+        removed_content = get_removed_content(repo)
+        self.assertEqual(len(removed_content), 0, removed_content)


### PR DESCRIPTION
Explore the use of `page_hanlder` and test pagination for different
endpoints.

Use the just added `FILE_MANY_FEED_URL` to trigger pagination and make
assertions about the content.

Add a new constant `FILE_MANY_FEED_COUNT`.

This test was created based on the MVP documentation, and auto generated
docs.