### PR TITLE
Add deprecation warning to BaseAPICrudTestCase

### DIFF
--- a/pulp_smash/pulp2/utils.py
+++ b/pulp_smash/pulp2/utils.py
@@ -40,6 +40,15 @@ class BaseAPICrudTestCase(unittest.TestCase):
         http://docs.pulpproject.org/en/latest/dev-guide/integration/rest-api/repo/cud.html#delete-a-repository
     """
 
+    def __init__(self, *args, **kwargs):
+        """Raise a deprecation warning."""
+        warnings.warn(
+            'Avoid using BaseAPICrudTestCase. It is coupled to the unittest '
+            'test runner.',
+            DeprecationWarning
+        )
+        super().__init__(*args, **kwargs)
+
     @classmethod
     def setUpClass(cls):
         """Create, update, read and delete a repository."""


### PR DESCRIPTION
Make the warning message point out that this class is coupled to
unittest.

See: https://github.com/PulpQE/pulp-smash/issues/1033