### PR TITLE
Test last_override_config, drop a BaseAPITestCase

### DIFF
--- a/pulp_smash/tests/pulp2/docker/api_v2/test_sync.py
+++ b/pulp_smash/tests/pulp2/docker/api_v2/test_sync.py
@@ -4,11 +4,11 @@ import unittest
 from urllib.parse import urljoin
 
 from packaging.version import Version
+from requests.exceptions import HTTPError
 
 from pulp_smash import api, config, selectors
 from pulp_smash.constants import DOCKER_V1_FEED_URL, DOCKER_V2_FEED_URL
 from pulp_smash.pulp2.constants import REPOSITORY_PATH
-from pulp_smash.pulp2.utils import BaseAPITestCase
 from pulp_smash.tests.pulp2.docker.api_v2.utils import gen_repo
 from pulp_smash.tests.pulp2.docker.utils import (
     get_upstream_name,
@@ -23,80 +23,130 @@ def setUpModule():  # pylint:disable=invalid-name
         raise unittest.SkipTest('These tests require at least Pulp 2.8.')
 
 
-class UpstreamNameTestsMixin():
-    """Provides tests that sync a repository and override ``upstream_name``.
+class UpstreamNameTestCase(unittest.TestCase):
+    """Sync v1 and Docker repositories with varying ``upstream_name``."""
 
-    Any class inheriting from this mixin must also inherit from
-    :class:`pulp_smash.pulp2.utils.BaseAPITestCase`.
-    """
+    @classmethod
+    def setUpClass(cls):
+        """Create shared variables."""
+        cls.cfg = config.get_config()
+        cls.client = api.Client(cls.cfg, api.json_handler)
 
-    def test_valid_upstream_name(self):
-        """Sync the repository and pass a valid ``upstream_name``.
+    def test_v1_valid_upstream_name(self):
+        """Sync a v1 Docker repository with a valid ``upstream_name``.
 
-        Verify the sync succeeds.
+        Do the following:
+
+        1. Create a v1 Docker repository.
+        2. Sync the repository with a valid upstream name, and assert it
+           succeeds.
+
+        In addition, verify its ``last_override_config`` attribute is an empty
+        dict after each step.
         """
-        api.Client(self.cfg).post(
-            urljoin(self.repo_href, 'actions/sync/'),
+        repo = self._do_create_v1_repo()
+        self._do_test_last_override_config(repo)
+        self._do_test_valid_upstream_name(repo)
+        self._do_test_last_override_config(repo)
+
+    def test_v1_invalid_upstream_name(self):
+        """Sync a v1 Docker repository with a invalid ``upstream_name``.
+
+        Do the following:
+
+        1. Create a v1 Docker repository.
+        2. Sync the repository with an invalid upstream name, and assert it
+           succeeds.
+
+        In addition, verify its ``last_override_config`` attribute is an empty
+        dict after each step.
+        """
+        repo = self._do_create_v1_repo()
+        self._do_test_last_override_config(repo)
+        self._do_test_invalid_upstream_name(repo)
+        self._do_test_last_override_config(repo)
+
+    def test_v2_valid_upstream_name(self):
+        """Sync a v2 Docker repository with a valid ``upstream_name``.
+
+        Do the same as :meth:`test_v1_valid_upstream_name`, but with a v2
+        repository.
+        """
+        repo = self._do_create_v2_repo()
+        self._do_test_last_override_config(repo)
+        self._do_test_valid_upstream_name(repo)
+        self._do_test_last_override_config(repo)
+
+    def test_v2_invalid_upstream_name(self):
+        """Sync a v2 Docker repository with a invalid ``upstream_name``.
+
+        Do the same as :meth:`test_v1_invalid_upstream_name`, but with a v2
+        repository.
+        """
+        repo = self._do_create_v2_repo()
+        self._do_test_last_override_config(repo)
+        self._do_test_invalid_upstream_name(repo)
+        self._do_test_last_override_config(repo)
+
+    def _do_create_v1_repo(self):
+        """Create a v1 Docker repository, and schedule it for deletion.
+
+        The repository's importer has no ``upstream_name`` set. One must be
+        passed via an ``override_config`` when a sync is requested.
+        """
+        repo = self.client.post(
+            REPOSITORY_PATH,
+            gen_repo(importer_config={
+                'enable_v1': True,
+                'enable_v2': False,
+                'feed': DOCKER_V1_FEED_URL,
+            })
+        )
+        self.addCleanup(self.client.delete, repo['_href'])
+        return repo
+
+    def _do_create_v2_repo(self):
+        """Create a v2 Docker repository, and schedule it for deletion.
+
+        The repository's importer has no ``upstream_name`` set. One must be
+        passed via an ``override_config`` when a sync is requested.
+        """
+        repo = self.client.post(
+            REPOSITORY_PATH,
+            gen_repo(importer_config={'feed': DOCKER_V2_FEED_URL}),
+        )
+        self.addCleanup(self.client.delete, repo['_href'])
+        return repo
+
+    def _do_test_last_override_config(self, repo):
+        """Assert ``last_override_config`` is empty.
+
+        This method tests `Pulp #3521 <https://pulp.plan.io/issues/3521>`_.
+        """
+        if not selectors.bug_is_fixed(3521, self.cfg.pulp_version):
+            self.skipTest('https://pulp.plan.io/issues/3521')
+        repo = self.client.get(repo['_href'], params={'details': True})
+        self.assertEqual(repo['importers'][0]['last_override_config'], {})
+
+    def _do_test_valid_upstream_name(self, repo):
+        """Sync a v1 Docker repository with a valid ``upstream_name``."""
+        self.client.post(
+            urljoin(repo['_href'], 'actions/sync/'),
             {'override_config': {'upstream_name': get_upstream_name(self.cfg)}}
         )
 
-    def test_invalid_upstream_name(self):
-        """Sync the repository and pass an invalid ``upstream_name``.
+    def _do_test_invalid_upstream_name(self, repo):
+        """Sync a v2 Docker repository with an invalid ``upstream_name``.
 
-        Verify the sync request is rejected with an HTTP 400 status code.
+        This method tests `Pulp #2230 <https://pulp.plan.io/issues/2230>`_.
         """
         if not selectors.bug_is_fixed(2230, self.cfg.pulp_version):
             self.skipTest('https://pulp.plan.io/issues/2230')
-        docker_upstream_name = get_upstream_name(self.cfg).replace('/', ' ')
-        response = api.Client(self.cfg, api.echo_handler).post(
-            urljoin(self.repo_href, 'actions/sync/'),
-            {'override_config': {'upstream_name': docker_upstream_name}},
-        )
-        self.assertEqual(response.status_code, 400)
-
-
-class UpstreamNameV1TestCase(UpstreamNameTestsMixin, BaseAPITestCase):
-    """Sync a v1 docker repository with various ``upstream_name`` options.
-
-    This test targets `Pulp #2230 <https://pulp.plan.io/issues/2230-docker>`_.
-    """
-
-    @classmethod
-    def setUpClass(cls):
-        """Create a docker repository with an importer.
-
-        The importer has no ``upstream_name`` set. it must be passed via
-        ``override_config`` when a sync is requested.
-        """
-        super().setUpClass()
-        body = gen_repo()
-        body['importer_config'] = {
-            'enable_v1': True,
-            'feed': DOCKER_V1_FEED_URL,
-        }
-        cls.repo_href = (
-            api.Client(cls.cfg).post(REPOSITORY_PATH, body).json()['_href']
-        )
-        cls.resources.add(cls.repo_href)
-
-
-class UpstreamNameV2TestCase(UpstreamNameTestsMixin, BaseAPITestCase):
-    """Sync a v2 docker repository with various ``upstream_name`` options.
-
-    This test targets `Pulp #2230 <https://pulp.plan.io/issues/2230-docker>`_.
-    """
-
-    @classmethod
-    def setUpClass(cls):
-        """Create a docker repository with an importer.
-
-        The importer has no ``upstream_name`` set. it must be passed via
-        ``override_config`` when a sync is requested.
-        """
-        super().setUpClass()
-        body = gen_repo()
-        body['importer_config'] = {'feed': DOCKER_V2_FEED_URL}
-        cls.repo_href = (
-            api.Client(cls.cfg).post(REPOSITORY_PATH, body).json()['_href']
-        )
-        cls.resources.add(cls.repo_href)
+        with self.assertRaises(HTTPError):
+            self.client.post(
+                urljoin(repo['_href'], 'actions/sync/'),
+                {'override_config': {
+                    'upstream_name':
+                    get_upstream_name(self.cfg).replace('/', ' ')
+                }},
+            )


### PR DESCRIPTION
Rewrite `pulp_smash.tests.pulp2.docker.api_v2.test_sync`:

* Drop `BaseAPITestCase` from the module.
* Assert that `last_override_config` is an empty dict.
* Restructure the tests to be more independent.

See: https://github.com/PulpQE/pulp-smash/issues/763

Fix: https://github.com/PulpQE/pulp-smash/issues/1066