### PR TITLE
Change signature of upload_import_erratum()

### DIFF
--- a/pulp_smash/pulp2/utils.py
+++ b/pulp_smash/pulp2/utils.py
@@ -483,7 +483,7 @@ def sync_repo(cfg, repo):
     return api.Client(cfg).post(urljoin(repo['_href'], 'actions/sync/'))
 
 
-def upload_import_erratum(cfg, erratum, repo_href):
+def upload_import_erratum(cfg, erratum, repo):
     """Upload an erratum to a Pulp server and import it into a repository.
 
     For most content types, use :meth:`upload_import_unit`.
@@ -492,18 +492,20 @@ def upload_import_erratum(cfg, erratum, repo_href):
         the Pulp server being targeted.
     :param erratum: A dict, with keys such as "id," "status," "issued," and
         "references."
-    :param repo_href: The path to the repository into which ``erratum`` will be
-        imported.
+    :param repo: A dict. The repository into which ``erratum`` be imported.
     :returns: The call report returned when importing the erratum.
     """
     client = api.Client(cfg, api.json_handler)
     malloc = client.post(CONTENT_UPLOAD_PATH)
-    call_report = client.post(urljoin(repo_href, 'actions/import_upload/'), {
-        'unit_key': {'id': erratum['id']},
-        'unit_metadata': erratum,
-        'unit_type_id': 'erratum',
-        'upload_id': malloc['upload_id'],
-    })
+    call_report = client.post(
+        urljoin(repo['_href'], 'actions/import_upload/'),
+        {
+            'unit_key': {'id': erratum['id']},
+            'unit_metadata': erratum,
+            'unit_type_id': 'erratum',
+            'upload_id': malloc['upload_id'],
+        }
+    )
     client.delete(malloc['_href'])
     return call_report
 

--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_updateinfo.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_updateinfo.py
@@ -185,7 +185,7 @@ class UpdateInfoTestCase(BaseAPITestCase):
                 cls.cfg, unit, {'unit_type_id': 'rpm'}, repo
             )
             for key, erratum in cls.errata.items():
-                report = upload_import_erratum(cls.cfg, erratum, repo['_href'])
+                report = upload_import_erratum(cls.cfg, erratum, repo)
                 cls.tasks[key] = tuple(api.poll_spawned_tasks(cls.cfg, report))
             publish_repo(cls.cfg, repo)
 

--- a/tests/test_pulp2_utils.py
+++ b/tests/test_pulp2_utils.py
@@ -142,7 +142,7 @@ class SyncRepoTestCase(unittest.TestCase):
 
 
 class UploadImportErratumTestCase(unittest.TestCase):
-    """Test :func:`pulp_smash.pulp2.utils.upload_import_unit`."""
+    """Test :func:`pulp_smash.pulp2.utils.upload_import_erratum`."""
 
     def test_post(self):
         """Assert the function makes an HTTP POST request."""
@@ -158,7 +158,7 @@ class UploadImportErratumTestCase(unittest.TestCase):
             response = upload_import_erratum(
                 mock.Mock(),  # cfg
                 {'id': 'abc123'},  # erratum
-                'http://example.com',  # repo_href
+                {'_href': 'http://example.com'},  # repo
             )
         self.assertIs(response, client.return_value.post.return_value)
 


### PR DESCRIPTION
Update the `upload_import_erratum` function so that it accepts an entire
dict of information about a repository, instead of just a repository
href. This has two benefits:

* Variable passing is easier. Rather than worrying about which bits of
  information are required where, one can typically just pass the
  information returned by Pulp itself.
* The function is now more like other, similar functions, which makes
  usage more intuitive.