### PR TITLE
Make assertion on prose more lax

### DIFF
--- a/pulp_smash/tests/pulp2/rpm/api_v2/test_upload_publish.py
+++ b/pulp_smash/tests/pulp2/rpm/api_v2/test_upload_publish.py
@@ -514,7 +514,7 @@ class UploadInvalidRPMTestCase(unittest.TestCase):
 
         # Assert that rturned error contains a descriptive message
         self.assertIsNotNone(task['error']['description'])
-        self.assertIn('upload', task['error']['description'])
+        self.assertIn('upload', task['error']['description'].lower())
 
         # Verify that the repository contains no RPMs
         rpm = search_units(cfg, repo, {'type_ids': ('rpm',)})


### PR DESCRIPTION
`UploadInvalidRPMTestCase` verifies that a certain string is in a prose
error message. That prose error message has changed in the current
development branch of Pulp. Make the test case slightly more lax, so
that it passes on either version of Pulp, all without reducing the
integrity of the test case by an appreciable amount.