### PR TITLE
Move certain "file" tests underneath the "pulpcore" dir

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -135,22 +135,23 @@ developers, not a gospel.
     api/pulp_smash.tests.pulp3.constants
     api/pulp_smash.tests.pulp3.file
     api/pulp_smash.tests.pulp3.file.api_v3
-    api/pulp_smash.tests.pulp3.file.api_v3.test_auto_distribution
     api/pulp_smash.tests.pulp3.file.api_v3.test_crd_publications
     api/pulp_smash.tests.pulp3.file.api_v3.test_crud_content_unit
     api/pulp_smash.tests.pulp3.file.api_v3.test_crud_publishers
     api/pulp_smash.tests.pulp3.file.api_v3.test_crud_remotes
     api/pulp_smash.tests.pulp3.file.api_v3.test_download_content
-    api/pulp_smash.tests.pulp3.file.api_v3.test_orphans
-    api/pulp_smash.tests.pulp3.file.api_v3.test_pagination
     api/pulp_smash.tests.pulp3.file.api_v3.test_publish
-    api/pulp_smash.tests.pulp3.file.api_v3.test_repo_version
     api/pulp_smash.tests.pulp3.file.api_v3.test_sync
-    api/pulp_smash.tests.pulp3.file.api_v3.test_unlinking_repo
     api/pulp_smash.tests.pulp3.file.api_v3.utils
     api/pulp_smash.tests.pulp3.file.utils
     api/pulp_smash.tests.pulp3.pulpcore
     api/pulp_smash.tests.pulp3.pulpcore.api_v3
+    api/pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved
+    api/pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved.test_auto_distribution
+    api/pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved.test_orphans
+    api/pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved.test_pagination
+    api/pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved.test_repo_version
+    api/pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved.test_unlinking_repo
     api/pulp_smash.tests.pulp3.pulpcore.api_v3.test_api_docs
     api/pulp_smash.tests.pulp3.pulpcore.api_v3.test_auth
     api/pulp_smash.tests.pulp3.pulpcore.api_v3.test_crd_artifacts

--- a/docs/api/pulp_smash.tests.pulp3.file.api_v3.test_auto_distribution.rst
+++ b/docs/api/pulp_smash.tests.pulp3.file.api_v3.test_auto_distribution.rst
@@ -1,6 +1,0 @@
-`pulp_smash.tests.pulp3.file.api_v3.test_auto_distribution`
-===========================================================
-
-Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.pulp3.file.api_v3.test_auto_distribution`
-
-.. automodule:: pulp_smash.tests.pulp3.file.api_v3.test_auto_distribution

--- a/docs/api/pulp_smash.tests.pulp3.file.api_v3.test_orphans.rst
+++ b/docs/api/pulp_smash.tests.pulp3.file.api_v3.test_orphans.rst
@@ -1,6 +1,0 @@
-`pulp_smash.tests.pulp3.file.api_v3.test_orphans`
-=================================================
-
-Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.pulp3.file.api_v3.test_orphans`
-
-.. automodule:: pulp_smash.tests.pulp3.file.api_v3.test_orphans

--- a/docs/api/pulp_smash.tests.pulp3.file.api_v3.test_pagination.rst
+++ b/docs/api/pulp_smash.tests.pulp3.file.api_v3.test_pagination.rst
@@ -1,6 +1,0 @@
-`pulp_smash.tests.pulp3.file.api_v3.test_pagination`
-====================================================
-
-Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.pulp3.file.api_v3.test_pagination`
-
-.. automodule:: pulp_smash.tests.pulp3.file.api_v3.test_pagination

--- a/docs/api/pulp_smash.tests.pulp3.file.api_v3.test_repo_version.rst
+++ b/docs/api/pulp_smash.tests.pulp3.file.api_v3.test_repo_version.rst
@@ -1,6 +1,0 @@
-`pulp_smash.tests.pulp3.file.api_v3.test_repo_version`
-======================================================
-
-Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.pulp3.file.api_v3.test_repo_version`
-
-.. automodule:: pulp_smash.tests.pulp3.file.api_v3.test_repo_version

--- a/docs/api/pulp_smash.tests.pulp3.file.api_v3.test_unlinking_repo.rst
+++ b/docs/api/pulp_smash.tests.pulp3.file.api_v3.test_unlinking_repo.rst
@@ -1,6 +1,0 @@
-`pulp_smash.tests.pulp3.file.api_v3.test_unlinking_repo`
-========================================================
-
-Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.pulp3.file.api_v3.test_unlinking_repo`
-
-.. automodule:: pulp_smash.tests.pulp3.file.api_v3.test_unlinking_repo

--- a/docs/api/pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved.rst
+++ b/docs/api/pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved.rst
@@ -1,0 +1,6 @@
+`pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved`
+========================================================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved`
+
+.. automodule:: pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved

--- a/docs/api/pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved.test_auto_distribution.rst
+++ b/docs/api/pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved.test_auto_distribution.rst
@@ -1,0 +1,6 @@
+`pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved.test_auto_distribution`
+===============================================================================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved.test_auto_distribution`
+
+.. automodule:: pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved.test_auto_distribution

--- a/docs/api/pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved.test_orphans.rst
+++ b/docs/api/pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved.test_orphans.rst
@@ -1,0 +1,6 @@
+`pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved.test_orphans`
+=====================================================================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved.test_orphans`
+
+.. automodule:: pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved.test_orphans

--- a/docs/api/pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved.test_pagination.rst
+++ b/docs/api/pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved.test_pagination.rst
@@ -1,0 +1,6 @@
+`pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved.test_pagination`
+========================================================================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved.test_pagination`
+
+.. automodule:: pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved.test_pagination

--- a/docs/api/pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved.test_repo_version.rst
+++ b/docs/api/pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved.test_repo_version.rst
@@ -1,0 +1,6 @@
+`pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved.test_repo_version`
+==========================================================================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved.test_repo_version`
+
+.. automodule:: pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved.test_repo_version

--- a/docs/api/pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved.test_unlinking_repo.rst
+++ b/docs/api/pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved.test_unlinking_repo.rst
@@ -1,0 +1,6 @@
+`pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved.test_unlinking_repo`
+============================================================================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved.test_unlinking_repo`
+
+.. automodule:: pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved.test_unlinking_repo

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/plugin_involved/__init__.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/plugin_involved/__init__.py
@@ -1,0 +1,16 @@
+# coding=utf-8
+"""Tests for core functionality that require plugin involvement to exercise."""
+
+from unittest import SkipTest
+
+from pulp_smash.pulp3.utils import require_pulp_3, require_pulp_plugins
+
+
+def set_up_module():
+    """Conditions to skip tests.
+
+    Skip tests if not testing Pulp 3, or if either pulpcore or pulp_file
+    aren't installed.
+    """
+    require_pulp_3(SkipTest)
+    require_pulp_plugins({'pulpcore', 'pulp_file'}, SkipTest)

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/plugin_involved/test_auto_distribution.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/plugin_involved/test_auto_distribution.py
@@ -15,9 +15,6 @@ from pulp_smash.pulp3.constants import (
     FILE_REMOTE_PATH,
     REPO_PATH,
 )
-from pulp_smash.tests.pulp3.file.api_v3.utils import gen_publisher
-from pulp_smash.tests.pulp3.file.utils import populate_pulp
-from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_smash.pulp3.utils import (
     delete_orphans,
     gen_distribution,
@@ -28,6 +25,12 @@ from pulp_smash.pulp3.utils import (
     get_versions,
     publish,
     sync,
+)
+
+from pulp_smash.tests.pulp3.file.api_v3.utils import gen_publisher
+from pulp_smash.tests.pulp3.file.utils import populate_pulp
+from pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved import (  # pylint:disable=unused-import
+    set_up_module as setUpModule
 )
 
 

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/plugin_involved/test_orphans.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/plugin_involved/test_orphans.py
@@ -16,8 +16,6 @@ from pulp_smash.pulp3.constants import (
     FILE_REMOTE_PATH,
     REPO_PATH,
 )
-
-from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_smash.pulp3.utils import (
     delete_orphans,
     delete_version,
@@ -27,6 +25,9 @@ from pulp_smash.pulp3.utils import (
     get_content,
     get_versions,
     sync,
+)
+from pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved import (  # pylint:disable=unused-import
+    set_up_module as setUpModule
 )
 
 

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/plugin_involved/test_pagination.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/plugin_involved/test_pagination.py
@@ -7,10 +7,12 @@ from urllib.parse import urljoin
 
 from pulp_smash import api, config
 from pulp_smash.constants import FILE_MANY_FEED_COUNT, FILE_MANY_FEED_URL
-from pulp_smash.tests.pulp3.file.utils import populate_pulp
 from pulp_smash.pulp3.constants import FILE_CONTENT_PATH, REPO_PATH
-from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_smash.pulp3.utils import gen_repo, get_auth, get_versions
+from pulp_smash.tests.pulp3.file.utils import populate_pulp
+from pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved import (  # pylint:disable=unused-import
+    set_up_module as setUpModule
+)
 
 
 class PaginationTestCase(unittest.TestCase):

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/plugin_involved/test_repo_version.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/plugin_involved/test_repo_version.py
@@ -19,9 +19,6 @@ from pulp_smash.pulp3.constants import (
     FILE_PUBLISHER_PATH,
     REPO_PATH,
 )
-from pulp_smash.tests.pulp3.file.api_v3.utils import gen_publisher
-from pulp_smash.tests.pulp3.file.utils import populate_pulp, skip_if
-from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_smash.pulp3.utils import (
     delete_version,
     gen_remote,
@@ -34,6 +31,11 @@ from pulp_smash.pulp3.utils import (
     get_versions,
     publish,
     sync,
+)
+from pulp_smash.tests.pulp3.file.api_v3.utils import gen_publisher
+from pulp_smash.tests.pulp3.file.utils import populate_pulp, skip_if
+from pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved import (  # pylint:disable=unused-import
+    set_up_module as setUpModule
 )
 
 

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/plugin_involved/test_unlinking_repo.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/plugin_involved/test_unlinking_repo.py
@@ -12,7 +12,6 @@ from pulp_smash.pulp3.constants import (
     REPO_PATH,
 )
 from pulp_smash.tests.pulp3.file.api_v3.utils import gen_publisher
-from pulp_smash.tests.pulp3.file.utils import set_up_module as setUpModule  # pylint:disable=unused-import
 from pulp_smash.pulp3.utils import (
     gen_remote,
     gen_repo,
@@ -20,6 +19,9 @@ from pulp_smash.pulp3.utils import (
     get_content,
     publish,
     sync,
+)
+from pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved import (  # pylint:disable=unused-import
+    set_up_module as setUpModule
 )
 
 


### PR DESCRIPTION
Some tests for the file plugin are really only testing pulpcore
functionality, however, they require a plugin in order to
exercise said functionality. re: discussion with Jeremy, it
makes sense to move these tests underneath pulpcore, but skip
them if the file plugin is not installed.