### PR TITLE
Make settings machinery support Pulp 3

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -89,7 +89,8 @@ you declare properties of the individual hosts that comprise the Pulp
 application.
 
 Each host must fulfill the "shell" role. In addition, the hosts must
-collectively fulfill the :obj:`pulp_smash.config.REQUIRED_ROLES`.
+collectively fulfill either :obj:`pulp_smash.config.P2_REQUIRED_ROLES` or
+:obj:`pulp_smash.config.P3_REQUIRED_ROLES`.
 
 Not all roles requires additional information. Currently, only the ``amqp
 broker``, ``api`` and ``shell`` roles do. The ``amqp broker`` object must have a

--- a/pulp_smash/exceptions.py
+++ b/pulp_smash/exceptions.py
@@ -60,17 +60,14 @@ class ConfigValidationError(Exception):
         configuration validation is handled.
     """
 
-    def __init__(self, error_messages, *args, **kwargs):
-        """Require that the validation messages list is defined."""
-        super().__init__(error_messages, *args, **kwargs)
-        self.error_messages = error_messages
+    def __init__(self, message, *args, **kwargs):
+        """Require that an error message be provided."""
+        super().__init__(message, *args, **kwargs)
+        self.message = message
 
     def __str__(self):
         """Provide a human-friendly string representation of this exception."""
-        return (
-            'Configuration file is not valid:\n\n'
-            '{}'
-        ).format('\n'.join(self.error_messages))
+        return 'Pulp Smash configuration is invalid: {}'.format(self.message)
 
 
 class ConfigFileSectionNotFoundError(Exception):

--- a/pulp_smash/pulp_smash_cli.py
+++ b/pulp_smash/pulp_smash_cli.py
@@ -1,8 +1,10 @@
 # coding=utf-8
 """The entry point for Pulp Smash's command line interface."""
 import json
+import sys
 
 import click
+from packaging.version import Version
 
 from pulp_smash import config, exceptions
 from pulp_smash.config import PulpSmashConfig
@@ -39,109 +41,220 @@ def settings(ctx):
 
 @settings.command('create')
 @click.pass_context
-def settings_create(ctx):  # pylint:disable=too-many-locals
+def settings_create(ctx):
     """Create a settings file."""
+    # Choose where and whether to save the configuration file.
     path = ctx.obj['load_path']
     if path:
-        click.echo(
-            'A settings file already exists. Continuing will override it.'
+        click.confirm(
+            'A settings file already exists. Continuing will override it. '
+            'Do you want to continue?',
+            abort=True,
         )
-        click.confirm('Do you want to continue?', abort=True)
     else:
         path = ctx.obj['save_path']
-    pulp_username = click.prompt('Pulp admin username', default='admin')
-    pulp_password = click.prompt('Pulp admin password', default='admin')
-    pulp_version = click.prompt('Pulp version')
-    pulp_selinux_enabled = click.confirm(
-        'Is SELinux supported in the test environment?',
-        default=True
+
+    # Get information about Pulp.
+    pulp_config = {'pulp': _get_pulp_properties()}
+    pulp_config['hosts'] = [
+        _get_host_properties(pulp_config['pulp']['version'])
+    ]
+    pulp_config['pulp']['version'] = str(pulp_config['pulp']['version'])
+    try:
+        config.validate_config(pulp_config)  # This should NEVER fail!
+    except exceptions.ConfigValidationError:
+        print(
+            'An internal error has occurred. Please report this to the Pulp '
+            'Smash developers at https://github.com/PulpQE/pulp-smash/issues',
+            file=sys.stderr,
+        )
+        raise
+
+    # Write the config to disk.
+    with open(path, 'w') as handler:
+        handler.write(json.dumps(pulp_config, indent=2, sort_keys=True))
+    click.echo('Settings written to {}.'.format(path))
+
+
+def _get_pulp_properties():
+    """Get information about the Pulp application as a whole."""
+    version = click.prompt(
+        'Which version of Pulp is under test?',
+        type=PulpVersionType()
     )
-    host_hostname = click.prompt('Host hostname')
-    if click.confirm(
-            "Is Pulp's API available over HTTPS (no for HTTP)?", default=True):
-        host_api_scheme = 'https'
-    else:
-        host_api_scheme = 'http'
+    username = click.prompt(
+        "What is the Pulp administrative user's username?",
+        default='admin',
+        type=click.STRING,
+    )
+    password = click.prompt(
+        "What is the Pulp administrative user's password?",
+        default='admin',
+        type=click.STRING,
+    )
+    # We could make this default to "false" if version >= 3, but it seems
+    # better to assume that Pulp is secure by default, and to annoy everyone
+    # about Pulp 3's lack of security.
+    selinux_enabled = click.confirm(
+        'Is SELinux supported on the Pulp hosts?',
+        default=True,
+    )
+    return {
+        'auth': [username, password],
+        'selinux enabled': selinux_enabled,
+        'version': version,
+    }
 
-    if (host_api_scheme == 'https' and
+
+def _get_host_properties(pulp_version):
+    """Get information about a Pulp host."""
+    if pulp_version < Version('3'):
+        return _get_v2_host_properties(pulp_version)
+    return _get_v3_host_properties(pulp_version)
+
+
+def _get_v2_host_properties(pulp_version):
+    """Get information about a Pulp 2 host."""
+    hostname = _get_hostname()
+    amqp_broker = _get_amqp_broker_role()
+    api_role = _get_api_role(pulp_version)
+    shell_role = _get_shell_role(hostname)
+    return {
+        'hostname': hostname,
+        'roles': {
+            'amqp broker': {'service': amqp_broker},
+            'api': api_role,
+            'mongod': {},
+            'pulp celerybeat': {},
+            'pulp cli': {},
+            'pulp resource manager': {},
+            'pulp workers': {},
+            'shell': shell_role,
+            'squid': {},
+        }
+    }
+
+
+def _get_v3_host_properties(pulp_version):
+    """Get information about a Pulp 3 host."""
+    hostname = _get_hostname()
+    api_role = _get_api_role(pulp_version)
+    shell_role = _get_shell_role(hostname)
+    return {
+        'hostname': hostname,
+        'roles': {
+            'api': api_role,
+            'pulp resource manager': {},
+            'pulp workers': {},
+            'redis': {},
+            'shell': shell_role,
+        }
+    }
+
+
+def _get_hostname():
+    """Get the Pulp host's hostname."""
+    return click.prompt("What is the Pulp host's hostname?", type=click.STRING)
+
+
+def _get_amqp_broker_role():
+    """Get information for the "amqp broker" role."""
+    return click.prompt(
+        "What service backs Pulp's AMQP broker?",
+        default='qpidd',
+        type=click.Choice(('qpidd', 'rabbitmq')),
+    )
+
+
+def _get_api_role(pulp_version):
+    """Get information for the "api" role."""
+    api_role = {}
+
+    # Get "scheme"
+    api_role['scheme'] = click.prompt(
+        "What scheme should be used when communicating with Pulp's API?",
+        default='https',
+        type=click.Choice(('https', 'http')),
+    )
+
+    # Get "verify"
+    if (api_role['scheme'] == 'https' and
             click.confirm('Verify HTTPS?', default=True)):
-        certificate_path = click.prompt('SSL certificate path', default='')
-        if not certificate_path:
-            host_api_verify = True  # pragma: no cover
-        else:
-            host_api_verify = certificate_path
+        certificate_path = click.prompt(
+            'SSL certificate path',
+            default='',
+            type=click.Path(),
+        )
+        api_role['verify'] = certificate_path if certificate_path else True
     else:
-        host_api_verify = False
+        api_role['verify'] = False
 
+    # Get "port"
     click.echo(
         "By default, Pulp Smash will communicate with Pulp's API on the port "
         "number implied by the scheme. For example, if Pulp's API is "
-        'available over HTTPS, then Pulp Smash will communicate on port 443.'
-        "If Pulp's API is avaialable on a non-standard port, like 8000, then "
+        'available over HTTPS, then Pulp Smash will communicate on port 443. '
+        "If Pulp's API is available on a non-standard port, like 8000, then "
         'Pulp Smash needs to know about that.'
     )
-    host_api_port = click.prompt('Pulp API port number', type=int, default=0)
+    port = click.prompt('Pulp API port number', default=0, type=click.INT)
+    if port:
+        api_role['port'] = port
 
-    if click.confirm(
-            'Is Pulp\'s message broker Qpid (no for RabbitMQ)?', default=True):
-        amqp_broker = 'qpidd'
-    else:
-        amqp_broker = 'rabbitmq'
-    using_ssh = not click.confirm(
-        'Are you running Pulp Smash on the Pulp host?')
-    if using_ssh:
-        click.echo(
-            'Pulp Smash will be configured to access the Pulp host using '
-            'SSH. Because of that, some additional information is required.'
-        )
-        ssh_user = click.prompt('SSH username to use', default='root')
-        click.echo(
-            'Ensure ~/.ssh/controlmasters/ exists, and ensure the following '
-            'is present in your ~/.ssh/config file:'
-            '\n\n'
-            '  Host {host_hostname}\n'
-            '      StrictHostKeyChecking no\n'
-            '      User {ssh_user}\n'
-            '      UserKnownHostsFile /dev/null\n'
-            '      ControlMaster auto\n'
-            '      ControlPersist 10m\n'
-            '      ControlPath ~/.ssh/controlmasters/%C\n'
-            .format(host_hostname=host_hostname, ssh_user=ssh_user)
-        )
-
-    click.echo('Creating the settings file at {}...'.format(path))
-    config_dict = {
-        'pulp': {
-            'auth': [pulp_username, pulp_password],
-            'version': pulp_version,
-            'selinux enabled': pulp_selinux_enabled,
-        },
-        'hosts': [{
-            'hostname': host_hostname,
-            'roles': {
-                'amqp broker': {'service': amqp_broker},
-                'api': {
-                    'scheme': host_api_scheme,
-                    'verify': host_api_verify,
-                },
-                'mongod': {},
-                'pulp celerybeat': {},
-                'pulp cli': {},
-                'pulp resource manager': {},
-                'pulp workers': {},
-                'shell': {'transport': 'ssh' if using_ssh else 'local'},
-                'squid': {},
-            }
-        }]
-    }
-    if host_api_port:
-        config_dict['hosts'][0]['roles']['api']['port'] = host_api_port
-    with open(path, 'w') as handler:
-        handler.write(json.dumps(config_dict, indent=2, sort_keys=True))
-    click.echo(
-        'Settings file created, run `pulp-smash settings show` to show its '
-        'contents.'
+    # Get "service"
+    api_role['service'] = click.prompt(
+        "What web server service backs Pulp's API?",
+        default='httpd' if pulp_version < Version('3') else 'nginx',
+        type=click.Choice(('httpd', 'nginx'))
     )
+
+    return api_role
+
+
+def _get_shell_role(hostname):
+    if click.confirm('Is Pulp Smash installed on the same host as Pulp?'):
+        click.echo('Pulp Smash will access the Pulp host using a local shell.')
+        return {'transport': 'local'}
+    click.echo('Pulp Smash will access the Pulp host using SSH.')
+    ssh_user = click.prompt('SSH username', default='root')
+    click.echo(
+        'Ensure the SSH user has passwordless sudo access, ensure '
+        '~/.ssh/controlmasters/ exists, and ensure the following is '
+        'present in your ~/.ssh/config file:'
+        '\n\n'
+        '  Host {}\n'
+        '    StrictHostKeyChecking no\n'
+        '    User {}\n'
+        '    UserKnownHostsFile /dev/null\n'
+        '    ControlMaster auto\n'
+        '    ControlPersist 10m\n'
+        '    ControlPath ~/.ssh/controlmasters/%C\n'
+        .format(hostname, ssh_user)
+    )
+    return {'transport': 'ssh'}
+
+
+class PulpVersionType(click.ParamType):
+    """Define the possible values for a Pulp version string.
+
+    A Pulp version string is valid if it can be cast to a
+    ``packaging.version.Version`` object, if it is at least 2, and if it is
+    less than 4.
+    """
+
+    name = 'Pulp version'
+
+    def convert(self, value, param, ctx):
+        """Convert a version string to a ``Version`` object."""
+        converted_ver = Version(value)
+        if converted_ver < Version('2') or converted_ver >= Version('4'):
+            self.fail(
+                "Pulp Smash can test Pulp version 2.y and 3.y. It can't test "
+                'Pulp version {}.'.format(converted_ver),
+                param,
+                ctx
+            )
+        return converted_ver
 
 
 @settings.command('path')
@@ -188,7 +301,6 @@ def settings_show(ctx):
     path = ctx.obj['load_path']
     if not path:
         _raise_settings_not_found()
-
     with open(path) as handle:
         click.echo(json.dumps(json.load(handle), indent=2, sort_keys=True))
 
@@ -205,12 +317,9 @@ def settings_validate(ctx):
     try:
         config.validate_config(config_dict)
     except exceptions.ConfigValidationError as err:
-        message = ('Invalid settings file: {}\n' .format(path))
-        for error_message in err.error_messages:
-            message += error_message
-        result = click.ClickException(message)
-        result.exit_code = -1
-        raise result
+        raise click.ClickException(
+            '{} is invalid: '.format(path) + err.message
+        ) from err
 
 
 if __name__ == '__main__':

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -102,7 +102,7 @@ class ClientTestCase(unittest.TestCase):
         cfg = _get_pulp_smash_config(hosts=[
             config.PulpHost(
                 hostname=socket.getfqdn(),
-                roles={'pulp cli': {}},
+                roles={'shell': {}},
             )
         ])
         self.assertIsInstance(cli.Client(cfg).machine, LocalMachine)
@@ -133,11 +133,11 @@ class ClientTestCase(unittest.TestCase):
         cfg = _get_pulp_smash_config(hosts=[
             config.PulpHost(
                 hostname=utils.uuid4(),
-                roles={'pulp cli': {}},
+                roles={'shell': {}},
             ),
             config.PulpHost(
                 hostname=utils.uuid4(),
-                roles={'pulp cli': {}},
+                roles={'shell': {}},
             )
         ])
         with mock.patch('pulp_smash.cli.plumbum') as plumbum:


### PR DESCRIPTION
When applied, this commit will redefine what a "valid" configuration
file is. Existing configuration files will continue to be valid. But in
addition, entirely new (and similar-looking) configuration files may
also be written.

The old configuration files are suitable for use when testing Pulp 2.
They let one declare information like "host pulp.example.com is running
rabbitmq." The new configuration files are suitable for testing Pulp 3.
They lew one declare information like "host pulp.example.com is running
redis."

In addition, this commit will update two pieces of machinery that are
related to the configuration file. Specifically, this commit will
overhaul the entire CLI interface (as accessed by the `pulp-smash`
executable) and re-implement the `PulpSmashConfig.get_services` method.

Fix: https://github.com/PulpQE/pulp-smash/issues/965

Fix: https://github.com/PulpQE/pulp-smash/issues/980