### PR TITLE
Fix cross-plugin imports

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -152,6 +152,7 @@ developers, not a gospel.
     api/pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved.test_pagination
     api/pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved.test_repo_version
     api/pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved.test_unlinking_repo
+    api/pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved.utils
     api/pulp_smash.tests.pulp3.pulpcore.api_v3.test_api_docs
     api/pulp_smash.tests.pulp3.pulpcore.api_v3.test_auth
     api/pulp_smash.tests.pulp3.pulpcore.api_v3.test_crd_artifacts

--- a/docs/api/pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved.utils.rst
+++ b/docs/api/pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved.utils.rst
@@ -1,0 +1,6 @@
+`pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved.utils`
+==============================================================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved.utils`
+
+.. automodule:: pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved.utils

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/plugin_involved/test_auto_distribution.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/plugin_involved/test_auto_distribution.py
@@ -26,11 +26,12 @@ from pulp_smash.pulp3.utils import (
     publish,
     sync,
 )
-
-from pulp_smash.tests.pulp3.file.api_v3.utils import gen_publisher
-from pulp_smash.tests.pulp3.file.utils import populate_pulp
 from pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved import (  # pylint:disable=unused-import
     set_up_module as setUpModule
+)
+from pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved.utils import (
+    gen_publisher,
+    populate_pulp,
 )
 
 

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/plugin_involved/test_pagination.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/plugin_involved/test_pagination.py
@@ -9,9 +9,11 @@ from pulp_smash import api, config
 from pulp_smash.constants import FILE_MANY_FEED_COUNT, FILE_MANY_FEED_URL
 from pulp_smash.pulp3.constants import FILE_CONTENT_PATH, REPO_PATH
 from pulp_smash.pulp3.utils import gen_repo, get_auth, get_versions
-from pulp_smash.tests.pulp3.file.utils import populate_pulp
 from pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved import (  # pylint:disable=unused-import
     set_up_module as setUpModule
+)
+from pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved.utils import (
+    populate_pulp,
 )
 
 

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/plugin_involved/test_repo_version.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/plugin_involved/test_repo_version.py
@@ -32,11 +32,14 @@ from pulp_smash.pulp3.utils import (
     publish,
     sync,
 )
-from pulp_smash.tests.pulp3.file.api_v3.utils import gen_publisher
-from pulp_smash.tests.pulp3.file.utils import populate_pulp, skip_if
 from pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved import (  # pylint:disable=unused-import
     set_up_module as setUpModule
 )
+from pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved.utils import (
+    gen_publisher,
+    populate_pulp,
+)
+from pulp_smash.tests.pulp3.pulpcore.utils import skip_if
 
 
 class AddRemoveContentTestCase(unittest.TestCase):

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/plugin_involved/test_unlinking_repo.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/plugin_involved/test_unlinking_repo.py
@@ -11,7 +11,6 @@ from pulp_smash.pulp3.constants import (
     FILE_PUBLISHER_PATH,
     REPO_PATH,
 )
-from pulp_smash.tests.pulp3.file.api_v3.utils import gen_publisher
 from pulp_smash.pulp3.utils import (
     gen_remote,
     gen_repo,
@@ -22,6 +21,9 @@ from pulp_smash.pulp3.utils import (
 )
 from pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved import (  # pylint:disable=unused-import
     set_up_module as setUpModule
+)
+from pulp_smash.tests.pulp3.pulpcore.api_v3.plugin_involved.utils import (
+    gen_publisher,
 )
 
 

--- a/pulp_smash/tests/pulp3/pulpcore/api_v3/plugin_involved/utils.py
+++ b/pulp_smash/tests/pulp3/pulpcore/api_v3/plugin_involved/utils.py
@@ -1,0 +1,46 @@
+# coding=utf-8
+"""Utilities for pulpcore API tests that require the file plugin."""
+from urllib.parse import urljoin
+
+from pulp_smash import api, utils
+from pulp_smash.constants import FILE_FEED_URL
+from pulp_smash.pulp3.constants import (
+    FILE_CONTENT_PATH,
+    FILE_REMOTE_PATH,
+    REPO_PATH,
+)
+from pulp_smash.pulp3.utils import gen_repo, gen_remote, sync
+
+
+def gen_publisher(**kwargs):
+    """Return a semi-random dict for use in creating a publisher."""
+    data = {'name': utils.uuid4()}
+    data.update(kwargs)
+    return data
+
+
+def populate_pulp(cfg, url=None):
+    """Add file contents to Pulp.
+
+    :param pulp_smash.config.PulpSmashConfig: Information about a Pulp
+        application.
+    :param url: The URL to a file repository's ``PULP_MANIFEST`` file. Defaults
+        to :data:`pulp_smash.constants.FILE_FEED_URL` + ``PULP_MANIFEST``.
+    :returns: A list of dicts, where each dict describes one file content in
+        Pulp.
+    """
+    if url is None:
+        url = urljoin(FILE_FEED_URL, 'PULP_MANIFEST')
+    client = api.Client(cfg, api.json_handler)
+    remote = {}
+    repo = {}
+    try:
+        remote.update(client.post(FILE_REMOTE_PATH, gen_remote(url)))
+        repo.update(client.post(REPO_PATH, gen_repo()))
+        sync(cfg, remote, repo)
+    finally:
+        if remote:
+            client.delete(remote['_href'])
+        if repo:
+            client.delete(repo['_href'])
+    return client.get(FILE_CONTENT_PATH)['results']


### PR DESCRIPTION
`pulp_smash.tests.pulp3.pulpcore` should not import from
`pulp_smash.tests.pulp3.file`. This is because these two different
packages will soon be moved into separate repositories that don't have
access to each others' namespaces.

Fix: https://github.com/PulpQE/pulp-smash/issues/1104