### PR TITLE
Improve definition of CalledProcessError

### DIFF
--- a/pulp_smash/exceptions.py
+++ b/pulp_smash/exceptions.py
@@ -36,13 +36,21 @@ class CalledProcessError(Exception):
     See :meth:`pulp_smash.cli.CompletedProcess` for more information.
     """
 
+    def __init__(self, args_, returncode, stdout, stderr, *args, **kwargs):
+        """Require that information about the error be provided."""
+        super().__init__(args_, returncode, stdout, stderr, *args, **kwargs)
+        self.args_ = args_
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
     def __str__(self):
         """Provide a human-friendly string representation of this exception."""
         return (
             'Command {} returned non-zero exit status {}.\n\n'
             'stdout: {}\n\n'
             'stderr: {}'
-        ).format(*self.args)
+        ).format(self.args_, self.returncode, self.stdout, self.stderr)
 
 
 class ConfigFileNotFoundError(Exception):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -93,7 +93,8 @@ class FipsIsSupportedtestCase(unittest.TestCase):
     def test_return_false(self):
         """Assert false is returned if Called process Error Exception is thrown."""
         with mock.patch.object(cli, 'Client') as client:
-            client.side_effect = exceptions.CalledProcessError()
+            client.side_effect = exceptions.CalledProcessError(
+                ('arg', 'arg'), 1, 'stdout', 'stderr')
             response = utils.fips_is_supported(mock.Mock())
         self.assertFalse(response)
 


### PR DESCRIPTION
The `CalledProcessError` exception assumes that it is passed four
arguments. This is a recipe for bugs. Make its `__init__` require four
arguments.