### PR TITLE
Upgrade release machinery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ help:
 all: test-coverage lint docs-clean docs-html dist-clean dist
 
 dist:
-	./setup.py --quiet sdist bdist_wheel --universal
+	./setup.py --quiet sdist bdist_wheel --universal test
 
 dist-clean:
 	rm -rf build dist pulp_smash.egg-info

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,7 +6,6 @@ http://sphinx-doc.org/config.html
 
 """
 import os
-import re
 import sys
 from packaging.version import Version
 
@@ -23,16 +22,9 @@ sys.path.insert(0, ROOT_DIR)
 # PEP 440. An InvalidVersion exception is raised if the version is
 # non-conformant, so the act of generating documentation serves as a unit test
 # for the contents of the `VERSION` file.
-#
-# We use the raw version string when generating documentation for the sake of
-# human friendliness: the meaning of '2016.02.18' is presumably more intuitive
-# than the meaning of '2016.2.18'. The regex enforcing this format allows
-# additional segments. This is done to allow multiple releases in a single day.
-# For example, 2016.02.18.3 is the fourth release in a given day.
 with open(os.path.join(ROOT_DIR, 'VERSION')) as handle:
     VERSION = handle.read().strip()
     Version(VERSION)
-    assert re.match(r'\d{4,4}(\.\d\d){2,2}', VERSION) is not None
 
 
 # pylint:disable=invalid-name


### PR DESCRIPTION
Make the `dist` make target test the egg and wheel that it builds.

Don't require that the current VERSION file look like a date, e.g.
`2018.07.19`.

Overhaul `scripts/release.sh`:

* Give it proper argument parsing capabilities, and add several
  arguments.
* Make it generate annotated tags, not lightweight tags. This greatly
  improves traceability.

See: https://github.com/PulpQE/pulp-smash/issues/1050