### PR TITLE
Normalize indentation in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,21 @@
 sudo: false
 language: python
 python:
-    - 3.4
-    - 3.5
-    - 3.6
-
+- 3.4
+- 3.5
+- 3.6
+# Python 3.7+ is only available on Xenial, due to dependency requirements. For
+# these builds, "sudo" must be enabled, or else Trusty will be used.
 matrix:
   include:
   - python: 3.7
-    dist: xenial # Python 3.7 is only available on xenial because of deps
-    sudo: required # if this isn't specified it'll use a trusty image :(
-
+    dist: xenial
+    sudo: required
 install:
-    - ./setup.py test; git clean -dfx
-    # Old versions of pip can't handle extras_require in setup.py.
-    - pip install --upgrade pip
-    - pip install .[dev]
-script:
-    - make all
+- ./setup.py test; git clean -dfx
+# Old versions of pip can't handle extras_require in setup.py.
+- pip install --upgrade pip
+- pip install .[dev]
+script: make all
 cache: pip
-after_success:
-    coveralls
+after_success: coveralls


### PR DESCRIPTION
Indent by two spaces, and only indent where syntactically required.