### PR TITLE
Deal with new pulp.plan.io issue status

### DIFF
--- a/pulp_smash/selectors.py
+++ b/pulp_smash/selectors.py
@@ -24,6 +24,7 @@ _TESTABLE_BUGS = frozenset((
     'MODIFIED',  # bug fix has been accepted by dev
     'ON_QA',  # bug fix is being reviewed by qe
     'VERIFIED',  # bug fix has been accepted by qe
+    'CLOSED - COMPLETE',
     'CLOSED - CURRENTRELEASE',
     'CLOSED - DUPLICATE',
     'CLOSED - NOTABUG',


### PR DESCRIPTION
pulp.plan.io issues may now have a status of "CLOSED - COMPLETE." Update
`pulp_smash.selectors` to deal with this new state of affairs.