### PR TITLE
Add a function for generating a publisher dict

### DIFF
--- a/pulp_smash/pulp3/utils.py
+++ b/pulp_smash/pulp3/utils.py
@@ -234,6 +234,13 @@ def gen_distribution(**kwargs):
     return data
 
 
+def gen_publisher(**kwargs):
+    """Return a semi-random dict for use in creating an Publisher."""
+    data = {'name': utils.uuid4()}
+    data.update(kwargs)
+    return data
+
+
 def gen_remote(url, **kwargs):
     """Return a semi-random dict for use in creating an remote.
 

--- a/tests/test_pulp3_utils.py
+++ b/tests/test_pulp3_utils.py
@@ -2,14 +2,19 @@
 
 import unittest
 
-from pulp_smash.pulp3.utils import gen_distribution, gen_remote, gen_repo
+from pulp_smash.pulp3.utils import (
+    gen_distribution,
+    gen_publisher,
+    gen_remote,
+    gen_repo,
+)
 
 
 class GenTestCase(unittest.TestCase):
     """Tests the `gen_` functions."""
 
     def test_gen_distribution(self):
-        """Asserts the generation of distibution dict."""
+        """Tests the generation of a distibution dict."""
         self.assertIn('base_path', gen_distribution())
         self.assertIn('name', gen_distribution())
 
@@ -17,8 +22,15 @@ class GenTestCase(unittest.TestCase):
         self.assertIn('base_path', dist)
         self.assertEqual('foodist', dist['name'])
 
+    def test_gen_publisher(self):
+        """Tests the generation of a publisher dict."""
+        self.assertIn('name', gen_publisher())
+
+        publisher = gen_publisher(name='foopub')
+        self.assertEqual('foopub', publisher['name'])
+
     def test_gen_remote(self):
-        """Asserts the generation of remote dict."""
+        """Tests the generation of a remote dict."""
         self.assertIn('url', gen_remote('http://foo.com'))
         self.assertIn('name', gen_remote('http://foo.com'))
         self.assertEqual('http://foo.com', gen_remote('http://foo.com')['url'])
@@ -29,7 +41,7 @@ class GenTestCase(unittest.TestCase):
         self.assertEqual('fooremote', rem['name'])
 
     def test_gen_repo(self):
-        """Asserts the generation of repository dict."""
+        """Tests the generation of a repository dict."""
         self.assertIn('notes', gen_repo())
         self.assertIn('name', gen_repo())
 


### PR DESCRIPTION
Since Remote has one, it makes sense for Publisher to have one,
especially since Publisher is less likely to need custom behavior.