### PR TITLE
Add a utility function for getting the "content_summary" from Pulp

### DIFF
--- a/pulp_smash/pulp3/utils.py
+++ b/pulp_smash/pulp3/utils.py
@@ -158,6 +158,24 @@ def get_removed_content(repo, version_href=None):
     return client.get(urljoin(version_href, 'removed_content/'))
 
 
+def get_content_summary(repo, version_href=None):
+    """Read the "content summary" of a given repository version.
+
+    Repository versions have a "content_summary" which lists the content types
+    and the number of units of that type present in the repo version.
+
+    :param repo: A dict of information about the repository.
+    :param version_href: The repository version to read. If none, read the
+        latest repository version.
+    :returns: The "content_summary" of the repo version.
+    """
+    if version_href is None:
+        version_href = repo['_latest_version_href']
+
+    client = api.Client(config.get_config(), api.page_handler)
+    return client.get(version_href)['content_summary']
+
+
 def delete_orphans(cfg=None):
     """Clean all content units present in pulp.
 


### PR DESCRIPTION
Pulp has a "content_summary" field on repository versions which provides an easy way to see how many of each content type are in the repository.  It looks like (e.g.) {'file': 5, 'rpm': 10, 'errata': 2}. This utility function provides an easy way to get these counts without manually taking a len() of the list content, and is also necessary for plugins which have multiple content types, such as the RPM plugin with both RPMs and Errata.  It avoids the issue of all different types of content being mixed together when taking counts.


