### PR TITLE
Added a `sudo` argument to `cli.Client.run` to avoid boilerplate.

### DIFF
--- a/pulp_smash/cli.py
+++ b/pulp_smash/cli.py
@@ -213,13 +213,19 @@ class Client():  # pylint:disable=too-few-public-methods
         else:
             self.response_handler = response_handler
 
-    def run(self, args, **kwargs):
+        self.cfg = cfg
+
+    def run(self, args, sudo=False, **kwargs):
         """Run a command and ``return self.response_handler(result)``.
 
         This method is a thin wrapper around Plumbum's `BaseCommand.run`_
         method, which is itself a thin wrapper around the standard library's
         `subprocess.Popen`_ class. See their documentation for detailed usage
         instructions. See :class:`pulp_smash.cli.Client` for a usage example.
+
+        :param args: Any arguments to be passed to the process (a tuple).
+        :param sudo: If the command should run as superuser (a boolean).
+        :param kwargs: Extra named arguments passed to plumbumBaseCommand.run.
 
         .. _BaseCommand.run:
            http://plumbum.readthedocs.io/en/latest/api/commands.html#plumbum.commands.base.BaseCommand.run
@@ -229,6 +235,9 @@ class Client():  # pylint:disable=too-few-public-methods
         # Let self.response_handler check return codes. See:
         # https://plumbum.readthedocs.io/en/latest/api/commands.html#plumbum.commands.base.BaseCommand.run
         kwargs.setdefault('retcode')
+
+        if sudo and args[0] != 'sudo' and not is_root(self.cfg):
+            args = ('sudo',) + tuple(args)
 
         code, stdout, stderr = self.machine[args[0]].run(args[1:], **kwargs)
         completed_process = CompletedProcess(args, code, stdout, stderr)


### PR DESCRIPTION
Fix #1037 

As part of our `less boilerplate` effort I added a new method `sudo` argument
to `cli.Client.run`.

In a lot of test cases there are code like:

```python
sudo = () if cli.is_root(cfg) else ('sudo',)
...
client.run(sudo + ('command_name', 'argument1', ...))
```

The idea is to replace the above boilerplate with

```python
client.run(('command_name', 'argument1', ...), sudo=True)
```

With this change we will be able to remove the `sudo = () if cli.is_root(cfg) else ('sudo',)` boilerplate in 28 Pulp-2-tests references:

```bash

pulp_2_tests/tests/docker/utils.py:    sudo = '' if cli.is_root(cfg) else 'sudo'
pulp_2_tests/tests/puppet/api_v2/test_install_distributor.py:        sudo = () if cli.is_root(self.cfg) else ('sudo',)
pulp_2_tests/tests/rpm/api_v2/test_content_sources.py:        sudo = () if cli.is_root(cls.cfg) else ('sudo',)
pulp_2_tests/tests/rpm/api_v2/test_content_sources.py:        sudo = () if cli.is_root(cls.cfg) else ('sudo',)
pulp_2_tests/tests/rpm/api_v2/test_content_sources.py:    sudo = '' if cli.is_root(cfg) else 'sudo'
pulp_2_tests/tests/rpm/api_v2/test_crud.py:        sudo = () if cli.is_root(self.cfg) else ('sudo',)
pulp_2_tests/tests/rpm/api_v2/test_download_policies.py:        sudo = '' if cli.is_root(cls.cfg) else 'sudo '
pulp_2_tests/tests/rpm/api_v2/test_errata.py:        # sudo = () if cli.is_root(cfg) else ('sudo',)
pulp_2_tests/tests/rpm/api_v2/test_errata.py:        sudo = () if cli.is_root(cfg) else ('sudo',)
pulp_2_tests/tests/rpm/api_v2/test_export.py:        self.__sudo = None
pulp_2_tests/tests/rpm/api_v2/test_export.py:            self.__sudo = '' if cli.is_root(self.cfg) else 'sudo '
pulp_2_tests/tests/rpm/api_v2/test_iso_sync_publish.py:        sudo = () if cli.is_root(self.cfg) else ('sudo',)
pulp_2_tests/tests/rpm/api_v2/test_modularity.py:        sudo = () if cli.is_root(cfg) else ('sudo',)
pulp_2_tests/tests/rpm/api_v2/test_republish.py:        sudo = () if cli.is_root(self.cfg) else ('sudo',)
pulp_2_tests/tests/rpm/api_v2/test_rich_weak_dependencies.py:        sudo = () if cli.is_root(cfg) else ('sudo',)
pulp_2_tests/tests/rpm/api_v2/test_rsync_distributor.py:        sudo = () if cli.is_root(cfg) else ('sudo',)
pulp_2_tests/tests/rpm/api_v2/test_rsync_distributor.py:        sudo = () if cli.is_root(cfg) else ('sudo',)
pulp_2_tests/tests/rpm/api_v2/test_rsync_distributor.py:        sudo = '' if cli.is_root(cfg) else 'sudo '
pulp_2_tests/tests/rpm/api_v2/test_service_resiliency.py:        sudo = '' if cli.is_root(self.cfg) else 'sudo'
pulp_2_tests/tests/rpm/api_v2/test_service_resiliency.py:        sudo = () if cli.is_root(self.cfg) else ('sudo',)
pulp_2_tests/tests/rpm/api_v2/utils.py:        sudo = '' if cli.is_root(cfg) else 'sudo '
pulp_2_tests/tests/rpm/api_v2/utils.py:        sudo = '' if cli.is_root(cfg) else 'sudo '
pulp_2_tests/tests/rpm/api_v2/utils.py:        sudo = () if cli.is_root(cfg) else ('sudo',)
pulp_2_tests/tests/rpm/api_v2/utils.py:        sudo = '' if cli.is_root(cfg) else 'sudo '
pulp_2_tests/tests/rpm/api_v2/utils.py:    sudo = () if cli.is_root(cfg) else ('sudo',)
pulp_2_tests/tests/rpm/cli/test_copy_units.py:        sudo = () if cli.is_root(cfg) else ('sudo',)
pulp_2_tests/tests/rpm/cli/test_process_recycling.py:    sudo = () if cli.is_root(cfg) else ('sudo',)
pulp_2_tests/tests/rpm/cli/test_process_recycling.py:        sudo = () if cli.is_root(cfg) else ('sudo',)

```