### PR TITLE
Make Pulp 3 sync() function accept `**kwargs`

### DIFF
--- a/pulp_smash/pulp3/utils.py
+++ b/pulp_smash/pulp3/utils.py
@@ -64,7 +64,7 @@ def get_plugins(cfg=None):
     return {version['component'] for version in status['versions']}
 
 
-def sync(cfg, remote, repo):
+def sync(cfg, remote, repo, **kwargs):
     """Sync a repository.
 
     :param pulp_smash.config.PulpSmashConfig cfg: Information about the Pulp
@@ -72,13 +72,14 @@ def sync(cfg, remote, repo):
     :param remote: A dict of information about the remote of the repository
         to be synced.
     :param repo: A dict of information about the repository.
+    :param kwargs: Keyword arguments to be merged in to the request data.
     :returns: The server's response. Call ``.json()`` on the response to get
         a call report.
     """
     client = api.Client(cfg, api.json_handler)
-    return client.post(
-        urljoin(remote['_href'], 'sync/'), {'repository': repo['_href']}
-    )
+    data = {'repository': repo['_href']}
+    data.update(kwargs)
+    return client.post(urljoin(remote['_href'], 'sync/'), data)
 
 
 def publish(cfg, publisher, repo, version_href=None):

--- a/tests/test_pulp3_utils.py
+++ b/tests/test_pulp3_utils.py
@@ -1,12 +1,15 @@
 """Unit tests for pulp_smash.pulp3.utils."""
 
 import unittest
+from unittest import mock
 
+from pulp_smash import api
 from pulp_smash.pulp3.utils import (
     gen_distribution,
     gen_publisher,
     gen_remote,
     gen_repo,
+    sync,
 )
 
 
@@ -48,3 +51,14 @@ class GenTestCase(unittest.TestCase):
         repo = gen_repo(name='foorepo')
         self.assertIn('notes', repo)
         self.assertEqual('foorepo', repo['name'])
+
+    def test_sync(self):  # pylint:disable=no-self-use
+        """Test HTTP POST request for sync."""
+        remote_href = '/pulp/api/v3/remotes/file/9/'
+        repo_href = '/pulp/api/v3/repositories/11/'
+        with mock.patch.object(api, 'Client') as client:
+            remote = {'_href': remote_href}
+            repo = {'_href': repo_href}
+            sync(None, remote, repo, mirror=True)
+        data = {'repository': repo_href, 'mirror': True}
+        client.return_value.post.assert_called_once_with(remote_href + 'sync/', data)


### PR DESCRIPTION
As (some) plugins support "mirror" parameters now, allow to call sync() with
customized parameters.