### PR TITLE
Fix sphinx autodoc_default_flags

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,8 +40,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 exclude_patterns = ['_build']
 nitpicky = True
-autodoc_default_options = {'members': None, 'undoc-members': None}
-
+nitpick_ignore = [('py:class', 'type')]
+autodoc_default_flags = ['members', 'show-inheritance', 'undoc-members']
 # Format-Specific Options -----------------------------------------------------
 htmlhelp_basename = 'PulpSmashdoc'
 latex_documents = [(


### PR DESCRIPTION
Conf was using _default_options and the right parameter is _default_flags