### PR TITLE
Add a new constant to pulp 3

### DIFF
--- a/pulp_smash/pulp3/constants.py
+++ b/pulp_smash/pulp3/constants.py
@@ -14,6 +14,8 @@ BASE_REMOTE_PATH = urljoin(BASE_PATH, 'remotes/')
 
 BASE_PUBLISHER_PATH = urljoin(BASE_PATH, 'publishers/')
 
+CONTENT_GUARDS_PATH = urljoin(BASE_PATH, 'content-guards/')
+
 CONTENT_PATH = urljoin(BASE_PATH, 'content/')
 
 DISTRIBUTION_PATH = urljoin(BASE_PATH, 'distributions/')


### PR DESCRIPTION
Add a new constant to pulp 3 namespace. `CONTENT_GUARDS_PATH`.

See:https://pulp.plan.io/issues/3968