### PR TITLE
Update Makefile to ignore new flake8 rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,9 @@ install-dev:
 lint: lint-flake8 lint-pylint
 
 # E501 and F401 are ignored because Pylint performs similar checks.
+# W504 ignored since it requires line breaks after binary operators.
 lint-flake8:
-	flake8 . --ignore E501,F401 --exclude docs/_build
+	flake8 . --ignore E501,F401,W504 --exclude docs/_build
 
 lint-pylint:
 	pylint -j $(CPU_COUNT) --reports=n --disable=I \


### PR DESCRIPTION
Add W504, ``W504 line break after binary operator``, for errors to be
ignored.

Failed Job can be seen [here](https://travis-ci.org/PulpQE/pulp-smash/jobs/443414844)
New flake8 version added new rule.

See:http://flake8.pycqa.org/en/latest/release-notes/3.6.0.html