### PR TITLE
Added `raise_if_unsupported` on Packagemanager

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -264,6 +264,26 @@ class PackageManagerTestCase(unittest.TestCase):
             with self.assertRaises(NoKnownPackageManagerError):
                 self.assertIn(pkr_mgr.name, ('yum', 'dnf'))
 
+    def test_raise_if_unsupported(self, ):
+        """Test if proper exception raises on raise_if_unsupported."""
+        with mock.patch.object(cli, 'Client') as client:
+            client.return_value.run.return_value.returncode = 1
+            # `fpm` is a Fake Package Manager
+            client.return_value.run.return_value.stdout = 'fpm'
+
+            # Should not raise error without raise_if_unsupported param
+            cli.PackageManager(self.cfg)
+
+            with self.assertRaises(RuntimeError):
+                cli.PackageManager(self.cfg, (RuntimeError, 'foo'))
+
+            with self.assertRaises(RuntimeError):
+                cli.PackageManager(self.cfg, [RuntimeError])
+
+            with self.assertRaises(RuntimeError):
+                pkr_mgr = cli.PackageManager(self.cfg)
+                pkr_mgr.raise_if_unsupported(RuntimeError)
+
     def test_package_manager_name(self):
         """Test the property `name` returns the proper Package Manager."""
         for name in ('yum', 'dnf'):


### PR DESCRIPTION
Related to pulp/pulp_file#129

```python
pm = PackageManager(cfg)
pm.raise_if_unsupported(unittest.SkipTest, 'Test requires yum/dnf')
# will raise and skip if not yum or dnf
# else test continues
pm.install('foobar')
```

or

```python
pm = PackageManager(cfg, raise_if_unsupported=(unittest.SkipTest, 'Test requires yum'))
# will raise and skip if not yum or dnf
# else test continues
pm.install('foobar')
```

The main idea is to replace this:

```py
try:
    PackageManager(cgf).name
except exceptions.NoKnownPackagemanager:
    raise unittest.SkipTest("This test requires dnf/yum")
```