### PR TITLE
Added `pulp-smash lint` subcommand

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: python
 python:
-- 3.4
 - 3.5
 - 3.6
 # Python 3.7+ is only available on Xenial, due to dependency requirements. For

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,6 +26,7 @@ Documentation contents:
 
     installation
     configuration
+    usage
     about
     api
     changelog

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,0 +1,94 @@
+Usage
+=====
+
+Location: :doc:`/index` → :doc:`/usage`
+
+Utilities
+---------
+
+Pulp-Smash provides utilities to help writing tests for Pulp2 and Pulp3.
+The most important utilities are:
+
+- API  :doc:`/api/pulp_smash.api`
+- CLI  :doc:`/api/pulp_smash.cli`
+- Utils  
+    - General :doc:`/api/pulp_smash.utils`
+    - Pulp2 :doc:`/api/pulp_smash.pulp2.utils`
+    - Pulp3 :doc:`/api/pulp_smash.pulp3.utils`
+
+The `pulp-smash` CLI 
+--------------------
+
+The command `pulp-smash` is provided to help with `settings` management and test style `lint`::
+
+    $ pulp-smash --help         
+    Usage: pulp-smash [OPTIONS] COMMAND [ARGS]...
+
+    Pulp Smash facilitates functional testing of Pulp.
+
+    Options:
+    --help  Show this message and exit.
+
+    Commands:
+    lint      Lint input files.
+    settings  Manage settings file.
+
+
+Settings
+~~~~~~~~
+
+The command `pulp-smash settings` can be used to manage the configuration of your `pulp-smash` test runner.
+ 
+See more info in :doc:`/configuration`
+
+Available subcommands::
+
+    $ pulp-smash settings --help
+    Usage: pulp-smash settings [OPTIONS] COMMAND [ARGS]...
+
+    Manage settings file.
+
+    Options:
+    --help  Show this message and exit.
+
+    Commands:
+    create     Create a settings file.
+    load-path  Print the path from which settings are...
+    path       Deprecated in favor of 'load-path'.
+    save-path  Print the path to which settings are saved.
+    show       Print the settings file.
+    validate   Validate the settings file.
+
+
+Lint
+~~~~
+
+This command can be used to check for code style errors in Pulp functional tests 
+in any repository the tests are located.
+
+For example, to check coding style for only the files that were changed in git::
+
+    $ pulp-smash lint --picked
+
+To check style for all files under a certain path::
+
+    $ pulp-smash lint pulpcore/tests/funtional
+
+The lint command uses only `flake8` but it is also possible to check using `pylint`::
+
+    $ pulp-smash lint path/to/tests/ --pylint 
+
+Complete subcommand help::
+
+    $ pulp-smash lint --help
+    Usage: pulp-smash lint [OPTIONS] [FILEPATH]
+
+    Lint input files.
+
+    Usage: `pulp-smash lint /path/to/files/`
+
+    Options:
+    --pylint  Enables pylint
+    --picked  Checks only git changed files
+    --help    Show this message and exit.
+


### PR DESCRIPTION
For tests located in different repositories such as pulp/pulp (pulp3)
and its plugins, it is helpful to have `pulp-smash lint` to check
for coding style independently of the standard used by the specific
repo.

This command can be used to check for code style errors in Pulp functional tests 
in any repository the tests are located.

For example to check coding style for only the files that were changed in git:

    $ pulp-smash lint --picked

To check style for all files under a certain path:

    $ pulp-smash lint pulpcore/tests/funtional

The `lint` command by default uses only `flake8`, because some external repositories like pulp3 cannot be checked with pylint, but it is also possible to force aditional check using `pylint`:

    $ pulp-smash lint path/to/tests/ --pylint 

Complete subcommand help::

    $ pulp-smash lint --help
    Usage: pulp-smash lint [OPTIONS] [FILEPATH]

    Lint input files.

    Usage: `pulp-smash lint /path/to/files/`

    Options:
    --pylint  Enables pylint
    --picked  Checks only git changed files
    --help    Show this message and exit.


> NOTE: removed Python 3.4 from travis CI