### PR TITLE
Fix pylint 2.2.0 errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ lint-flake8:
 	flake8 . --ignore E501,F401,W504 --exclude docs/_build
 
 lint-pylint:
-	pylint -j $(CPU_COUNT) --reports=n --disable=I \
+	pylint -j $(CPU_COUNT) --reports=n --disable=I,unnecessary-pass \
 		docs/conf.py \
 		pulp_smash \
 		setup.py \

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -80,7 +80,7 @@ class CompletedProcessTestCase(unittest.TestCase):
     def test_can_eval(self):
         """Assert ``__repr__()`` can be parsed by ``eval()``."""
         string = repr(cli.CompletedProcess(**self.kwargs))
-        from pulp_smash.cli import CompletedProcess  # pylint:disable=unused-variable
+        from pulp_smash.cli import CompletedProcess  # pylint:disable=unused-import
         # pylint:disable=eval-used
         self.assertEqual(string, repr(eval(string)))
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -365,7 +365,7 @@ class ReprTestCase(unittest.TestCase):
 
     def test_can_eval(self):
         """Assert that the result can be parsed by ``eval``."""
-        from pulp_smash.config import PulpSmashConfig, PulpHost  # pylint:disable=unused-variable
+        from pulp_smash.config import PulpSmashConfig, PulpHost  # pylint:disable=unused-import
         # pylint:disable=eval-used
         cfg = eval(self.result)
         with self.subTest('check pulp_version'):


### PR DESCRIPTION
pylint newest version 2.2.0  doesn't allow `simplifiable-if-expression`. This
commit adds an ignore statement in the MakeFile.

See: https://pypi.org/project/pylint/2.2.0/