### PR TITLE
Introduced the Pulp 3 'content' role.

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -80,7 +80,7 @@ class CompletedProcessTestCase(unittest.TestCase):
     def test_can_eval(self):
         """Assert ``__repr__()`` can be parsed by ``eval()``."""
         string = repr(cli.CompletedProcess(**self.kwargs))
-        from pulp_smash.cli import CompletedProcess  # pylint:disable=unused-import
+        from pulp_smash.cli import CompletedProcess  # pylint:disable=unused-import,unused-variable
         # pylint:disable=eval-used
         self.assertEqual(string, repr(eval(string)))
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -365,7 +365,7 @@ class ReprTestCase(unittest.TestCase):
 
     def test_can_eval(self):
         """Assert that the result can be parsed by ``eval``."""
-        from pulp_smash.config import PulpSmashConfig, PulpHost  # pylint:disable=unused-import
+        from pulp_smash.config import PulpSmashConfig, PulpHost  # pylint:disable=unused-import,unused-variable
         # pylint:disable=eval-used
         cfg = eval(self.result)
         with self.subTest('check pulp_version'):


### PR DESCRIPTION
Added `content` as a valid role for config hosts
Added helper methods in `cfg` to get content_host Base URL.
Added `content` as a new option on `pulp-smash settings create`

Note: In cases where `content` role is not defined then the `api`
host is assumed as the content host.

https://docs.pulpproject.org/en/3.0/nightly/components.html#content-serving-application