### PR TITLE
Remove constant USER_PATH

### DIFF
--- a/pulp_smash/pulp3/constants.py
+++ b/pulp_smash/pulp3/constants.py
@@ -36,6 +36,4 @@ STATUS_PATH = urljoin(BASE_PATH, 'status/')
 
 TASKS_PATH = urljoin(BASE_PATH, 'tasks/')
 
-USER_PATH = urljoin(BASE_PATH, 'users/')
-
 WORKER_PATH = urljoin(BASE_PATH, 'workers/')


### PR DESCRIPTION
Pulp 3 is removing the endpoints realated to user management. Remove
this constant.

See: https://pulp.plan.io/issues/4398