### PR TITLE
Adds `RegistryClient` to talk with container registries.

### DIFF
--- a/pulp_smash/exceptions.py
+++ b/pulp_smash/exceptions.py
@@ -100,6 +100,13 @@ class NoKnownPackageManagerError(Exception):
     """
 
 
+class NoRegistryClientError(Exception):
+    """We cannot determine the registry client used by a system.
+
+    A "registry client" is a tool such as ``podman`` or ``docker``.
+    """
+
+
 class NoKnownServiceManagerError(Exception):
     """We cannot determine the service manager used by a system.
 


### PR DESCRIPTION
Adds a new class to the cli to deal with registry clients
currently supporting `podman` and `docker`.

```py
>>> from pulp_smash import cli, config
>>> registry = cli.RegistryClient(config.get_config())
>>> registry.pull('image_name')
>>> image_data = registry.inspect('image_name')
>>> print(image_data)  # see details below
```

<details>
<summary>Click to see image_data results</summary>

```json
[
    {
        "Id": "d8233ab899d419c58cf3634c0df54ff5d8acc28f8173f09c21df4a07229e1205",
        "Digest": "sha256:4415a904b1aca178c2450fd54928ab362825e863c0ad5452fd020e92f7a6a47e",
        "RepoTags": [
            "fedora-29-pulp-3:8080/foo:latest",
            "docker.io/library/busybox:latest"
        ],
        "RepoDigests": [
            "fedora-29-pulp-3@sha256:4415a904b1aca178c2450fd54928ab362825e863c0ad5452fd020e92f7a6a47e",
            "docker.io/library/busybox@sha256:4415a904b1aca178c2450fd54928ab362825e863c0ad5452fd020e92f7a6a47e"
        ],
        "Parent": "",
        "Comment": "",
        "Created": "2019-02-15T00:19:37.830935034Z",
        "Config": {
            "Env": [
                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
            ],
            "Cmd": [
                "sh"
            ]
        },
        "Version": "18.06.1-ce",
        "Author": "",
        "Architecture": "amd64",
        "Os": "linux",
        "Size": 1417704,
        "VirtualSize": 1417704,
        "GraphDriver": {
            "Name": "vfs",
            "Data": null
        },
        "RootFS": {
            "Type": "layers",
            "Layers": [
                "sha256:adab5d09ba79ecf30d3a5af58394b23a447eda7ffffe16c500ddc5ccb4c0222f"
            ]
        },
        "Labels": null,
        "Annotations": {},
        "ManifestType": "application/vnd.docker.distribution.manifest.v2+json",
        "User": "",
        "History": [
            {
                "created": "2019-02-15T00:19:37.703602988Z",
                "created_by": "/bin/sh -c #(nop) ADD file:9ce77bda0ecf8a7f559c143ea91876057a8684775239a68639198fe64d38ca0c in / "
            },
            {
                "created": "2019-02-15T00:19:37.830935034Z",
                "created_by": "/bin/sh -c #(nop)  CMD [\"sh\"]",
                "empty_layer": true
            }
        ]
    }
]
```
</details>