### PR TITLE
Add lazy download policies constant

### DIFF
--- a/pulp_smash/pulp3/constants.py
+++ b/pulp_smash/pulp3/constants.py
@@ -24,6 +24,10 @@ DOWNLOAD_POLICIES = ('immediate', 'on_demand', 'streamed',)
 
 JWT_PATH = urljoin(BASE_PATH, 'jwt/')
 
+LAZY_DOWNLOAD_POLICIES = tuple(
+    [item for item in DOWNLOAD_POLICIES if item != 'immediate']
+)
+
 MEDIA_PATH = '/var/lib/pulp'
 
 ORPHANS_PATH = urljoin(BASE_PATH, 'orphans/')


### PR DESCRIPTION
Add a constant `LAZY_DOWNLOAD_POLICIES` to ease tests related to lazy
sync on Pulp 3.