### PR TITLE
[DO NOT MERGE] Add task_handler, ensureteardown and fixes some constants.

### DIFF
--- a/pulp_smash/pulp3/constants.py
+++ b/pulp_smash/pulp3/constants.py
@@ -14,7 +14,7 @@ BASE_REMOTE_PATH = urljoin(BASE_PATH, 'remotes/')
 
 BASE_PUBLISHER_PATH = urljoin(BASE_PATH, 'publishers/')
 
-CONTENT_GUARDS_PATH = urljoin(BASE_PATH, 'content-guards/')
+CONTENT_GUARDS_PATH = urljoin(BASE_PATH, 'contentguards/certguard/certguard/')
 
 CONTENT_PATH = urljoin(BASE_PATH, 'content/')
 

--- a/pulp_smash/pulp3/utils.py
+++ b/pulp_smash/pulp3/utils.py
@@ -84,13 +84,14 @@ def sync(cfg, remote, repo, **kwargs):
     return client.post(urljoin(remote['_href'], 'sync/'), data)
 
 
-def download_content_unit(cfg, distribution, unit_path):
+def download_content_unit(cfg, distribution, unit_path, **kwargs):
     """Download the content unit from distribution base path.
 
     :param pulp_smash.config.PulpSmashConfig cfg: Information about the Pulp
         host.
     :param distribution: A dict of information about the distribution.
     :param unit_path: A string path to the unit to be downloaded.
+    :param kwargs: Extra arguments passed to requests.get
     """
     client = api.Client(cfg, api.safe_handler)
     unit_url = reduce(urljoin, (
@@ -98,7 +99,7 @@ def download_content_unit(cfg, distribution, unit_path):
         '//' + distribution['base_url'] + '/',
         unit_path
     ))
-    return client.get(unit_url).content
+    return client.get(unit_url, **kwargs).content
 
 
 def publish(cfg, publisher, repo, version_href=None):

--- a/pulp_smash/utils.py
+++ b/pulp_smash/utils.py
@@ -4,6 +4,7 @@
 This module may make use of :mod:`pulp_smash.api` and :mod:`pulp_smash.cli`,
 but the reverse should not be done.
 """
+import contextlib
 import hashlib
 import uuid
 from urllib.parse import urlparse
@@ -124,3 +125,26 @@ def fips_is_enabled(cfg, pulp_host=None):
 def uuid4():
     """Return a random UUID4 as a string."""
     return str(uuid.uuid4())
+
+
+@contextlib.contextmanager
+def ensure_teardownclass(testcase):
+    """Ensure the call of tearDownClass on classmethods.
+
+    Unittest will not execute tearDownClass if an error occurs on classmethods
+    this contextmanager will ensure that method is executed in case of error.
+
+    Usage::
+
+        # in a test case class
+        @classmethod
+        def setUpClass(cls):
+            with ensure_teardownclass(cls):
+                # this raises error tearDownClass should be executed after
+                1 / 0
+
+    """
+    with contextlib.ExitStack() as stack:
+        stack.callback(testcase.tearDownClass)
+        yield stack
+        stack.pop_all()


### PR DESCRIPTION

This PR is introduces 3 changes (instead of separete PRs) because certguard/functional test case needs to require this PR. 
https://github.com/pulp/pulp-certguard/pull/9


1. added dependency injection method to switch response handler

```py
client = api.Client(cfg, api.safe_handler)

# will get using `safe_handler`
client.get(url)

# Will get using different injected handler dependency
client.using_handler(api.json_handler).get(url)
```

2. Add a task handler to return `created`, `updated` or `done_task` resources

The `task_handler` will spawn the create task, pool task until it is `done`, if error will raise, if success will return the creatd distribution entity. (if it was a `PATCH|PUT` it would return the modified entity).

```py
distribution = client.using_handler(api.task_handler).post(DISTRIBUTION_PATH, gen_distribution())
```

3. ensureteardown

unittest will not execute `tearDownClass` if error occurs in a `@classmethod` use ExitStack to fix it

```py
from pulp_smash.utils import ensure_teardownclass

class TestCase(unittest.TestCase):
    @classmethod
    def setUpClass(cls):
        with ensure_teardownclass(cls):
            result = 1 / 0  # will raise ZeroDivisionError

    @classmethod
    def tearDownClass(cls):
        print("I will always be executed even if the error is on a classmethod")
        # this would never print without the `ensure_teardownclass`

```
