### PR TITLE
Add 'pulp-smash shell' command.

### DIFF
--- a/docs/about.rst
+++ b/docs/about.rst
@@ -62,6 +62,22 @@ Learning Pulp Smash
 Not sure where to start? Consider reading some existing tests in `Pulp 2
 Tests`_.
 
+Pulp Smash Interactive Console
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The command ``pulp-smash shell`` opens an interactive Python console with Pulp-Smash
+most common used objects already imported in to the context.
+
+The configuration for the shell is read from 
+``XDG HOME`` usually ``~/.config/pulp_smash/settings.json`` 
+optionally it is possible to set on env ``export PULP_SMASH_CONFIG_FILE=/path/to/settings.json`` 
+or by passing it to the command line as in ``pulp-smash shell --config ~/path/to/settings.json``
+
+.. raw:: html
+
+    <script id="asciicast-235178" src="https://asciinema.org/a/235178.js" async></script>
+    <a href="https://asciinema.org/a/235178">https://asciinema.org/a/235178</a>
+
 Code Standards
 ~~~~~~~~~~~~~~
 


### PR DESCRIPTION
```bash
$ pulp-smash shell --help      
Usage: pulp-smash shell [OPTIONS]

  Run a Python shell with Pulp-Smash context.

  Start an interactive shell with pulp-smash objects available, if `ipython`
  is installed it will start ipython session, else it will start standard
  python shell.

Options:
  --ipython / --no-ipython
  --help                    Show this message and exit.
```

```bash
$ pulp-smash shell       
Welcome to Pulp-Smash interactive shell
	Auto imported: api, cli, config, utils, pulp2, pulp3, constants, exceptions
	Available objects: api.client, cli.client, cfg

In [1]: api.client.get('/pulp/api/v2/status/').json()
Out[1]: 
{'known_workers': [{'_ns': 'workers',
   'last_heartbeat': '2019-03-20T18:44:57Z',
   '_id': 'scheduler@rhel-76-pulp-2'},
  {'_ns': 'workers',
   'last_heartbeat': '2019-03-20T18:44:57Z',
   '_id': 'resource_manager@rhel-76-pulp-2'},
  {'_ns': 'workers',
   'last_heartbeat': '2019-03-20T18:44:54Z',
   '_id': 'reserved_resource_worker-0@rhel-76-pulp-2'}],
 'messaging_connection': {'connected': True},
 'database_connection': {'connected': True},
 'api_version': '2',
 'versions': {'platform_version': '2.19c1'}}

```

[![asciicast](https://asciinema.org/a/235178.svg)](https://asciinema.org/a/235178)