### PR TITLE
Lazy load the cli.Client machine

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -180,7 +180,7 @@ class ClientTestCase(unittest.TestCase):
             ]
         )
         client = cli.Client(cfg)
-        with mock.patch.object(client, "machine") as machine:
+        with mock.patch.object(client, "_machine") as machine:
 
             machine.__getitem__.return_value = machine
             machine.run.return_value = (0, "ok", None)
@@ -205,7 +205,7 @@ class ClientTestCase(unittest.TestCase):
             ]
         )
         client = cli.Client(cfg)
-        with mock.patch.object(client, "machine") as machine:
+        with mock.patch.object(client, "_machine") as machine:
 
             machine.__getitem__.return_value = machine
             machine.run.return_value = (0, "ok", None)


### PR DESCRIPTION
## Problem:

Everytime we instantiate a new instance of `cli.Client` its `__init__` method
code tries to make communication with the remote host to determine if it is
a local or ssh machine to be used.

The communication with `machine` should be done only when it is necessary,
which is when the `run` command is called.

### To reproduce the problem

```json
{
  "hosts": [
    {
      "hostname": "this-host-does-not-exists-or-server-is-down",
     ...
    }
  ]
}
```

```bash
$ export PULP_SMASH_CONFIG_FILE=/path/to/above/settings.json
$ python -c "from pulp_smash import cli, config; c = cli.Client(config.get_config()); print(c)"
Traceback (most recent call last):
plumbum.machines.session.SSHCommsError: No communication channel detected. Does the remote exist?
```


**We have not called the **run** method, so the communication with server should not be done yet.**


## Solution:

Transform `machine` in a lazy `@property` then it is instantiated only
when it is first called.

Not calling `run`
```bash
$ python -c "from pulp_smash import cli, config; c = cli.Client(config.get_config()); print(c)"
<pulp_smash.cli.Client object at 0x7f5439275ef0>
```

When `run` is called
```bash
$ python -c "from pulp_smash import cli, config; c = cli.Client(config.get_config()); c.run(['ls'])"
Traceback (most recent call last):
plumbum.machines.session.SSHCommsError: No communication channel detected. Does the remote exist?
```