### PR TITLE
Introduce BASE_CONTENT_GUARD_PATH

### DIFF
--- a/pulp_smash/pulp3/constants.py
+++ b/pulp_smash/pulp3/constants.py
@@ -12,11 +12,11 @@ API_DOCS_PATH = urljoin(BASE_PATH, "docs/")
 
 ARTIFACTS_PATH = urljoin(BASE_PATH, "artifacts/")
 
-BASE_REMOTE_PATH = urljoin(BASE_PATH, "remotes/")
+BASE_CONTENT_GUARDS_PATH = urljoin(BASE_PATH, "contentguards/")
 
 BASE_PUBLISHER_PATH = urljoin(BASE_PATH, "publishers/")
 
-CONTENT_GUARDS_PATH = urljoin(BASE_PATH, "contentguards/certguard/certguard/")
+BASE_REMOTE_PATH = urljoin(BASE_PATH, "remotes/")
 
 CONTENT_PATH = urljoin(BASE_PATH, "content/")
 


### PR DESCRIPTION
There is an existing constant called CONTENT_GUARD_PATH which includes
plugin-specific portions to its URL. This changes the name to indicate
it's only a BASE path and includes only the URL portions that are
specified by core.

The corresponding viewset comes from here: https://github.com/pulp/pulpcore/blob/7fdc5626559051e540509f7b699c28684e1043a9/pulpcore/app/viewsets/publication.py#L49