### PR TITLE
Modify response_handler for delete_orphans

### DIFF
--- a/pulp_smash/pulp3/utils.py
+++ b/pulp_smash/pulp3/utils.py
@@ -244,7 +244,7 @@ def delete_orphans(cfg=None):
     """
     if cfg is None:
         cfg = config.get_config()
-    api.Client(cfg, api.safe_handler).delete(ORPHANS_PATH)
+    api.Client(cfg, api.task_handler).delete(ORPHANS_PATH)
 
 
 def get_versions(repo, params=None):


### PR DESCRIPTION
Pulp 3 API endpoint to delete orphans returns a 202 and a task object.
Adjust the reponse_handler used by the delete_orphans function.

See: https://pulp.plan.io/issues/4555