### PR TITLE
Add pulp_smash.log.logger and some logger.debug calls

### DIFF
--- a/docs/api/pulp_smash.log.rst
+++ b/docs/api/pulp_smash.log.rst
@@ -1,0 +1,6 @@
+`pulp_smash.log`
+================
+
+Location: :doc:`/index` → :doc:`/api` → :doc:`/api/pulp_smash.log`
+
+.. automodule:: pulp_smash.log

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -140,6 +140,40 @@ sub-key, e.g. ``"shell": {"transport": "..."}``:
     without typing a password. Make sure to configure SSH so just running ``ssh
     "$hostname"`` will access the host. See sshd_config(5).
 
+
+Logs
+----
+
+Pulp Smash logs out information for important methods and functions,
+by default the log output is enabled only for ``ERROR`` level.
+
+To enable the logging of ``DEBUG`` information set the
+``PULP_SMASH_LOG_LEVEL`` environment variable to value ``DEBUG``.
+
+
+Example
+
+.. code-block:: console
+
+    $ export PULP_SMASH_LOG_LEVEL=DEBUG
+    $ pulp_smash shell
+    >>> response = api.Client(cfg).get('/pulp/api/v3/status/')
+    2019-04-23. DEBUG [api.py:530 - __init__] New <api.Client(...)>
+    2019-04-23. DEBUG [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://FQDN:80/pulp/api/v3/status/'}
+    2019-04-23. DEBUG [api.py:156 - safe_handler] reponse status: 200
+    2019-04-23. DEBUG [api.py:309 - smart_handler] Response is a JSON
+    2019-04-23. DEBUG [api.py:168 - json_handler] reponse status: 200
+    2019-04-23. DEBUG [api.py:642 - request] Finished GET request with {'versions': [...], 'online_workers': [...], 'missing_workers': [], 'database_connection': {'connected': True}, 'redis_connection': {'connected': True}}
+
+That variable holds the string name of Python's ``logging`` levels.
+
+- NOTSET
+- INFO
+- DEBUG
+- ERROR
+- CRITICAL
+- WARNING
+
 .. _Pulp installation:
     http://docs.pulpproject.org/user-guide/installation/index.html
 .. _XDG Base Directory Specification:

--- a/pulp_smash/log.py
+++ b/pulp_smash/log.py
@@ -1,0 +1,23 @@
+"""Pulpsmash logger module."""
+# pragma: no cover
+import functools
+import logging
+import os
+
+
+@functools.lru_cache()
+def get_logger(level):
+    """Return the same logger instance for changed level."""
+    logging.basicConfig(
+        format=(
+            "%(asctime)s,%(msecs)d %(levelname)-5s "
+            "[%(filename)s:%(lineno)d - %(funcName)s] %(message)s"
+        ),
+        datefmt="%Y-%m-%d:%H:%M:%S",
+    )
+    logger = logging.getLogger("pulp_smash")
+    logger.setLevel(getattr(logging, level, "DEBUG"))
+    return logger
+
+
+logger = get_logger(os.environ.get("PULP_SMASH_LOG_LEVEL", "ERROR"))

--- a/pulp_smash/pulp3/utils.py
+++ b/pulp_smash/pulp3/utils.py
@@ -8,6 +8,7 @@ from urllib.parse import urljoin, urlsplit
 from packaging.version import Version
 
 from pulp_smash import api, config, utils
+from pulp_smash.log import logger
 from pulp_smash.pulp3.constants import ORPHANS_PATH, STATUS_PATH
 
 
@@ -104,6 +105,7 @@ def download_content_unit(cfg, distribution, unit_path, **kwargs):
             unit_path,
         ),
     )
+    logger.debug("Downloading content %s", unit_url)
     return client.get(unit_url, **kwargs).content
 
 

--- a/pulp_smash/utils.py
+++ b/pulp_smash/utils.py
@@ -12,6 +12,7 @@ from urllib.parse import urlparse
 import requests
 
 from pulp_smash import cli, exceptions
+from pulp_smash.log import logger
 
 # A mapping between URLs and SHA 256 checksums. Used by get_sha256_checksum().
 _CHECKSUM_CACHE = {}
@@ -84,6 +85,7 @@ def http_get(url, **kwargs):
     """
     response = requests.get(url, **kwargs)
     response.raise_for_status()
+    logger.debug("GET Request to %s finished with %s", url, response)
     return response.content
 
 
@@ -100,7 +102,8 @@ def fips_is_supported(cfg, pulp_host=None):
         cli.Client(cfg, pulp_host=pulp_host).run(
             ("sysctl", "crypto.fips_enabled")
         )
-    except exceptions.CalledProcessError:
+    except exceptions.CalledProcessError as e:
+        logger.exception(e)
         return False
     return True
 


### PR DESCRIPTION
Adding some DEBUG loggings on api and cli Clients.

By default the logger will output on `ERROR` level, (only ERROR and CRITICAL messages)

To enagle debug logging the log level needs to be changed.

`export PULP_SMASH_LOG_LEVEL=DEBUG`

That variable holds the string name of `logging` levels `NOTSET,INFO,DEBUG,ERROR,CRITICAL,WARNING`

Examples and outputs:

<details>
<summary>Pulp Smash Shell</summary>

```logtalk
PULP_SMASH_LOG_LEVEL=DEBUG pulp-smash shell
In [1]: response = api.Client(cfg).get('/pulp/api/v3/status/', headers={'foo': 'bar'})
2019-04-23:17:59:47,147 DEBUG    [api.py:530 - __init__] New <api.Client({'response_handler': <function smart_handler at 0x7fd712b3dc80>, 'host': PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}}), 'cfg': "PulpSmashConfig(pulp_auth=['admin', 'admin'], pulp_version='3.0', pulp_selinux_enabled=False, hosts=[PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}})])"})>
2019-04-23:17:59:47,147 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/status/', 'headers': {'foo': 'bar'}}
2019-04-23:17:59:47,165 DEBUG    [api.py:156 - safe_handler] reponse status: 200
2019-04-23:17:59:47,166 DEBUG    [api.py:309 - smart_handler] Response is a JSON
2019-04-23:17:59:47,166 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:59:47,166 DEBUG    [api.py:642 - request] Finished GET request with response: {'versions': [{'component': 'pulpcore', 'version': '3.0.0rc1'}, {'component': 'pulpcore-plugin', 'version': '0.1.0rc1'}, {'component': 'pulp_rpm', 'version': '3.0.0b2'}, {'component': 'pulp_file', 'version': '0.0.1b10'}, {'component': 'pulp_docker', 'version': '4.0.0b3'}, {'component': 'pulp_certguard', 'version': '0.1.0rc1'}, {'component': 'pulp_ansible', 'version': '0.1.0rc4'}], 'online_workers': [{'_href': '/pulp/api/v3/workers/c299fb4b-d79b-4740-9261-a6b3221f0f0e/', '_created': '2019-04-23T14:47:47.276629Z', 'name': 'reserved-resource-worker-2@fedora29base.virt.box', 'last_heartbeat': '2019-04-23T20:59:42.461183Z', 'online': True, 'missing': False}, {'_href': '/pulp/api/v3/workers/46e07617-e257-4374-8055-a0c9e05bb9a5/', '_created': '2019-04-23T14:47:48.919015Z', 'name': 'resource-manager@fedora29base.virt.box', 'last_heartbeat': '2019-04-23T20:59:42.662936Z', 'online': True, 'missing': False}, {'_href': '/pulp/api/v3/workers/128d9703-128b-4ecd-925e-2ac50d3f15e1/', '_created': '2019-04-23T14:47:46.093730Z', 'name': 'reserved-resource-worker-1@fedora29base.virt.box', 'last_heartbeat': '2019-04-23T20:59:42.862157Z', 'online': True, 'missing': False}], 'missing_workers': [], 'database_connection': {'connected': True}, 'redis_connection': {'connected': True}}

```

</details>


<details>
<summary>Api test case with Task</summary>

```logtalk
PULP_SMASH_LOG_LEVEL=DEBUG py.test -vs pulpcore/tests/functional/api/test_crud_distributions.py >> /tmp/result.log 2>&1

----------------------------------------------------------------------
pulpcore/tests/functional/api/test_crud_distributions.py::CRUDDistributionsTestCase::test_01_create_distribution ...
2019-04-23:17:38:29,206 DEBUG    [api.py:530 - __init__] New <api.Client({'response_handler': <function json_handler at 0x7f06f6aa40d0>, 'host': PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}}), 'cfg': "PulpSmashConfig(pulp_auth=['admin', 'admin'], pulp_version='3.0', pulp_selinux_enabled=False, hosts=[PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}})])"})>
2019-04-23:17:38:29,206 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/status/'}
2019-04-23:17:38:29,219 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:38:29,219 DEBUG    [api.py:642 - request] Finished GET request with response: {'versions': [{'component': 'pulpcore', 'version': '3.0.0rc1'}, {'component': 'pulpcore-plugin', 'version': '0.1.0rc1'}, {'component': 'pulp_rpm', 'version': '3.0.0b2'}, {'component': 'pulp_file', 'version': '0.0.1b10'}, {'component': 'pulp_docker', 'version': '4.0.0b3'}, {'component': 'pulp_certguard', 'version': '0.1.0rc1'}, {'component': 'pulp_ansible', 'version': '0.1.0rc4'}], 'online_workers': [{'_href': '/pulp/api/v3/workers/c299fb4b-d79b-4740-9261-a6b3221f0f0e/', '_created': '2019-04-23T14:47:47.276629Z', 'name': 'reserved-resource-worker-2@fedora29base.virt.box', 'last_heartbeat': '2019-04-23T20:38:14.919324Z', 'online': True, 'missing': False}, {'_href': '/pulp/api/v3/workers/46e07617-e257-4374-8055-a0c9e05bb9a5/', '_created': '2019-04-23T14:47:48.919015Z', 'name': 'resource-manager@fedora29base.virt.box', 'last_heartbeat': '2019-04-23T20:38:15.321715Z', 'online': True, 'missing': False}, {'_href': '/pulp/api/v3/workers/128d9703-128b-4ecd-925e-2ac50d3f15e1/', '_created': '2019-04-23T14:47:46.093730Z', 'name': 'reserved-resource-worker-1@fedora29base.virt.box', 'last_heartbeat': '2019-04-23T20:38:15.422653Z', 'online': True, 'missing': False}], 'missing_workers': [], 'database_connection': {'connected': True}, 'redis_connection': {'connected': True}}
2019-04-23:17:38:29,220 DEBUG    [api.py:530 - __init__] New <api.Client({'response_handler': <function json_handler at 0x7f06f6aa40d0>, 'host': PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}}), 'cfg': "PulpSmashConfig(pulp_auth=['admin', 'admin'], pulp_version='3.0', pulp_selinux_enabled=False, hosts=[PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}})])"})>
2019-04-23:17:38:29,220 DEBUG    [api.py:563 - using_handler] Switching <function json_handler at 0x7f06f6aa40d0> to <function task_handler at 0x7f06f6aa41e0>
2019-04-23:17:38:29,220 DEBUG    [api.py:573 - using_handler] Creating a new copy of Client <api.Client({'response_handler': <function task_handler at 0x7f06f6aa41e0>, 'host': PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}}), 'cfg': "PulpSmashConfig(pulp_auth=['admin', 'admin'], pulp_version='3.0', pulp_selinux_enabled=False, hosts=[PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}})])"})>
2019-04-23:17:38:29,220 DEBUG    [api.py:638 - request] Making a POST request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/distributions/', 'json': {'base_path': 'a0f18bc2-94a8-4a2b-9a5b-b2e35ff170f0', 'name': 'dff8779e-a0fc-4464-b74c-b3273deb866b'}}
2019-04-23:17:38:29,314 DEBUG    [api.py:168 - json_handler] reponse status: 202
2019-04-23:17:38:29,314 DEBUG    [api.py:530 - __init__] New <api.Client({'response_handler': <function json_handler at 0x7f06f6aa40d0>, 'host': PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}}), 'cfg': "PulpSmashConfig(pulp_auth=['admin', 'admin'], pulp_version='3.0', pulp_selinux_enabled=False, hosts=[PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}})])"})>
2019-04-23:17:38:29,314 DEBUG    [api.py:693 - poll_task] Polling task /pulp/api/v3/tasks/91cb15b1-50e7-40f9-bcd2-361fe2997cf5/ with poll_limit 900
2019-04-23:17:38:29,314 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/tasks/91cb15b1-50e7-40f9-bcd2-361fe2997cf5/'}
2019-04-23:17:38:29,572 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:38:29,572 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/tasks/91cb15b1-50e7-40f9-bcd2-361fe2997cf5/', '_created': '2019-04-23T20:38:29.314225Z', 'state': 'running', 'name': 'pulpcore.app.tasks.distribution.create', 'started_at': '2019-04-23T20:38:29.473573Z', 'finished_at': None, 'non_fatal_errors': [], 'error': None, 'worker': '/pulp/api/v3/workers/c299fb4b-d79b-4740-9261-a6b3221f0f0e/', 'parent': None, 'spawned_tasks': [], 'progress_reports': [], 'created_resources': []}
2019-04-23:17:38:29,572 DEBUG    [api.py:716 - poll_task] Polling /pulp/api/v3/tasks/91cb15b1-50e7-40f9-bcd2-361fe2997cf5/ progress 1/900
2019-04-23:17:38:31,574 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/tasks/91cb15b1-50e7-40f9-bcd2-361fe2997cf5/'}
2019-04-23:17:38:31,688 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:38:31,688 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/tasks/91cb15b1-50e7-40f9-bcd2-361fe2997cf5/', '_created': '2019-04-23T20:38:29.314225Z', 'state': 'completed', 'name': 'pulpcore.app.tasks.distribution.create', 'started_at': '2019-04-23T20:38:29.473573Z', 'finished_at': '2019-04-23T20:38:29.602372Z', 'non_fatal_errors': [], 'error': None, 'worker': '/pulp/api/v3/workers/c299fb4b-d79b-4740-9261-a6b3221f0f0e/', 'parent': None, 'spawned_tasks': [], 'progress_reports': [], 'created_resources': ['/pulp/api/v3/distributions/92651319-666c-44fc-acc4-5921a214b055/']}
2019-04-23:17:38:31,688 DEBUG    [api.py:102 - _handle_202] Task call report: {'task': '/pulp/api/v3/tasks/91cb15b1-50e7-40f9-bcd2-361fe2997cf5/'}
2019-04-23:17:38:31,689 DEBUG    [api.py:563 - using_handler] Switching <function task_handler at 0x7f06f6aa41e0> to <function json_handler at 0x7f06f6aa40d0>
2019-04-23:17:38:31,689 DEBUG    [api.py:573 - using_handler] Creating a new copy of Client <api.Client({'response_handler': <function json_handler at 0x7f06f6aa40d0>, 'host': PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}}), 'cfg': "PulpSmashConfig(pulp_auth=['admin', 'admin'], pulp_version='3.0', pulp_selinux_enabled=False, hosts=[PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}})])"})>
2019-04-23:17:38:31,689 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/tasks/91cb15b1-50e7-40f9-bcd2-361fe2997cf5/'}
2019-04-23:17:38:31,782 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:38:31,782 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/tasks/91cb15b1-50e7-40f9-bcd2-361fe2997cf5/', '_created': '2019-04-23T20:38:29.314225Z', 'state': 'completed', 'name': 'pulpcore.app.tasks.distribution.create', 'started_at': '2019-04-23T20:38:29.473573Z', 'finished_at': '2019-04-23T20:38:29.602372Z', 'non_fatal_errors': [], 'error': None, 'worker': '/pulp/api/v3/workers/c299fb4b-d79b-4740-9261-a6b3221f0f0e/', 'parent': None, 'spawned_tasks': [], 'progress_reports': [], 'created_resources': ['/pulp/api/v3/distributions/92651319-666c-44fc-acc4-5921a214b055/']}
2019-04-23:17:38:31,782 DEBUG    [api.py:258 - task_handler] Task created resources: ['/pulp/api/v3/distributions/92651319-666c-44fc-acc4-5921a214b055/']
2019-04-23:17:38:31,782 DEBUG    [api.py:563 - using_handler] Switching <function task_handler at 0x7f06f6aa41e0> to <function json_handler at 0x7f06f6aa40d0>
2019-04-23:17:38:31,782 DEBUG    [api.py:567 - using_handler] Reusing Existing Client: <api.Client({'response_handler': <function json_handler at 0x7f06f6aa40d0>, 'host': PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}}), 'cfg': "PulpSmashConfig(pulp_auth=['admin', 'admin'], pulp_version='3.0', pulp_selinux_enabled=False, hosts=[PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}})])"})>
2019-04-23:17:38:31,783 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/distributions/92651319-666c-44fc-acc4-5921a214b055/'}
2019-04-23:17:38:31,868 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:38:31,869 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/distributions/92651319-666c-44fc-acc4-5921a214b055/', '_created': '2019-04-23T20:38:29.592660Z', 'name': 'dff8779e-a0fc-4464-b74c-b3273deb866b', 'publisher': None, 'publication': None, 'repository': None, 'content_guard': None, 'remote': None, 'base_path': 'a0f18bc2-94a8-4a2b-9a5b-b2e35ff170f0', 'base_url': 'fedora-29-pulp-3:24816/pulp/content/a0f18bc2-94a8-4a2b-9a5b-b2e35ff170f0'}
2019-04-23:17:38:31,869 DEBUG    [api.py:642 - request] Finished POST request with response: {'_href': '/pulp/api/v3/distributions/92651319-666c-44fc-acc4-5921a214b055/', '_created': '2019-04-23T20:38:29.592660Z', 'name': 'dff8779e-a0fc-4464-b74c-b3273deb866b', 'publisher': None, 'publication': None, 'repository': None, 'content_guard': None, 'remote': None, 'base_path': 'a0f18bc2-94a8-4a2b-9a5b-b2e35ff170f0', 'base_url': 'fedora-29-pulp-3:24816/pulp/content/a0f18bc2-94a8-4a2b-9a5b-b2e35ff170f0'}
2019-04-23:17:38:31,869 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/distributions/92651319-666c-44fc-acc4-5921a214b055/'}
2019-04-23:17:38:31,954 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:38:31,955 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/distributions/92651319-666c-44fc-acc4-5921a214b055/', '_created': '2019-04-23T20:38:29.592660Z', 'name': 'dff8779e-a0fc-4464-b74c-b3273deb866b', 'publisher': None, 'publication': None, 'repository': None, 'content_guard': None, 'remote': None, 'base_path': 'a0f18bc2-94a8-4a2b-9a5b-b2e35ff170f0', 'base_url': 'fedora-29-pulp-3:24816/pulp/content/a0f18bc2-94a8-4a2b-9a5b-b2e35ff170f0'}
ok
pulpcore/tests/functional/api/test_crud_distributions.py::CRUDDistributionsTestCase::test_02_create_same_name ...
2019-04-23:17:38:31,956 DEBUG    [api.py:638 - request] Making a POST request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/distributions/', 'json': {'base_path': '948f6138-9554-429d-9819-cdc6b9f6da8d', 'name': 'dff8779e-a0fc-4464-b74c-b3273deb866b'}}
ok
pulpcore/tests/functional/api/test_crud_distributions.py::CRUDDistributionsTestCase::test_02_read_distribution ...
2019-04-23:17:38:32,42 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/distributions/92651319-666c-44fc-acc4-5921a214b055/'}
2019-04-23:17:38:32,126 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:38:32,127 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/distributions/92651319-666c-44fc-acc4-5921a214b055/', '_created': '2019-04-23T20:38:29.592660Z', 'name': 'dff8779e-a0fc-4464-b74c-b3273deb866b', 'publisher': None, 'publication': None, 'repository': None, 'content_guard': None, 'remote': None, 'base_path': 'a0f18bc2-94a8-4a2b-9a5b-b2e35ff170f0', 'base_url': 'fedora-29-pulp-3:24816/pulp/content/a0f18bc2-94a8-4a2b-9a5b-b2e35ff170f0'}
ok
pulpcore/tests/functional/api/test_crud_distributions.py::CRUDDistributionsTestCase::test_02_read_distribution_with_specific_fields ...
2019-04-23:17:38:32,128 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/distributions/92651319-666c-44fc-acc4-5921a214b055/', 'params': {'fields': '_href,base_path'}}
2019-04-23:17:38:32,213 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:38:32,213 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/distributions/92651319-666c-44fc-acc4-5921a214b055/', 'base_path': 'a0f18bc2-94a8-4a2b-9a5b-b2e35ff170f0'}
2019-04-23:17:38:32,213 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/distributions/92651319-666c-44fc-acc4-5921a214b055/', 'params': {'fields': '_href,base_url'}}
2019-04-23:17:38:32,298 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:38:32,299 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/distributions/92651319-666c-44fc-acc4-5921a214b055/', 'base_url': 'fedora-29-pulp-3:24816/pulp/content/a0f18bc2-94a8-4a2b-9a5b-b2e35ff170f0'}
2019-04-23:17:38:32,299 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/distributions/92651319-666c-44fc-acc4-5921a214b055/', 'params': {'fields': '_href,_created'}}
2019-04-23:17:38:32,382 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:38:32,382 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/distributions/92651319-666c-44fc-acc4-5921a214b055/', '_created': '2019-04-23T20:38:29.592660Z'}
2019-04-23:17:38:32,383 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/distributions/92651319-666c-44fc-acc4-5921a214b055/', 'params': {'fields': 'base_path,_href'}}
2019-04-23:17:38:32,467 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:38:32,467 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/distributions/92651319-666c-44fc-acc4-5921a214b055/', 'base_path': 'a0f18bc2-94a8-4a2b-9a5b-b2e35ff170f0'}
2019-04-23:17:38:32,467 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/distributions/92651319-666c-44fc-acc4-5921a214b055/', 'params': {'fields': 'base_path,base_url'}}
2019-04-23:17:38:32,551 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:38:32,551 DEBUG    [api.py:642 - request] Finished GET request with response: {'base_path': 'a0f18bc2-94a8-4a2b-9a5b-b2e35ff170f0', 'base_url': 'fedora-29-pulp-3:24816/pulp/content/a0f18bc2-94a8-4a2b-9a5b-b2e35ff170f0'}
2019-04-23:17:38:32,552 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/distributions/92651319-666c-44fc-acc4-5921a214b055/', 'params': {'fields': 'base_path,_created'}}
2019-04-23:17:38:32,636 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:38:32,636 DEBUG    [api.py:642 - request] Finished GET request with response: {'_created': '2019-04-23T20:38:29.592660Z', 'base_path': 'a0f18bc2-94a8-4a2b-9a5b-b2e35ff170f0'}
2019-04-23:17:38:32,636 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/distributions/92651319-666c-44fc-acc4-5921a214b055/', 'params': {'fields': 'base_url,_href'}}
2019-04-23:17:38:32,724 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:38:32,724 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/distributions/92651319-666c-44fc-acc4-5921a214b055/', 'base_url': 'fedora-29-pulp-3:24816/pulp/content/a0f18bc2-94a8-4a2b-9a5b-b2e35ff170f0'}
2019-04-23:17:38:32,724 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/distributions/92651319-666c-44fc-acc4-5921a214b055/', 'params': {'fields': 'base_url,base_path'}}
2019-04-23:17:38:32,809 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:38:32,809 DEBUG    [api.py:642 - request] Finished GET request with response: {'base_path': 'a0f18bc2-94a8-4a2b-9a5b-b2e35ff170f0', 'base_url': 'fedora-29-pulp-3:24816/pulp/content/a0f18bc2-94a8-4a2b-9a5b-b2e35ff170f0'}
2019-04-23:17:38:32,809 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/distributions/92651319-666c-44fc-acc4-5921a214b055/', 'params': {'fields': 'base_url,_created'}}
2019-04-23:17:38:32,902 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:38:32,902 DEBUG    [api.py:642 - request] Finished GET request with response: {'_created': '2019-04-23T20:38:29.592660Z', 'base_url': 'fedora-29-pulp-3:24816/pulp/content/a0f18bc2-94a8-4a2b-9a5b-b2e35ff170f0'}
2019-04-23:17:38:32,902 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/distributions/92651319-666c-44fc-acc4-5921a214b055/', 'params': {'fields': '_created,_href'}}
2019-04-23:17:38:32,998 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:38:32,998 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/distributions/92651319-666c-44fc-acc4-5921a214b055/', '_created': '2019-04-23T20:38:29.592660Z'}
2019-04-23:17:38:32,998 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/distributions/92651319-666c-44fc-acc4-5921a214b055/', 'params': {'fields': '_created,base_path'}}
2019-04-23:17:38:33,107 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:38:33,108 DEBUG    [api.py:642 - request] Finished GET request with response: {'_created': '2019-04-23T20:38:29.592660Z', 'base_path': 'a0f18bc2-94a8-4a2b-9a5b-b2e35ff170f0'}
2019-04-23:17:38:33,108 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/distributions/92651319-666c-44fc-acc4-5921a214b055/', 'params': {'fields': '_created,base_url'}}
2019-04-23:17:38:33,208 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:38:33,208 DEBUG    [api.py:642 - request] Finished GET request with response: {'_created': '2019-04-23T20:38:29.592660Z', 'base_url': 'fedora-29-pulp-3:24816/pulp/content/a0f18bc2-94a8-4a2b-9a5b-b2e35ff170f0'}
ok
pulpcore/tests/functional/api/test_crud_distributions.py::CRUDDistributionsTestCase::test_02_read_distribution_without_specific_fields ...
2019-04-23:17:38:33,209 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/distributions/92651319-666c-44fc-acc4-5921a214b055/?fields!=base_path,base_url'}
2019-04-23:17:38:33,295 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:38:33,295 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/distributions/92651319-666c-44fc-acc4-5921a214b055/', '_created': '2019-04-23T20:38:29.592660Z', 'name': 'dff8779e-a0fc-4464-b74c-b3273deb866b', 'publisher': None, 'publication': None, 'repository': None, 'content_guard': None, 'remote': None}
ok
pulpcore/tests/functional/api/test_crud_distributions.py::CRUDDistributionsTestCase::test_02_read_distributions ...
2019-04-23:17:38:33,297 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/distributions/', 'params': {'name': 'dff8779e-a0fc-4464-b74c-b3273deb866b'}}
2019-04-23:17:38:33,385 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:38:33,385 DEBUG    [api.py:642 - request] Finished GET request with response: {'count': 1, 'next': None, 'previous': None, 'results': [{'_href': '/pulp/api/v3/distributions/92651319-666c-44fc-acc4-5921a214b055/', '_created': '2019-04-23T20:38:29.592660Z', 'name': 'dff8779e-a0fc-4464-b74c-b3273deb866b', 'publisher': None, 'publication': None, 'repository': None, 'content_guard': None, 'remote': None, 'base_path': 'a0f18bc2-94a8-4a2b-9a5b-b2e35ff170f0', 'base_url': 'fedora-29-pulp-3:24816/pulp/content/a0f18bc2-94a8-4a2b-9a5b-b2e35ff170f0'}]}
2019-04-23:17:38:33,385 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/distributions/', 'params': {'base_path': 'a0f18bc2-94a8-4a2b-9a5b-b2e35ff170f0'}}
2019-04-23:17:38:33,471 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:38:33,471 DEBUG    [api.py:642 - request] Finished GET request with response: {'count': 1, 'next': None, 'previous': None, 'results': [{'_href': '/pulp/api/v3/distributions/92651319-666c-44fc-acc4-5921a214b055/', '_created': '2019-04-23T20:38:29.592660Z', 'name': 'dff8779e-a0fc-4464-b74c-b3273deb866b', 'publisher': None, 'publication': None, 'repository': None, 'content_guard': None, 'remote': None, 'base_path': 'a0f18bc2-94a8-4a2b-9a5b-b2e35ff170f0', 'base_url': 'fedora-29-pulp-3:24816/pulp/content/a0f18bc2-94a8-4a2b-9a5b-b2e35ff170f0'}]}
ok
pulpcore/tests/functional/api/test_crud_distributions.py::CRUDDistributionsTestCase::test_03_partially_update ...
2019-04-23:17:38:33,472 DEBUG    [api.py:638 - request] Making a PATCH request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/distributions/92651319-666c-44fc-acc4-5921a214b055/', 'json': {'base_path': 'a29061e3-e9f6-453a-a9ad-5f2a45ffe45c', 'name': '946bc0ac-c2c3-4b9f-831e-67a68bca68f5'}}
2019-04-23:17:38:33,569 DEBUG    [api.py:168 - json_handler] reponse status: 202
2019-04-23:17:38:33,569 DEBUG    [api.py:530 - __init__] New <api.Client({'response_handler': <function json_handler at 0x7f06f6aa40d0>, 'host': PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}}), 'cfg': "PulpSmashConfig(pulp_auth=['admin', 'admin'], pulp_version='3.0', pulp_selinux_enabled=False, hosts=[PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}})])"})>
2019-04-23:17:38:33,570 DEBUG    [api.py:693 - poll_task] Polling task /pulp/api/v3/tasks/0a4eb4e0-b606-49c6-9c03-a58ba0d4da1b/ with poll_limit 900
2019-04-23:17:38:33,570 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/tasks/0a4eb4e0-b606-49c6-9c03-a58ba0d4da1b/'}
2019-04-23:17:38:33,809 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:38:33,810 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/tasks/0a4eb4e0-b606-49c6-9c03-a58ba0d4da1b/', '_created': '2019-04-23T20:38:33.569886Z', 'state': 'running', 'name': 'pulpcore.app.tasks.distribution.update', 'started_at': '2019-04-23T20:38:33.713180Z', 'finished_at': None, 'non_fatal_errors': [], 'error': None, 'worker': '/pulp/api/v3/workers/128d9703-128b-4ecd-925e-2ac50d3f15e1/', 'parent': None, 'spawned_tasks': [], 'progress_reports': [], 'created_resources': []}
2019-04-23:17:38:33,810 DEBUG    [api.py:716 - poll_task] Polling /pulp/api/v3/tasks/0a4eb4e0-b606-49c6-9c03-a58ba0d4da1b/ progress 1/900
2019-04-23:17:38:35,812 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/tasks/0a4eb4e0-b606-49c6-9c03-a58ba0d4da1b/'}
2019-04-23:17:38:35,943 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:38:35,943 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/tasks/0a4eb4e0-b606-49c6-9c03-a58ba0d4da1b/', '_created': '2019-04-23T20:38:33.569886Z', 'state': 'completed', 'name': 'pulpcore.app.tasks.distribution.update', 'started_at': '2019-04-23T20:38:33.713180Z', 'finished_at': '2019-04-23T20:38:33.833139Z', 'non_fatal_errors': [], 'error': None, 'worker': '/pulp/api/v3/workers/128d9703-128b-4ecd-925e-2ac50d3f15e1/', 'parent': None, 'spawned_tasks': [], 'progress_reports': [], 'created_resources': []}
2019-04-23:17:38:35,943 DEBUG    [api.py:102 - _handle_202] Task call report: {'task': '/pulp/api/v3/tasks/0a4eb4e0-b606-49c6-9c03-a58ba0d4da1b/'}
2019-04-23:17:38:35,943 DEBUG    [api.py:642 - request] Finished PATCH request with response: {'task': '/pulp/api/v3/tasks/0a4eb4e0-b606-49c6-9c03-a58ba0d4da1b/'}
2019-04-23:17:38:35,943 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/distributions/92651319-666c-44fc-acc4-5921a214b055/'}
2019-04-23:17:38:36,32 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:38:36,32 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/distributions/92651319-666c-44fc-acc4-5921a214b055/', '_created': '2019-04-23T20:38:29.592660Z', 'name': '946bc0ac-c2c3-4b9f-831e-67a68bca68f5', 'publisher': None, 'publication': None, 'repository': None, 'content_guard': None, 'remote': None, 'base_path': 'a29061e3-e9f6-453a-a9ad-5f2a45ffe45c', 'base_url': 'fedora-29-pulp-3:24816/pulp/content/a29061e3-e9f6-453a-a9ad-5f2a45ffe45c'}
ok
pulpcore/tests/functional/api/test_crud_distributions.py::CRUDDistributionsTestCase::test_04_fully_update ...
2019-04-23:17:38:36,34 DEBUG    [api.py:638 - request] Making a PUT request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/distributions/92651319-666c-44fc-acc4-5921a214b055/', 'json': {'base_path': '8281d6bc-e9b6-4af7-af9c-bedb823ba8c9', 'name': '1de56efe-0336-4dc1-a5a8-43fbca3171d2'}}
2019-04-23:17:38:36,132 DEBUG    [api.py:168 - json_handler] reponse status: 202
2019-04-23:17:38:36,132 DEBUG    [api.py:530 - __init__] New <api.Client({'response_handler': <function json_handler at 0x7f06f6aa40d0>, 'host': PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}}), 'cfg': "PulpSmashConfig(pulp_auth=['admin', 'admin'], pulp_version='3.0', pulp_selinux_enabled=False, hosts=[PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}})])"})>
2019-04-23:17:38:36,132 DEBUG    [api.py:693 - poll_task] Polling task /pulp/api/v3/tasks/12f71f43-c3b8-4eea-aa76-638712ff53da/ with poll_limit 900
2019-04-23:17:38:36,133 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/tasks/12f71f43-c3b8-4eea-aa76-638712ff53da/'}
2019-04-23:17:38:36,360 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:38:36,360 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/tasks/12f71f43-c3b8-4eea-aa76-638712ff53da/', '_created': '2019-04-23T20:38:36.128630Z', 'state': 'running', 'name': 'pulpcore.app.tasks.distribution.update', 'started_at': '2019-04-23T20:38:36.272735Z', 'finished_at': None, 'non_fatal_errors': [], 'error': None, 'worker': '/pulp/api/v3/workers/128d9703-128b-4ecd-925e-2ac50d3f15e1/', 'parent': None, 'spawned_tasks': [], 'progress_reports': [], 'created_resources': []}
2019-04-23:17:38:36,361 DEBUG    [api.py:716 - poll_task] Polling /pulp/api/v3/tasks/12f71f43-c3b8-4eea-aa76-638712ff53da/ progress 1/900
2019-04-23:17:38:38,363 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/tasks/12f71f43-c3b8-4eea-aa76-638712ff53da/'}
2019-04-23:17:38:38,490 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:38:38,490 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/tasks/12f71f43-c3b8-4eea-aa76-638712ff53da/', '_created': '2019-04-23T20:38:36.128630Z', 'state': 'completed', 'name': 'pulpcore.app.tasks.distribution.update', 'started_at': '2019-04-23T20:38:36.272735Z', 'finished_at': '2019-04-23T20:38:36.384178Z', 'non_fatal_errors': [], 'error': None, 'worker': '/pulp/api/v3/workers/128d9703-128b-4ecd-925e-2ac50d3f15e1/', 'parent': None, 'spawned_tasks': [], 'progress_reports': [], 'created_resources': []}
2019-04-23:17:38:38,490 DEBUG    [api.py:102 - _handle_202] Task call report: {'task': '/pulp/api/v3/tasks/12f71f43-c3b8-4eea-aa76-638712ff53da/'}
2019-04-23:17:38:38,490 DEBUG    [api.py:642 - request] Finished PUT request with response: {'task': '/pulp/api/v3/tasks/12f71f43-c3b8-4eea-aa76-638712ff53da/'}
2019-04-23:17:38:38,490 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/distributions/92651319-666c-44fc-acc4-5921a214b055/'}
2019-04-23:17:38:38,573 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:38:38,573 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/distributions/92651319-666c-44fc-acc4-5921a214b055/', '_created': '2019-04-23T20:38:29.592660Z', 'name': '1de56efe-0336-4dc1-a5a8-43fbca3171d2', 'publisher': None, 'publication': None, 'repository': None, 'content_guard': None, 'remote': None, 'base_path': '8281d6bc-e9b6-4af7-af9c-bedb823ba8c9', 'base_url': 'fedora-29-pulp-3:24816/pulp/content/8281d6bc-e9b6-4af7-af9c-bedb823ba8c9'}
ok
pulpcore/tests/functional/api/test_crud_distributions.py::CRUDDistributionsTestCase::test_05_delete ...
2019-04-23:17:38:38,574 DEBUG    [api.py:638 - request] Making a DELETE request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/distributions/92651319-666c-44fc-acc4-5921a214b055/'}
2019-04-23:17:38:38,669 DEBUG    [api.py:168 - json_handler] reponse status: 202
2019-04-23:17:38:38,669 DEBUG    [api.py:530 - __init__] New <api.Client({'response_handler': <function json_handler at 0x7f06f6aa40d0>, 'host': PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}}), 'cfg': "PulpSmashConfig(pulp_auth=['admin', 'admin'], pulp_version='3.0', pulp_selinux_enabled=False, hosts=[PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}})])"})>
2019-04-23:17:38:38,669 DEBUG    [api.py:693 - poll_task] Polling task /pulp/api/v3/tasks/b40f3b3a-0f8a-4ecd-92d0-d1e824b941e6/ with poll_limit 900
2019-04-23:17:38:38,669 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/tasks/b40f3b3a-0f8a-4ecd-92d0-d1e824b941e6/'}
2019-04-23:17:38:38,945 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:38:38,945 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/tasks/b40f3b3a-0f8a-4ecd-92d0-d1e824b941e6/', '_created': '2019-04-23T20:38:38.666033Z', 'state': 'completed', 'name': 'pulpcore.app.tasks.distribution.delete', 'started_at': '2019-04-23T20:38:38.826105Z', 'finished_at': '2019-04-23T20:38:38.855522Z', 'non_fatal_errors': [], 'error': None, 'worker': '/pulp/api/v3/workers/c299fb4b-d79b-4740-9261-a6b3221f0f0e/', 'parent': None, 'spawned_tasks': [], 'progress_reports': [], 'created_resources': []}
2019-04-23:17:38:38,946 DEBUG    [api.py:102 - _handle_202] Task call report: {'task': '/pulp/api/v3/tasks/b40f3b3a-0f8a-4ecd-92d0-d1e824b941e6/'}
2019-04-23:17:38:38,946 DEBUG    [api.py:642 - request] Finished DELETE request with response: {'task': '/pulp/api/v3/tasks/b40f3b3a-0f8a-4ecd-92d0-d1e824b941e6/'}
2019-04-23:17:38:38,946 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/distributions/92651319-666c-44fc-acc4-5921a214b055/'}
ok
pulpcore/tests/functional/api/test_crud_distributions.py::CRUDDistributionsTestCase::test_negative_create_distribution_with_invalid_parameter ...
2019-04-23:17:38:39,103 DEBUG    [api.py:530 - __init__] New <api.Client({'response_handler': <function echo_handler at 0x7f06f6a9cea0>, 'host': PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}}), 'cfg': "PulpSmashConfig(pulp_auth=['admin', 'admin'], pulp_version='3.0', pulp_selinux_enabled=False, hosts=[PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}})])"})>
2019-04-23:17:38:39,104 DEBUG    [api.py:638 - request] Making a POST request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/distributions/', 'json': {'base_path': 'af578103-6c50-4ffa-8053-4bcbf4267c46', 'name': '28f2c44b-0206-4842-916d-71a3dfabc9d2', 'foo': 'bar'}}
2019-04-23:17:38:39,191 DEBUG    [api.py:123 - echo_handler] response status: 400
2019-04-23:17:38:39,191 DEBUG    [api.py:642 - request] Finished POST request with response: <Response [400]>
ok
pulpcore/tests/functional/api/test_crud_distributions.py::DistributionBasePathTestCase::test_begin_slash ...
2019-04-23:17:38:39,192 DEBUG    [api.py:530 - __init__] New <api.Client({'response_handler': <function json_handler at 0x7f06f6aa40d0>, 'host': PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}}), 'cfg': "PulpSmashConfig(pulp_auth=['admin', 'admin'], pulp_version='3.0', pulp_selinux_enabled=False, hosts=[PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}})])"})>
2019-04-23:17:38:39,192 DEBUG    [api.py:530 - __init__] New <api.Client({'response_handler': <function task_handler at 0x7f06f6aa41e0>, 'host': PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}}), 'cfg': "PulpSmashConfig(pulp_auth=['admin', 'admin'], pulp_version='3.0', pulp_selinux_enabled=False, hosts=[PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}})])"})>
2019-04-23:17:38:39,193 DEBUG    [api.py:638 - request] Making a POST request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/distributions/', 'json': {'base_path': '6aa640ab/342a/4701/ba17/2574a5130e50', 'name': 'f84fd9bd-cc68-47b9-9e91-1fa771b4d19e'}}
2019-04-23:17:38:39,291 DEBUG    [api.py:168 - json_handler] reponse status: 202
2019-04-23:17:38:39,291 DEBUG    [api.py:530 - __init__] New <api.Client({'response_handler': <function json_handler at 0x7f06f6aa40d0>, 'host': PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}}), 'cfg': "PulpSmashConfig(pulp_auth=['admin', 'admin'], pulp_version='3.0', pulp_selinux_enabled=False, hosts=[PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}})])"})>
2019-04-23:17:38:39,292 DEBUG    [api.py:693 - poll_task] Polling task /pulp/api/v3/tasks/0b3036de-3f81-4208-abc4-5bd9452c5e22/ with poll_limit 900
2019-04-23:17:38:39,292 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/tasks/0b3036de-3f81-4208-abc4-5bd9452c5e22/'}
2019-04-23:17:38:39,531 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:38:39,532 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/tasks/0b3036de-3f81-4208-abc4-5bd9452c5e22/', '_created': '2019-04-23T20:38:39.291310Z', 'state': 'running', 'name': 'pulpcore.app.tasks.distribution.create', 'started_at': '2019-04-23T20:38:39.429974Z', 'finished_at': None, 'non_fatal_errors': [], 'error': None, 'worker': '/pulp/api/v3/workers/128d9703-128b-4ecd-925e-2ac50d3f15e1/', 'parent': None, 'spawned_tasks': [], 'progress_reports': [], 'created_resources': []}
2019-04-23:17:38:39,532 DEBUG    [api.py:716 - poll_task] Polling /pulp/api/v3/tasks/0b3036de-3f81-4208-abc4-5bd9452c5e22/ progress 1/900
2019-04-23:17:38:41,534 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/tasks/0b3036de-3f81-4208-abc4-5bd9452c5e22/'}
2019-04-23:17:38:41,655 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:38:41,655 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/tasks/0b3036de-3f81-4208-abc4-5bd9452c5e22/', '_created': '2019-04-23T20:38:39.291310Z', 'state': 'completed', 'name': 'pulpcore.app.tasks.distribution.create', 'started_at': '2019-04-23T20:38:39.429974Z', 'finished_at': '2019-04-23T20:38:39.561401Z', 'non_fatal_errors': [], 'error': None, 'worker': '/pulp/api/v3/workers/128d9703-128b-4ecd-925e-2ac50d3f15e1/', 'parent': None, 'spawned_tasks': [], 'progress_reports': [], 'created_resources': ['/pulp/api/v3/distributions/41c0af2e-12bf-4b5a-9a82-8e836ad72b86/']}
2019-04-23:17:38:41,655 DEBUG    [api.py:102 - _handle_202] Task call report: {'task': '/pulp/api/v3/tasks/0b3036de-3f81-4208-abc4-5bd9452c5e22/'}
2019-04-23:17:38:41,655 DEBUG    [api.py:563 - using_handler] Switching <function task_handler at 0x7f06f6aa41e0> to <function json_handler at 0x7f06f6aa40d0>
2019-04-23:17:38:41,656 DEBUG    [api.py:573 - using_handler] Creating a new copy of Client <api.Client({'response_handler': <function json_handler at 0x7f06f6aa40d0>, 'host': PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}}), 'cfg': "PulpSmashConfig(pulp_auth=['admin', 'admin'], pulp_version='3.0', pulp_selinux_enabled=False, hosts=[PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}})])"})>
2019-04-23:17:38:41,656 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/tasks/0b3036de-3f81-4208-abc4-5bd9452c5e22/'}
2019-04-23:17:38:41,748 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:38:41,748 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/tasks/0b3036de-3f81-4208-abc4-5bd9452c5e22/', '_created': '2019-04-23T20:38:39.291310Z', 'state': 'completed', 'name': 'pulpcore.app.tasks.distribution.create', 'started_at': '2019-04-23T20:38:39.429974Z', 'finished_at': '2019-04-23T20:38:39.561401Z', 'non_fatal_errors': [], 'error': None, 'worker': '/pulp/api/v3/workers/128d9703-128b-4ecd-925e-2ac50d3f15e1/', 'parent': None, 'spawned_tasks': [], 'progress_reports': [], 'created_resources': ['/pulp/api/v3/distributions/41c0af2e-12bf-4b5a-9a82-8e836ad72b86/']}
2019-04-23:17:38:41,748 DEBUG    [api.py:258 - task_handler] Task created resources: ['/pulp/api/v3/distributions/41c0af2e-12bf-4b5a-9a82-8e836ad72b86/']
2019-04-23:17:38:41,748 DEBUG    [api.py:563 - using_handler] Switching <function task_handler at 0x7f06f6aa41e0> to <function json_handler at 0x7f06f6aa40d0>
2019-04-23:17:38:41,748 DEBUG    [api.py:567 - using_handler] Reusing Existing Client: <api.Client({'response_handler': <function json_handler at 0x7f06f6aa40d0>, 'host': PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}}), 'cfg': "PulpSmashConfig(pulp_auth=['admin', 'admin'], pulp_version='3.0', pulp_selinux_enabled=False, hosts=[PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}})])"})>
2019-04-23:17:38:41,749 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/distributions/41c0af2e-12bf-4b5a-9a82-8e836ad72b86/'}
2019-04-23:17:38:41,834 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:38:41,834 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/distributions/41c0af2e-12bf-4b5a-9a82-8e836ad72b86/', '_created': '2019-04-23T20:38:39.550982Z', 'name': 'f84fd9bd-cc68-47b9-9e91-1fa771b4d19e', 'publisher': None, 'publication': None, 'repository': None, 'content_guard': None, 'remote': None, 'base_path': '6aa640ab/342a/4701/ba17/2574a5130e50', 'base_url': 'fedora-29-pulp-3:24816/pulp/content/6aa640ab/342a/4701/ba17/2574a5130e50'}
2019-04-23:17:38:41,834 DEBUG    [api.py:642 - request] Finished POST request with response: {'_href': '/pulp/api/v3/distributions/41c0af2e-12bf-4b5a-9a82-8e836ad72b86/', '_created': '2019-04-23T20:38:39.550982Z', 'name': 'f84fd9bd-cc68-47b9-9e91-1fa771b4d19e', 'publisher': None, 'publication': None, 'repository': None, 'content_guard': None, 'remote': None, 'base_path': '6aa640ab/342a/4701/ba17/2574a5130e50', 'base_url': 'fedora-29-pulp-3:24816/pulp/content/6aa640ab/342a/4701/ba17/2574a5130e50'}
2019-04-23:17:38:41,834 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/distributions/41c0af2e-12bf-4b5a-9a82-8e836ad72b86/'}
2019-04-23:17:38:41,918 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:38:41,918 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/distributions/41c0af2e-12bf-4b5a-9a82-8e836ad72b86/', '_created': '2019-04-23T20:38:39.550982Z', 'name': 'f84fd9bd-cc68-47b9-9e91-1fa771b4d19e', 'publisher': None, 'publication': None, 'repository': None, 'content_guard': None, 'remote': None, 'base_path': '6aa640ab/342a/4701/ba17/2574a5130e50', 'base_url': 'fedora-29-pulp-3:24816/pulp/content/6aa640ab/342a/4701/ba17/2574a5130e50'}
2019-04-23:17:38:41,919 DEBUG    [api.py:638 - request] Making a POST request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/distributions/', 'json': {'base_path': '/e00d024d-6883-471d-b124-b3f844ee164d', 'name': 'd45931b0-f230-4d45-86f2-dc9b742e9d32'}}
2019-04-23:17:38:42,4 DEBUG    [api.py:638 - request] Making a PATCH request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/distributions/41c0af2e-12bf-4b5a-9a82-8e836ad72b86/', 'json': {'base_path': '/1cf83b88-afb3-4606-a93b-1ae5f2a8e39b'}}
ok
pulpcore/tests/functional/api/test_crud_distributions.py::DistributionBasePathTestCase::test_end_slash ...
2019-04-23:17:38:42,92 DEBUG    [api.py:638 - request] Making a POST request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/distributions/', 'json': {'base_path': '051f6396-37f5-412a-9f86-3eef5bb4f2b8/', 'name': 'a201f685-7657-406b-b99c-311570937d10'}}
2019-04-23:17:38:42,176 DEBUG    [api.py:638 - request] Making a PATCH request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/distributions/41c0af2e-12bf-4b5a-9a82-8e836ad72b86/', 'json': {'base_path': '82cd2bf8-e83f-4db6-a5d2-37bd70ca9b60/'}}
ok
pulpcore/tests/functional/api/test_crud_distributions.py::DistributionBasePathTestCase::test_overlapping_base_path ...
2019-04-23:17:38:42,278 DEBUG    [api.py:638 - request] Making a POST request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/distributions/', 'json': {'base_path': '6aa640ab/342a/4701/ba17', 'name': '9cbf0d47-9095-4c85-a877-451c6a326d63'}}
2019-04-23:17:38:42,377 DEBUG    [api.py:638 - request] Making a POST request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/distributions/', 'json': {'base_path': '6aa640ab/342a/4701/ba17/2574a5130e50/c853b811/e3e6/488d/bdf4/b5d8ed4ccf36', 'name': '45ca147e-62a2-40e0-ab8b-c5a2e231ebf2'}}
ok
pulpcore/tests/functional/api/test_crud_distributions.py::DistributionBasePathTestCase::test_spaces ...
2019-04-23:17:38:42,478 DEBUG    [api.py:638 - request] Making a POST request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/distributions/', 'json': {'base_path': '9d440fb9 1e37 4699 8460 50ecfaf73ce9', 'name': '1687cc0d-eb39-4cd7-9cca-b7ed36948e33'}}
2019-04-23:17:38:42,566 DEBUG    [api.py:638 - request] Making a PATCH request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/distributions/41c0af2e-12bf-4b5a-9a82-8e836ad72b86/', 'json': {'base_path': '2b4dc720 19d4 4fa4 a355 dc2cea6694d0'}}
ok
pulpcore/tests/functional/api/test_crud_distributions.py::DistributionBasePathTestCase::test_unique_base_path ...
2019-04-23:17:38:42,655 DEBUG    [api.py:638 - request] Making a POST request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/distributions/', 'json': {'base_path': '6aa640ab/342a/4701/ba17/2574a5130e50', 'name': '55fe2227-81d4-41ae-9e86-de9da077802e'}}
2019-04-23:17:38:42,741 DEBUG    [api.py:638 - request] Making a DELETE request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/distributions/41c0af2e-12bf-4b5a-9a82-8e836ad72b86/'}
2019-04-23:17:38:42,836 DEBUG    [api.py:168 - json_handler] reponse status: 202
2019-04-23:17:38:42,836 DEBUG    [api.py:530 - __init__] New <api.Client({'response_handler': <function json_handler at 0x7f06f6aa40d0>, 'host': PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}}), 'cfg': "PulpSmashConfig(pulp_auth=['admin', 'admin'], pulp_version='3.0', pulp_selinux_enabled=False, hosts=[PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}})])"})>
2019-04-23:17:38:42,836 DEBUG    [api.py:693 - poll_task] Polling task /pulp/api/v3/tasks/e3d13d07-5976-4720-8514-c0d44a37c807/ with poll_limit 900
2019-04-23:17:38:42,836 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/tasks/e3d13d07-5976-4720-8514-c0d44a37c807/'}
2019-04-23:17:38:43,91 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:38:43,91 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/tasks/e3d13d07-5976-4720-8514-c0d44a37c807/', '_created': '2019-04-23T20:38:42.831609Z', 'state': 'completed', 'name': 'pulpcore.app.tasks.distribution.delete', 'started_at': '2019-04-23T20:38:42.970225Z', 'finished_at': '2019-04-23T20:38:43.003789Z', 'non_fatal_errors': [], 'error': None, 'worker': '/pulp/api/v3/workers/c299fb4b-d79b-4740-9261-a6b3221f0f0e/', 'parent': None, 'spawned_tasks': [], 'progress_reports': [], 'created_resources': []}
2019-04-23:17:38:43,91 DEBUG    [api.py:102 - _handle_202] Task call report: {'task': '/pulp/api/v3/tasks/e3d13d07-5976-4720-8514-c0d44a37c807/'}
2019-04-23:17:38:43,91 DEBUG    [api.py:642 - request] Finished DELETE request with response: {'task': '/pulp/api/v3/tasks/e3d13d07-5976-4720-8514-c0d44a37c807/'}
ok

----------------------------------------------------------------------
Ran 15 tests in 14.05s

OK
```

</details>

<details>
<summary>Api test case </summary>

```logtalk
PULP_SMASH_LOG_LEVEL=DEBUG py.test -vs pulpcore/tests/functional/api/test_crud_repos.py >> /tmp/result.log 2>&1

----------------------------------------------------------------------
pulpcore/tests/functional/api/test_crud_repos.py::CRUDRepoTestCase::test_01_create_repo ...
2019-04-23:17:39:01,545 DEBUG    [api.py:530 - __init__] New <api.Client({'response_handler': <function json_handler at 0x7fcc163e6d08>, 'host': PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}}), 'cfg': "PulpSmashConfig(pulp_auth=['admin', 'admin'], pulp_version='3.0', pulp_selinux_enabled=False, hosts=[PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}})])"})>
2019-04-23:17:39:01,545 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/status/'}
2019-04-23:17:39:01,557 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:39:01,558 DEBUG    [api.py:642 - request] Finished GET request with response: {'versions': [{'component': 'pulpcore', 'version': '3.0.0rc1'}, {'component': 'pulpcore-plugin', 'version': '0.1.0rc1'}, {'component': 'pulp_rpm', 'version': '3.0.0b2'}, {'component': 'pulp_file', 'version': '0.0.1b10'}, {'component': 'pulp_docker', 'version': '4.0.0b3'}, {'component': 'pulp_certguard', 'version': '0.1.0rc1'}, {'component': 'pulp_ansible', 'version': '0.1.0rc4'}], 'online_workers': [{'_href': '/pulp/api/v3/workers/128d9703-128b-4ecd-925e-2ac50d3f15e1/', '_created': '2019-04-23T14:47:46.093730Z', 'name': 'reserved-resource-worker-1@fedora29base.virt.box', 'last_heartbeat': '2019-04-23T20:38:54.795461Z', 'online': True, 'missing': False}, {'_href': '/pulp/api/v3/workers/46e07617-e257-4374-8055-a0c9e05bb9a5/', '_created': '2019-04-23T14:47:48.919015Z', 'name': 'resource-manager@fedora29base.virt.box', 'last_heartbeat': '2019-04-23T20:38:58.011731Z', 'online': True, 'missing': False}, {'_href': '/pulp/api/v3/workers/c299fb4b-d79b-4740-9261-a6b3221f0f0e/', '_created': '2019-04-23T14:47:47.276629Z', 'name': 'reserved-resource-worker-2@fedora29base.virt.box', 'last_heartbeat': '2019-04-23T20:38:58.212000Z', 'online': True, 'missing': False}], 'missing_workers': [], 'database_connection': {'connected': True}, 'redis_connection': {'connected': True}}
2019-04-23:17:39:01,559 DEBUG    [api.py:530 - __init__] New <api.Client({'response_handler': <function json_handler at 0x7fcc163e6d08>, 'host': PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}}), 'cfg': "PulpSmashConfig(pulp_auth=['admin', 'admin'], pulp_version='3.0', pulp_selinux_enabled=False, hosts=[PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}})])"})>
2019-04-23:17:39:01,559 DEBUG    [api.py:638 - request] Making a POST request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/', 'json': {'name': '2a9a0ed7-d547-48a5-9b1a-bc1a81d34a25'}}
2019-04-23:17:39:01,647 DEBUG    [api.py:168 - json_handler] reponse status: 201
2019-04-23:17:39:01,647 DEBUG    [api.py:642 - request] Finished POST request with response: {'_href': '/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', '_created': '2019-04-23T20:39:01.648039Z', '_versions_href': '/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/versions/', '_latest_version_href': None, 'name': '2a9a0ed7-d547-48a5-9b1a-bc1a81d34a25', 'description': ''}
ok
pulpcore/tests/functional/api/test_crud_repos.py::CRUDRepoTestCase::test_02_create_same_name ...
2019-04-23:17:39:01,648 DEBUG    [api.py:530 - __init__] New <api.Client({'response_handler': <function json_handler at 0x7fcc163e6d08>, 'host': PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}}), 'cfg': "PulpSmashConfig(pulp_auth=['admin', 'admin'], pulp_version='3.0', pulp_selinux_enabled=False, hosts=[PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}})])"})>
2019-04-23:17:39:01,648 DEBUG    [api.py:638 - request] Making a POST request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/', 'json': {'name': '2a9a0ed7-d547-48a5-9b1a-bc1a81d34a25'}}
2019-04-23:17:39:01,727 DEBUG    [api.py:123 - echo_handler] response status: 400
2019-04-23:17:39:01,727 DEBUG    [api.py:642 - request] Finished POST request with response: <Response [400]>
ok
pulpcore/tests/functional/api/test_crud_repos.py::CRUDRepoTestCase::test_02_read_all_repos ...
2019-04-23:17:39:01,728 DEBUG    [api.py:530 - __init__] New <api.Client({'response_handler': <function json_handler at 0x7fcc163e6d08>, 'host': PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}}), 'cfg': "PulpSmashConfig(pulp_auth=['admin', 'admin'], pulp_version='3.0', pulp_selinux_enabled=False, hosts=[PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}})])"})>
2019-04-23:17:39:01,728 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/'}
2019-04-23:17:39:01,807 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:39:01,807 DEBUG    [api.py:642 - request] Finished GET request with response: {'count': 1, 'next': None, 'previous': None, 'results': [{'_href': '/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', '_created': '2019-04-23T20:39:01.648039Z', '_versions_href': '/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/versions/', '_latest_version_href': None, 'name': '2a9a0ed7-d547-48a5-9b1a-bc1a81d34a25', 'description': ''}]}
ok
pulpcore/tests/functional/api/test_crud_repos.py::CRUDRepoTestCase::test_02_read_repo ...
2019-04-23:17:39:01,808 DEBUG    [api.py:530 - __init__] New <api.Client({'response_handler': <function json_handler at 0x7fcc163e6d08>, 'host': PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}}), 'cfg': "PulpSmashConfig(pulp_auth=['admin', 'admin'], pulp_version='3.0', pulp_selinux_enabled=False, hosts=[PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}})])"})>
2019-04-23:17:39:01,808 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/'}
2019-04-23:17:39:01,886 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:39:01,886 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', '_created': '2019-04-23T20:39:01.648039Z', '_versions_href': '/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/versions/', '_latest_version_href': None, 'name': '2a9a0ed7-d547-48a5-9b1a-bc1a81d34a25', 'description': ''}
ok
pulpcore/tests/functional/api/test_crud_repos.py::CRUDRepoTestCase::test_02_read_repo_with_specific_fields ...
2019-04-23:17:39:01,887 DEBUG    [api.py:530 - __init__] New <api.Client({'response_handler': <function json_handler at 0x7fcc163e6d08>, 'host': PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}}), 'cfg': "PulpSmashConfig(pulp_auth=['admin', 'admin'], pulp_version='3.0', pulp_selinux_enabled=False, hosts=[PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}})])"})>
2019-04-23:17:39:01,887 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', 'params': {'fields': '_href,_created'}}
2019-04-23:17:39:01,964 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:39:01,964 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', '_created': '2019-04-23T20:39:01.648039Z'}
2019-04-23:17:39:01,964 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', 'params': {'fields': '_href,_versions_href'}}
2019-04-23:17:39:02,41 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:39:02,41 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', '_versions_href': '/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/versions/'}
2019-04-23:17:39:02,41 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', 'params': {'fields': '_href,_latest_version_href'}}
2019-04-23:17:39:02,138 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:39:02,138 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', '_latest_version_href': None}
2019-04-23:17:39:02,138 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', 'params': {'fields': '_href,name'}}
2019-04-23:17:39:02,236 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:39:02,236 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', 'name': '2a9a0ed7-d547-48a5-9b1a-bc1a81d34a25'}
2019-04-23:17:39:02,236 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', 'params': {'fields': '_href,description'}}
2019-04-23:17:39:02,333 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:39:02,334 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', 'description': ''}
2019-04-23:17:39:02,334 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', 'params': {'fields': '_created,_href'}}
2019-04-23:17:39:02,444 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:39:02,445 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', '_created': '2019-04-23T20:39:01.648039Z'}
2019-04-23:17:39:02,445 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', 'params': {'fields': '_created,_versions_href'}}
2019-04-23:17:39:02,554 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:39:02,554 DEBUG    [api.py:642 - request] Finished GET request with response: {'_created': '2019-04-23T20:39:01.648039Z', '_versions_href': '/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/versions/'}
2019-04-23:17:39:02,554 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', 'params': {'fields': '_created,_latest_version_href'}}
2019-04-23:17:39:02,655 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:39:02,655 DEBUG    [api.py:642 - request] Finished GET request with response: {'_created': '2019-04-23T20:39:01.648039Z', '_latest_version_href': None}
2019-04-23:17:39:02,655 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', 'params': {'fields': '_created,name'}}
2019-04-23:17:39:02,752 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:39:02,752 DEBUG    [api.py:642 - request] Finished GET request with response: {'_created': '2019-04-23T20:39:01.648039Z', 'name': '2a9a0ed7-d547-48a5-9b1a-bc1a81d34a25'}
2019-04-23:17:39:02,752 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', 'params': {'fields': '_created,description'}}
2019-04-23:17:39:02,835 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:39:02,836 DEBUG    [api.py:642 - request] Finished GET request with response: {'_created': '2019-04-23T20:39:01.648039Z', 'description': ''}
2019-04-23:17:39:02,836 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', 'params': {'fields': '_versions_href,_href'}}
2019-04-23:17:39:02,915 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:39:02,915 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', '_versions_href': '/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/versions/'}
2019-04-23:17:39:02,915 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', 'params': {'fields': '_versions_href,_created'}}
2019-04-23:17:39:02,993 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:39:02,993 DEBUG    [api.py:642 - request] Finished GET request with response: {'_created': '2019-04-23T20:39:01.648039Z', '_versions_href': '/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/versions/'}
2019-04-23:17:39:02,993 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', 'params': {'fields': '_versions_href,_latest_version_href'}}
2019-04-23:17:39:03,71 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:39:03,71 DEBUG    [api.py:642 - request] Finished GET request with response: {'_versions_href': '/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/versions/', '_latest_version_href': None}
2019-04-23:17:39:03,71 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', 'params': {'fields': '_versions_href,name'}}
2019-04-23:17:39:03,147 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:39:03,147 DEBUG    [api.py:642 - request] Finished GET request with response: {'_versions_href': '/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/versions/', 'name': '2a9a0ed7-d547-48a5-9b1a-bc1a81d34a25'}
2019-04-23:17:39:03,147 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', 'params': {'fields': '_versions_href,description'}}
2019-04-23:17:39:03,223 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:39:03,224 DEBUG    [api.py:642 - request] Finished GET request with response: {'_versions_href': '/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/versions/', 'description': ''}
2019-04-23:17:39:03,224 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', 'params': {'fields': '_latest_version_href,_href'}}
2019-04-23:17:39:03,302 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:39:03,302 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', '_latest_version_href': None}
2019-04-23:17:39:03,302 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', 'params': {'fields': '_latest_version_href,_created'}}
2019-04-23:17:39:03,380 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:39:03,380 DEBUG    [api.py:642 - request] Finished GET request with response: {'_created': '2019-04-23T20:39:01.648039Z', '_latest_version_href': None}
2019-04-23:17:39:03,380 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', 'params': {'fields': '_latest_version_href,_versions_href'}}
2019-04-23:17:39:03,457 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:39:03,457 DEBUG    [api.py:642 - request] Finished GET request with response: {'_versions_href': '/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/versions/', '_latest_version_href': None}
2019-04-23:17:39:03,457 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', 'params': {'fields': '_latest_version_href,name'}}
2019-04-23:17:39:03,534 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:39:03,534 DEBUG    [api.py:642 - request] Finished GET request with response: {'_latest_version_href': None, 'name': '2a9a0ed7-d547-48a5-9b1a-bc1a81d34a25'}
2019-04-23:17:39:03,534 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', 'params': {'fields': '_latest_version_href,description'}}
2019-04-23:17:39:03,611 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:39:03,611 DEBUG    [api.py:642 - request] Finished GET request with response: {'_latest_version_href': None, 'description': ''}
2019-04-23:17:39:03,611 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', 'params': {'fields': 'name,_href'}}
2019-04-23:17:39:03,687 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:39:03,687 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', 'name': '2a9a0ed7-d547-48a5-9b1a-bc1a81d34a25'}
2019-04-23:17:39:03,687 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', 'params': {'fields': 'name,_created'}}
2019-04-23:17:39:03,763 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:39:03,763 DEBUG    [api.py:642 - request] Finished GET request with response: {'_created': '2019-04-23T20:39:01.648039Z', 'name': '2a9a0ed7-d547-48a5-9b1a-bc1a81d34a25'}
2019-04-23:17:39:03,764 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', 'params': {'fields': 'name,_versions_href'}}
2019-04-23:17:39:03,839 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:39:03,839 DEBUG    [api.py:642 - request] Finished GET request with response: {'_versions_href': '/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/versions/', 'name': '2a9a0ed7-d547-48a5-9b1a-bc1a81d34a25'}
2019-04-23:17:39:03,839 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', 'params': {'fields': 'name,_latest_version_href'}}
2019-04-23:17:39:03,916 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:39:03,916 DEBUG    [api.py:642 - request] Finished GET request with response: {'_latest_version_href': None, 'name': '2a9a0ed7-d547-48a5-9b1a-bc1a81d34a25'}
2019-04-23:17:39:03,916 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', 'params': {'fields': 'name,description'}}
2019-04-23:17:39:03,992 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:39:03,993 DEBUG    [api.py:642 - request] Finished GET request with response: {'name': '2a9a0ed7-d547-48a5-9b1a-bc1a81d34a25', 'description': ''}
2019-04-23:17:39:03,993 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', 'params': {'fields': 'description,_href'}}
2019-04-23:17:39:04,80 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:39:04,80 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', 'description': ''}
2019-04-23:17:39:04,80 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', 'params': {'fields': 'description,_created'}}
2019-04-23:17:39:04,156 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:39:04,156 DEBUG    [api.py:642 - request] Finished GET request with response: {'_created': '2019-04-23T20:39:01.648039Z', 'description': ''}
2019-04-23:17:39:04,156 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', 'params': {'fields': 'description,_versions_href'}}
2019-04-23:17:39:04,232 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:39:04,232 DEBUG    [api.py:642 - request] Finished GET request with response: {'_versions_href': '/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/versions/', 'description': ''}
2019-04-23:17:39:04,232 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', 'params': {'fields': 'description,_latest_version_href'}}
2019-04-23:17:39:04,308 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:39:04,309 DEBUG    [api.py:642 - request] Finished GET request with response: {'_latest_version_href': None, 'description': ''}
2019-04-23:17:39:04,309 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', 'params': {'fields': 'description,name'}}
2019-04-23:17:39:04,384 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:39:04,384 DEBUG    [api.py:642 - request] Finished GET request with response: {'name': '2a9a0ed7-d547-48a5-9b1a-bc1a81d34a25', 'description': ''}
ok
pulpcore/tests/functional/api/test_crud_repos.py::CRUDRepoTestCase::test_02_read_repo_without_specific_fields ...
2019-04-23:17:39:04,385 DEBUG    [api.py:530 - __init__] New <api.Client({'response_handler': <function json_handler at 0x7fcc163e6d08>, 'host': PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}}), 'cfg': "PulpSmashConfig(pulp_auth=['admin', 'admin'], pulp_version='3.0', pulp_selinux_enabled=False, hosts=[PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}})])"})>
2019-04-23:17:39:04,386 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/?fields!=created,name'}
2019-04-23:17:39:04,462 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:39:04,462 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', '_created': '2019-04-23T20:39:01.648039Z', '_versions_href': '/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/versions/', '_latest_version_href': None, 'description': ''}
ok
pulpcore/tests/functional/api/test_crud_repos.py::CRUDRepoTestCase::test_02_read_repos ...
2019-04-23:17:39:04,463 DEBUG    [api.py:530 - __init__] New <api.Client({'response_handler': <function json_handler at 0x7fcc163e6d08>, 'host': PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}}), 'cfg': "PulpSmashConfig(pulp_auth=['admin', 'admin'], pulp_version='3.0', pulp_selinux_enabled=False, hosts=[PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}})])"})>
2019-04-23:17:39:04,463 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/', 'params': {'name': '2a9a0ed7-d547-48a5-9b1a-bc1a81d34a25'}}
2019-04-23:17:39:04,540 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:39:04,541 DEBUG    [api.py:642 - request] Finished GET request with response: {'count': 1, 'next': None, 'previous': None, 'results': [{'_href': '/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', '_created': '2019-04-23T20:39:01.648039Z', '_versions_href': '/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/versions/', '_latest_version_href': None, 'name': '2a9a0ed7-d547-48a5-9b1a-bc1a81d34a25', 'description': ''}]}
ok
pulpcore/tests/functional/api/test_crud_repos.py::CRUDRepoTestCase::test_03_fully_update_desc ...
2019-04-23:17:39:04,542 DEBUG    [api.py:530 - __init__] New <api.Client({'response_handler': <function json_handler at 0x7fcc163e6d08>, 'host': PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}}), 'cfg': "PulpSmashConfig(pulp_auth=['admin', 'admin'], pulp_version='3.0', pulp_selinux_enabled=False, hosts=[PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}})])"})>
2019-04-23:17:39:04,542 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/'}
2019-04-23:17:39:04,619 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:39:04,619 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', '_created': '2019-04-23T20:39:01.648039Z', '_versions_href': '/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/versions/', '_latest_version_href': None, 'name': '2a9a0ed7-d547-48a5-9b1a-bc1a81d34a25', 'description': ''}
2019-04-23:17:39:04,619 DEBUG    [api.py:638 - request] Making a PUT request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', 'json': {'_href': '/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', '_created': '2019-04-23T20:39:01.648039Z', '_versions_href': '/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/versions/', '_latest_version_href': None, 'name': '2a9a0ed7-d547-48a5-9b1a-bc1a81d34a25', 'description': 'fd296e35-61ed-4486-91fd-d6ddacfc4042'}}
2019-04-23:17:39:04,707 DEBUG    [api.py:168 - json_handler] reponse status: 202
2019-04-23:17:39:04,707 DEBUG    [api.py:530 - __init__] New <api.Client({'response_handler': <function json_handler at 0x7fcc163e6d08>, 'host': PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}}), 'cfg': "PulpSmashConfig(pulp_auth=['admin', 'admin'], pulp_version='3.0', pulp_selinux_enabled=False, hosts=[PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}})])"})>
2019-04-23:17:39:04,708 DEBUG    [api.py:693 - poll_task] Polling task /pulp/api/v3/tasks/8125a28f-3180-475e-9d64-1eac4c564b50/ with poll_limit 900
2019-04-23:17:39:04,708 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/tasks/8125a28f-3180-475e-9d64-1eac4c564b50/'}
2019-04-23:17:39:04,934 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:39:04,934 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/tasks/8125a28f-3180-475e-9d64-1eac4c564b50/', '_created': '2019-04-23T20:39:04.703234Z', 'state': 'completed', 'name': 'pulpcore.app.tasks.repository.update', 'started_at': '2019-04-23T20:39:04.800220Z', 'finished_at': '2019-04-23T20:39:04.830936Z', 'non_fatal_errors': [], 'error': None, 'worker': '/pulp/api/v3/workers/128d9703-128b-4ecd-925e-2ac50d3f15e1/', 'parent': None, 'spawned_tasks': [], 'progress_reports': [], 'created_resources': []}
2019-04-23:17:39:04,934 DEBUG    [api.py:102 - _handle_202] Task call report: {'task': '/pulp/api/v3/tasks/8125a28f-3180-475e-9d64-1eac4c564b50/'}
2019-04-23:17:39:04,934 DEBUG    [api.py:642 - request] Finished PUT request with response: {'task': '/pulp/api/v3/tasks/8125a28f-3180-475e-9d64-1eac4c564b50/'}
2019-04-23:17:39:04,934 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/'}
2019-04-23:17:39:05,13 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:39:05,13 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', '_created': '2019-04-23T20:39:01.648039Z', '_versions_href': '/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/versions/', '_latest_version_href': None, 'name': '2a9a0ed7-d547-48a5-9b1a-bc1a81d34a25', 'description': 'fd296e35-61ed-4486-91fd-d6ddacfc4042'}
ok
pulpcore/tests/functional/api/test_crud_repos.py::CRUDRepoTestCase::test_03_fully_update_name ...
2019-04-23:17:39:05,14 DEBUG    [api.py:530 - __init__] New <api.Client({'response_handler': <function json_handler at 0x7fcc163e6d08>, 'host': PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}}), 'cfg': "PulpSmashConfig(pulp_auth=['admin', 'admin'], pulp_version='3.0', pulp_selinux_enabled=False, hosts=[PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}})])"})>
2019-04-23:17:39:05,14 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/'}
2019-04-23:17:39:05,92 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:39:05,92 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', '_created': '2019-04-23T20:39:01.648039Z', '_versions_href': '/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/versions/', '_latest_version_href': None, 'name': '2a9a0ed7-d547-48a5-9b1a-bc1a81d34a25', 'description': 'fd296e35-61ed-4486-91fd-d6ddacfc4042'}
2019-04-23:17:39:05,92 DEBUG    [api.py:638 - request] Making a PUT request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', 'json': {'_href': '/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', '_created': '2019-04-23T20:39:01.648039Z', '_versions_href': '/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/versions/', '_latest_version_href': None, 'name': 'd1d75634-0413-4a0c-971d-a1ac9def39e0', 'description': 'fd296e35-61ed-4486-91fd-d6ddacfc4042'}}
2019-04-23:17:39:05,176 DEBUG    [api.py:168 - json_handler] reponse status: 202
2019-04-23:17:39:05,176 DEBUG    [api.py:530 - __init__] New <api.Client({'response_handler': <function json_handler at 0x7fcc163e6d08>, 'host': PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}}), 'cfg': "PulpSmashConfig(pulp_auth=['admin', 'admin'], pulp_version='3.0', pulp_selinux_enabled=False, hosts=[PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}})])"})>
2019-04-23:17:39:05,176 DEBUG    [api.py:693 - poll_task] Polling task /pulp/api/v3/tasks/a60a157d-675e-4995-9bcf-85b8668198b4/ with poll_limit 900
2019-04-23:17:39:05,176 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/tasks/a60a157d-675e-4995-9bcf-85b8668198b4/'}
2019-04-23:17:39:05,399 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:39:05,399 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/tasks/a60a157d-675e-4995-9bcf-85b8668198b4/', '_created': '2019-04-23T20:39:05.176879Z', 'state': 'completed', 'name': 'pulpcore.app.tasks.repository.update', 'started_at': '2019-04-23T20:39:05.266102Z', 'finished_at': '2019-04-23T20:39:05.298383Z', 'non_fatal_errors': [], 'error': None, 'worker': '/pulp/api/v3/workers/128d9703-128b-4ecd-925e-2ac50d3f15e1/', 'parent': None, 'spawned_tasks': [], 'progress_reports': [], 'created_resources': []}
2019-04-23:17:39:05,399 DEBUG    [api.py:102 - _handle_202] Task call report: {'task': '/pulp/api/v3/tasks/a60a157d-675e-4995-9bcf-85b8668198b4/'}
2019-04-23:17:39:05,399 DEBUG    [api.py:642 - request] Finished PUT request with response: {'task': '/pulp/api/v3/tasks/a60a157d-675e-4995-9bcf-85b8668198b4/'}
2019-04-23:17:39:05,399 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/'}
2019-04-23:17:39:05,478 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:39:05,478 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', '_created': '2019-04-23T20:39:01.648039Z', '_versions_href': '/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/versions/', '_latest_version_href': None, 'name': 'd1d75634-0413-4a0c-971d-a1ac9def39e0', 'description': 'fd296e35-61ed-4486-91fd-d6ddacfc4042'}
ok
pulpcore/tests/functional/api/test_crud_repos.py::CRUDRepoTestCase::test_03_partially_update_desc ...
2019-04-23:17:39:05,479 DEBUG    [api.py:530 - __init__] New <api.Client({'response_handler': <function json_handler at 0x7fcc163e6d08>, 'host': PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}}), 'cfg': "PulpSmashConfig(pulp_auth=['admin', 'admin'], pulp_version='3.0', pulp_selinux_enabled=False, hosts=[PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}})])"})>
2019-04-23:17:39:05,479 DEBUG    [api.py:638 - request] Making a PATCH request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', 'json': {'description': '997c1eba-32dc-4696-87f3-a453fd6d8c03'}}
2019-04-23:17:39:05,563 DEBUG    [api.py:168 - json_handler] reponse status: 202
2019-04-23:17:39:05,563 DEBUG    [api.py:530 - __init__] New <api.Client({'response_handler': <function json_handler at 0x7fcc163e6d08>, 'host': PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}}), 'cfg': "PulpSmashConfig(pulp_auth=['admin', 'admin'], pulp_version='3.0', pulp_selinux_enabled=False, hosts=[PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}})])"})>
2019-04-23:17:39:05,563 DEBUG    [api.py:693 - poll_task] Polling task /pulp/api/v3/tasks/43def8b9-3957-43cd-8cf4-68e77943c6ee/ with poll_limit 900
2019-04-23:17:39:05,563 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/tasks/43def8b9-3957-43cd-8cf4-68e77943c6ee/'}
2019-04-23:17:39:05,787 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:39:05,787 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/tasks/43def8b9-3957-43cd-8cf4-68e77943c6ee/', '_created': '2019-04-23T20:39:05.562476Z', 'state': 'completed', 'name': 'pulpcore.app.tasks.repository.update', 'started_at': '2019-04-23T20:39:05.654114Z', 'finished_at': '2019-04-23T20:39:05.687468Z', 'non_fatal_errors': [], 'error': None, 'worker': '/pulp/api/v3/workers/128d9703-128b-4ecd-925e-2ac50d3f15e1/', 'parent': None, 'spawned_tasks': [], 'progress_reports': [], 'created_resources': []}
2019-04-23:17:39:05,787 DEBUG    [api.py:102 - _handle_202] Task call report: {'task': '/pulp/api/v3/tasks/43def8b9-3957-43cd-8cf4-68e77943c6ee/'}
2019-04-23:17:39:05,787 DEBUG    [api.py:642 - request] Finished PATCH request with response: {'task': '/pulp/api/v3/tasks/43def8b9-3957-43cd-8cf4-68e77943c6ee/'}
2019-04-23:17:39:05,788 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/'}
2019-04-23:17:39:05,868 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:39:05,868 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', '_created': '2019-04-23T20:39:01.648039Z', '_versions_href': '/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/versions/', '_latest_version_href': None, 'name': 'd1d75634-0413-4a0c-971d-a1ac9def39e0', 'description': '997c1eba-32dc-4696-87f3-a453fd6d8c03'}
ok
pulpcore/tests/functional/api/test_crud_repos.py::CRUDRepoTestCase::test_03_partially_update_name ...
2019-04-23:17:39:05,870 DEBUG    [api.py:530 - __init__] New <api.Client({'response_handler': <function json_handler at 0x7fcc163e6d08>, 'host': PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}}), 'cfg': "PulpSmashConfig(pulp_auth=['admin', 'admin'], pulp_version='3.0', pulp_selinux_enabled=False, hosts=[PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}})])"})>
2019-04-23:17:39:05,871 DEBUG    [api.py:638 - request] Making a PATCH request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', 'json': {'name': '601ffc48-c52f-46c8-ac07-3c0f8761d84f'}}
2019-04-23:17:39:05,964 DEBUG    [api.py:168 - json_handler] reponse status: 202
2019-04-23:17:39:05,964 DEBUG    [api.py:530 - __init__] New <api.Client({'response_handler': <function json_handler at 0x7fcc163e6d08>, 'host': PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}}), 'cfg': "PulpSmashConfig(pulp_auth=['admin', 'admin'], pulp_version='3.0', pulp_selinux_enabled=False, hosts=[PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}})])"})>
2019-04-23:17:39:05,964 DEBUG    [api.py:693 - poll_task] Polling task /pulp/api/v3/tasks/66578e1e-fb74-4fb1-a5e5-824962fd8c87/ with poll_limit 900
2019-04-23:17:39:05,965 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/tasks/66578e1e-fb74-4fb1-a5e5-824962fd8c87/'}
2019-04-23:17:39:06,193 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:39:06,193 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/tasks/66578e1e-fb74-4fb1-a5e5-824962fd8c87/', '_created': '2019-04-23T20:39:05.965309Z', 'state': 'completed', 'name': 'pulpcore.app.tasks.repository.update', 'started_at': '2019-04-23T20:39:06.057241Z', 'finished_at': '2019-04-23T20:39:06.090330Z', 'non_fatal_errors': [], 'error': None, 'worker': '/pulp/api/v3/workers/c299fb4b-d79b-4740-9261-a6b3221f0f0e/', 'parent': None, 'spawned_tasks': [], 'progress_reports': [], 'created_resources': []}
2019-04-23:17:39:06,193 DEBUG    [api.py:102 - _handle_202] Task call report: {'task': '/pulp/api/v3/tasks/66578e1e-fb74-4fb1-a5e5-824962fd8c87/'}
2019-04-23:17:39:06,193 DEBUG    [api.py:642 - request] Finished PATCH request with response: {'task': '/pulp/api/v3/tasks/66578e1e-fb74-4fb1-a5e5-824962fd8c87/'}
2019-04-23:17:39:06,193 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/'}
2019-04-23:17:39:06,273 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:39:06,273 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/', '_created': '2019-04-23T20:39:01.648039Z', '_versions_href': '/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/versions/', '_latest_version_href': None, 'name': '601ffc48-c52f-46c8-ac07-3c0f8761d84f', 'description': '997c1eba-32dc-4696-87f3-a453fd6d8c03'}
ok
pulpcore/tests/functional/api/test_crud_repos.py::CRUDRepoTestCase::test_04_delete_repo ...
2019-04-23:17:39:06,274 DEBUG    [api.py:530 - __init__] New <api.Client({'response_handler': <function json_handler at 0x7fcc163e6d08>, 'host': PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}}), 'cfg': "PulpSmashConfig(pulp_auth=['admin', 'admin'], pulp_version='3.0', pulp_selinux_enabled=False, hosts=[PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}})])"})>
2019-04-23:17:39:06,274 DEBUG    [api.py:638 - request] Making a DELETE request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/'}
2019-04-23:17:39:06,355 DEBUG    [api.py:168 - json_handler] reponse status: 202
2019-04-23:17:39:06,355 DEBUG    [api.py:530 - __init__] New <api.Client({'response_handler': <function json_handler at 0x7fcc163e6d08>, 'host': PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}}), 'cfg': "PulpSmashConfig(pulp_auth=['admin', 'admin'], pulp_version='3.0', pulp_selinux_enabled=False, hosts=[PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}})])"})>
2019-04-23:17:39:06,355 DEBUG    [api.py:693 - poll_task] Polling task /pulp/api/v3/tasks/125160df-ac49-488c-8f13-d0f08f81aa23/ with poll_limit 900
2019-04-23:17:39:06,355 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/tasks/125160df-ac49-488c-8f13-d0f08f81aa23/'}
2019-04-23:17:39:06,600 DEBUG    [api.py:168 - json_handler] reponse status: 200
2019-04-23:17:39:06,600 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/tasks/125160df-ac49-488c-8f13-d0f08f81aa23/', '_created': '2019-04-23T20:39:06.356976Z', 'state': 'completed', 'name': 'pulpcore.app.tasks.repository.delete', 'started_at': '2019-04-23T20:39:06.450154Z', 'finished_at': '2019-04-23T20:39:06.487485Z', 'non_fatal_errors': [], 'error': None, 'worker': '/pulp/api/v3/workers/128d9703-128b-4ecd-925e-2ac50d3f15e1/', 'parent': None, 'spawned_tasks': [], 'progress_reports': [], 'created_resources': []}
2019-04-23:17:39:06,600 DEBUG    [api.py:102 - _handle_202] Task call report: {'task': '/pulp/api/v3/tasks/125160df-ac49-488c-8f13-d0f08f81aa23/'}
2019-04-23:17:39:06,600 DEBUG    [api.py:642 - request] Finished DELETE request with response: {'task': '/pulp/api/v3/tasks/125160df-ac49-488c-8f13-d0f08f81aa23/'}
2019-04-23:17:39:06,600 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/9f5f34ac-3917-4ead-8b37-ea7a487acb08/'}
ok
pulpcore/tests/functional/api/test_crud_repos.py::CRUDRepoTestCase::test_negative_create_repo_with_invalid_parameter ...
2019-04-23:17:39:06,707 DEBUG    [api.py:530 - __init__] New <api.Client({'response_handler': <function json_handler at 0x7fcc163e6d08>, 'host': PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}}), 'cfg': "PulpSmashConfig(pulp_auth=['admin', 'admin'], pulp_version='3.0', pulp_selinux_enabled=False, hosts=[PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}})])"})>
2019-04-23:17:39:06,707 DEBUG    [api.py:530 - __init__] New <api.Client({'response_handler': <function echo_handler at 0x7fcc163e6b70>, 'host': PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}}), 'cfg': "PulpSmashConfig(pulp_auth=['admin', 'admin'], pulp_version='3.0', pulp_selinux_enabled=False, hosts=[PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}})])"})>
2019-04-23:17:39:06,707 DEBUG    [api.py:638 - request] Making a POST request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/repositories/', 'json': {'name': '97de6340-5e89-4c6f-bb62-0e57ab1a6e88', 'foo': 'bar'}}
2019-04-23:17:39:06,784 DEBUG    [api.py:123 - echo_handler] response status: 400
2019-04-23:17:39:06,784 DEBUG    [api.py:642 - request] Finished POST request with response: <Response [400]>
ok

----------------------------------------------------------------------
Ran 13 tests in 5.38s

OK
```

</details>


<details>
<summary>CLI test case </summary>

```logtalk
PULP_SMASH_LOG_LEVEL=DEBUG py.test -vs pulpcore/tests/functional/api/test_workers.py -k OfflineWorkerTestCase >> /tmp/result.log 2>&1

----------------------------------------------------------------------
pulpcore/tests/functional/api/test_workers.py::OfflineWorkerTestCase::test_01_start_new_worker ... 
2019-04-23:18:17:58,565 DEBUG    [api.py:530 - __init__] New <api.Client({'response_handler': <function json_handler at 0x7f0da1327400>, 'host': PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}}), 'cfg': "PulpSmashConfig(pulp_auth=['admin', 'admin'], pulp_version='3.0', pulp_selinux_enabled=False, hosts=[PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}})])"})>
2019-04-23:18:17:58,566 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/status/'}
2019-04-23:18:17:58,579 DEBUG    [api.py:168 - json_handler] response status: 200
2019-04-23:18:17:58,580 DEBUG    [api.py:642 - request] Finished GET request with response: {'versions': [{'component': 'pulpcore', 'version': '3.0.0rc1'}, {'component': 'pulpcore-plugin', 'version': '0.1.0rc1'}, {'component': 'pulp_rpm', 'version': '3.0.0b2'}, {'component': 'pulp_file', 'version': '0.0.1b10'}, {'component': 'pulp_docker', 'version': '4.0.0b3'}, {'component': 'pulp_certguard', 'version': '0.1.0rc1'}, {'component': 'pulp_ansible', 'version': '0.1.0rc4'}], 'online_workers': [{'_href': '/pulp/api/v3/workers/c299fb4b-d79b-4740-9261-a6b3221f0f0e/', '_created': '2019-04-23T14:47:47.276629Z', 'name': 'reserved-resource-worker-2@fedora29base.virt.box', 'last_heartbeat': '2019-04-23T21:17:47.665098Z', 'online': True, 'missing': False}, {'_href': '/pulp/api/v3/workers/46e07617-e257-4374-8055-a0c9e05bb9a5/', '_created': '2019-04-23T14:47:48.919015Z', 'name': 'resource-manager@fedora29base.virt.box', 'last_heartbeat': '2019-04-23T21:17:47.864911Z', 'online': True, 'missing': False}, {'_href': '/pulp/api/v3/workers/128d9703-128b-4ecd-925e-2ac50d3f15e1/', '_created': '2019-04-23T14:47:46.093730Z', 'name': 'reserved-resource-worker-1@fedora29base.virt.box', 'last_heartbeat': '2019-04-23T21:17:48.063013Z', 'online': True, 'missing': False}], 'missing_workers': [], 'database_connection': {'connected': True}, 'redis_connection': {'connected': True}}
2019-04-23:18:17:58,580 DEBUG    [api.py:530 - __init__] New <api.Client({'response_handler': <function json_handler at 0x7f0da1327400>, 'host': PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}}), 'cfg': "PulpSmashConfig(pulp_auth=['admin', 'admin'], pulp_version='3.0', pulp_selinux_enabled=False, hosts=[PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}})])"})>
2019-04-23:18:17:58,580 DEBUG    [cli.py:206 - __init__] New <cli.Client({'response_handler': <function code_handler at 0x7f0da12f11e0>, 'host': PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}}), 'cfg': "PulpSmashConfig(pulp_auth=['admin', 'admin'], pulp_version='3.0', pulp_selinux_enabled=False, hosts=[PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}})])"})>
2019-04-23:18:17:58,581 DEBUG    [cli.py:206 - __init__] New <cli.Client({'response_handler': <function echo_handler at 0x7f0da129e378>, 'host': PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}}), 'cfg': "PulpSmashConfig(pulp_auth=['admin', 'admin'], pulp_version='3.0', pulp_selinux_enabled=False, hosts=[PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}})])"})>
2019-04-23:18:17:58,581 DEBUG    [cli.py:270 - run] Running ['which', 'systemctl'] cmd (sudo:False) - {'retcode': None}
2019-04-23:18:18:04,476 DEBUG    [cli.py:232 - machine] Initialized plumbum machine ssh://fedora-29-pulp-3
2019-04-23:18:18:04,506 DEBUG    [cli.py:277 - run] Finished ['which', 'systemctl'] command: (0, '/usr/bin/systemctl\n', '')
2019-04-23:18:18:04,506 DEBUG    [cli.py:46 - echo_handler] Process return code: 0
2019-04-23:18:18:04,506 DEBUG    [cli.py:270 - run] Running ('systemctl', 'is-active', 'pulp-worker@*') cmd (sudo:True) - {'retcode': None}
2019-04-23:18:18:04,507 DEBUG    [cli.py:206 - __init__] New <cli.Client({'response_handler': <function code_handler at 0x7f0da12f11e0>, 'host': PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}}), 'cfg': "PulpSmashConfig(pulp_auth=['admin', 'admin'], pulp_version='3.0', pulp_selinux_enabled=False, hosts=[PulpHost(hostname='fedora-29-pulp-3', roles={'api': {'port': 80, 'scheme': 'http', 'service': 'nginx', 'verify': False}, 'content': {'port': 8080, 'scheme': 'http', 'service': 'pulp_content_app', 'verify': False}, 'pulp resource manager': {}, 'pulp workers': {}, 'redis': {}, 'shell': {}})])"})>
2019-04-23:18:18:04,507 DEBUG    [cli.py:270 - run] Running ('id', '-u') cmd (sudo:False) - {'retcode': None}
2019-04-23:18:18:05,157 DEBUG    [cli.py:232 - machine] Initialized plumbum machine ssh://fedora-29-pulp-3
2019-04-23:18:18:05,184 DEBUG    [cli.py:277 - run] Finished ('id', '-u') command: (0, '0\n', '')
2019-04-23:18:18:05,184 DEBUG    [cli.py:57 - code_handler] Process return code: 0
2019-04-23:18:18:05,184 DEBUG    [cli.py:247 - is_superuser] Is Superuser: True
2019-04-23:18:18:05,864 DEBUG    [cli.py:232 - machine] Initialized plumbum machine ssh://fedora-29-pulp-3
2019-04-23:18:18:05,897 DEBUG    [cli.py:277 - run] Finished ('systemctl', 'is-active', 'pulp-worker@*') command: (0, 'active\nactive\n', '')
2019-04-23:18:18:05,898 DEBUG    [cli.py:57 - code_handler] Process return code: 0
2019-04-23:18:18:05,899 DEBUG    [cli.py:270 - run] Running ('systemctl', 'start', 'pulp-worker@99') cmd (sudo:True) - {'retcode': None}
2019-04-23:18:18:05,899 DEBUG    [cli.py:247 - is_superuser] Is Superuser: True
2019-04-23:18:18:05,935 DEBUG    [cli.py:277 - run] Finished ('systemctl', 'start', 'pulp-worker@99') command: (0, '', '')
2019-04-23:18:18:05,936 DEBUG    [cli.py:57 - code_handler] Process return code: 0
2019-04-23:18:18:07,939 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/workers/', 'params': {'online': True}}
2019-04-23:18:18:08,71 DEBUG    [api.py:168 - json_handler] response status: 200
2019-04-23:18:18:08,71 DEBUG    [api.py:642 - request] Finished GET request with response: {'count': 4, 'next': None, 'previous': None, 'results': [{'_href': '/pulp/api/v3/workers/c299fb4b-d79b-4740-9261-a6b3221f0f0e/', '_created': '2019-04-23T14:47:47.276629Z', 'name': 'reserved-resource-worker-2@fedora29base.virt.box', 'last_heartbeat': '2019-04-23T21:18:02.736177Z', 'online': True, 'missing': False}, {'_href': '/pulp/api/v3/workers/46e07617-e257-4374-8055-a0c9e05bb9a5/', '_created': '2019-04-23T14:47:48.919015Z', 'name': 'resource-manager@fedora29base.virt.box', 'last_heartbeat': '2019-04-23T21:18:02.937453Z', 'online': True, 'missing': False}, {'_href': '/pulp/api/v3/workers/128d9703-128b-4ecd-925e-2ac50d3f15e1/', '_created': '2019-04-23T14:47:46.093730Z', 'name': 'reserved-resource-worker-1@fedora29base.virt.box', 'last_heartbeat': '2019-04-23T21:18:03.139386Z', 'online': True, 'missing': False}, {'_href': '/pulp/api/v3/workers/065406d9-c86a-4736-9a1f-0510accee764/', '_created': '2019-04-23T19:57:09.591180Z', 'name': 'reserved-resource-worker-99@fedora29base.virt.box', 'last_heartbeat': '2019-04-23T21:18:06.942486Z', 'online': True, 'missing': False}]}
ok
pulpcore/tests/functional/api/test_workers.py::OfflineWorkerTestCase::test_02_stop_worker ... 
2019-04-23:18:18:08,73 DEBUG    [cli.py:270 - run] Running ('systemctl', 'stop', 'pulp-worker@99') cmd (sudo:True) - {'retcode': None}
2019-04-23:18:18:08,73 DEBUG    [cli.py:247 - is_superuser] Is Superuser: True
2019-04-23:18:18:08,253 DEBUG    [cli.py:277 - run] Finished ('systemctl', 'stop', 'pulp-worker@99') command: (0, '', '')
2019-04-23:18:18:08,253 DEBUG    [cli.py:57 - code_handler] Process return code: 0
2019-04-23:18:18:10,256 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/workers/065406d9-c86a-4736-9a1f-0510accee764/'}
2019-04-23:18:18:10,391 DEBUG    [api.py:168 - json_handler] response status: 200
2019-04-23:18:18:10,391 DEBUG    [api.py:642 - request] Finished GET request with response: {'_href': '/pulp/api/v3/workers/065406d9-c86a-4736-9a1f-0510accee764/', '_created': '2019-04-23T19:57:09.591180Z', 'name': 'reserved-resource-worker-99@fedora29base.virt.box', 'last_heartbeat': '2019-04-23T21:18:08.115631Z', 'online': False, 'missing': False}
ok
pulpcore/tests/functional/api/test_workers.py::OfflineWorkerTestCase::test_03_filter_offline_worker ... 
2019-04-23:18:18:10,392 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/workers/', 'params': {'online': False}}
2019-04-23:18:18:10,479 DEBUG    [api.py:168 - json_handler] response status: 200
2019-04-23:18:18:10,479 DEBUG    [api.py:642 - request] Finished GET request with response: {'count': 1, 'next': None, 'previous': None, 'results': [{'_href': '/pulp/api/v3/workers/065406d9-c86a-4736-9a1f-0510accee764/', '_created': '2019-04-23T19:57:09.591180Z', 'name': 'reserved-resource-worker-99@fedora29base.virt.box', 'last_heartbeat': '2019-04-23T21:18:08.115631Z', 'online': False, 'missing': False}]}
ok
pulpcore/tests/functional/api/test_workers.py::OfflineWorkerTestCase::test_03_read_all_workers ... 
2019-04-23:18:18:10,480 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/workers/'}
2019-04-23:18:18:10,571 DEBUG    [api.py:168 - json_handler] response status: 200
2019-04-23:18:18:10,571 DEBUG    [api.py:642 - request] Finished GET request with response: {'count': 4, 'next': None, 'previous': None, 'results': [{'_href': '/pulp/api/v3/workers/c299fb4b-d79b-4740-9261-a6b3221f0f0e/', '_created': '2019-04-23T14:47:47.276629Z', 'name': 'reserved-resource-worker-2@fedora29base.virt.box', 'last_heartbeat': '2019-04-23T21:18:02.736177Z', 'online': True, 'missing': False}, {'_href': '/pulp/api/v3/workers/46e07617-e257-4374-8055-a0c9e05bb9a5/', '_created': '2019-04-23T14:47:48.919015Z', 'name': 'resource-manager@fedora29base.virt.box', 'last_heartbeat': '2019-04-23T21:18:02.937453Z', 'online': True, 'missing': False}, {'_href': '/pulp/api/v3/workers/128d9703-128b-4ecd-925e-2ac50d3f15e1/', '_created': '2019-04-23T14:47:46.093730Z', 'name': 'reserved-resource-worker-1@fedora29base.virt.box', 'last_heartbeat': '2019-04-23T21:18:03.139386Z', 'online': True, 'missing': False}, {'_href': '/pulp/api/v3/workers/065406d9-c86a-4736-9a1f-0510accee764/', '_created': '2019-04-23T19:57:09.591180Z', 'name': 'reserved-resource-worker-99@fedora29base.virt.box', 'last_heartbeat': '2019-04-23T21:18:08.115631Z', 'online': False, 'missing': False}]}
ok
pulpcore/tests/functional/api/test_workers.py::OfflineWorkerTestCase::test_03_status_api_omits_offline_worker ... 
2019-04-23:18:18:10,572 DEBUG    [api.py:638 - request] Making a GET request with {'verify': False, 'auth': ('admin', 'admin'), 'url': 'http://fedora-29-pulp-3:80/pulp/api/v3/status/'}
2019-04-23:18:18:10,584 DEBUG    [api.py:168 - json_handler] response status: 200
2019-04-23:18:18:10,584 DEBUG    [api.py:642 - request] Finished GET request with response: {'versions': [{'component': 'pulpcore', 'version': '3.0.0rc1'}, {'component': 'pulpcore-plugin', 'version': '0.1.0rc1'}, {'component': 'pulp_rpm', 'version': '3.0.0b2'}, {'component': 'pulp_file', 'version': '0.0.1b10'}, {'component': 'pulp_docker', 'version': '4.0.0b3'}, {'component': 'pulp_certguard', 'version': '0.1.0rc1'}, {'component': 'pulp_ansible', 'version': '0.1.0rc4'}], 'online_workers': [{'_href': '/pulp/api/v3/workers/c299fb4b-d79b-4740-9261-a6b3221f0f0e/', '_created': '2019-04-23T14:47:47.276629Z', 'name': 'reserved-resource-worker-2@fedora29base.virt.box', 'last_heartbeat': '2019-04-23T21:18:02.736177Z', 'online': True, 'missing': False}, {'_href': '/pulp/api/v3/workers/46e07617-e257-4374-8055-a0c9e05bb9a5/', '_created': '2019-04-23T14:47:48.919015Z', 'name': 'resource-manager@fedora29base.virt.box', 'last_heartbeat': '2019-04-23T21:18:02.937453Z', 'online': True, 'missing': False}, {'_href': '/pulp/api/v3/workers/128d9703-128b-4ecd-925e-2ac50d3f15e1/', '_created': '2019-04-23T14:47:46.093730Z', 'name': 'reserved-resource-worker-1@fedora29base.virt.box', 'last_heartbeat': '2019-04-23T21:18:03.139386Z', 'online': True, 'missing': False}], 'missing_workers': [], 'database_connection': {'connected': True}, 'redis_connection': {'connected': True}}
ok

----------------------------------------------------------------------
Ran 5 tests in 12.17s

OK
```

</details>
Fix #1191 
Fix #17 