### PR TITLE
Add optional timeout to settings.json 

### DIFF
--- a/pulp_smash/api.py
+++ b/pulp_smash/api.py
@@ -684,10 +684,12 @@ def poll_task(cfg, href, pulp_host=None):
     :raises pulp_smash.exceptions.TaskTimedOutError: If a task takes too
         long to complete.
     """
-    # 900 * 2s == 1800s == 30m
-    # NOTE: The timeout counter is synchronous. We query Pulp, then count down,
-    # then query pulp, then count down, etc. This is… dumb.
-    poll_limit = 900
+    # Read the timeout in seconds from the cfg, and divide by the sleep_time
+    # to see how many times we query Pulp.
+    # An example: Assuming timeout = 1800s, and sleep_time = 0.3s
+    # 1800s/0.3s = 6000
+    sleep_time = 0.3
+    poll_limit = int(cfg.timeout / sleep_time)
     poll_counter = 0
     json_client = Client(cfg, json_handler, pulp_host=pulp_host)
     logger.debug("Polling task %s with poll_limit %s", href, poll_limit)
@@ -715,4 +717,4 @@ def poll_task(cfg, href, pulp_host=None):
         logger.debug(
             "Polling %s progress %s/%s", href, poll_counter, poll_limit
         )
-        sleep(2)
+        sleep(sleep_time)

--- a/pulp_smash/config.py
+++ b/pulp_smash/config.py
@@ -104,6 +104,7 @@ JSON_CONFIG_SCHEMA = {
                     "items": {"$ref": "#/definitions/pulp 2 host"},
                 },
                 "pulp": {"$ref": "#/definitions/pulp"},
+                "general": {"$ref": "#/definitions/general"},
             },
         },
         {
@@ -117,6 +118,7 @@ JSON_CONFIG_SCHEMA = {
                     "items": {"$ref": "#/definitions/pulp 3 host"},
                 },
                 "pulp": {"$ref": "#/definitions/pulp"},
+                "general": {"$ref": "#/definitions/general"},
             },
         },
     ],
@@ -129,6 +131,14 @@ JSON_CONFIG_SCHEMA = {
                 "auth": {"type": "array", "maxItems": 2, "minItems": 2},
                 "version": {"type": "string"},
                 "selinux enabled": {"type": "boolean"},
+            },
+        },
+        "general": {
+            "additionalProperties": False,
+            "required": ["timeout"],
+            "type": "object",
+            "properties": {
+                "timeout": {"type": "number", "mininum": 1, "maximum": 1800}
             },
         },
         "pulp 2 host": {
@@ -375,12 +385,13 @@ class PulpSmashConfig:
     """
 
     def __init__(
-        self, pulp_auth, pulp_version, pulp_selinux_enabled, *, hosts
+        self, pulp_auth, pulp_version, pulp_selinux_enabled, timeout, *, hosts
     ):
         """Initialize this object with needed instance attributes."""
         self.pulp_auth = pulp_auth
         self.pulp_version = Version(pulp_version)
         self.pulp_selinux_enabled = pulp_selinux_enabled
+        self.timeout = timeout
         self.hosts = hosts
 
     def __repr__(self):
@@ -545,11 +556,14 @@ class PulpSmashConfig:
                 DeprecationWarning,
             )
             loaded_config["hosts"] = loaded_config.pop("systems")
+
+        timeout = loaded_config.get("general", {}).get("timeout", 1800)
+
         hosts = [PulpHost(**host) for host in loaded_config.get("hosts", [])]
 
         # Make object.
         return PulpSmashConfig(
-            pulp_auth, pulp_version, pulp_selinux_enabled, hosts=hosts
+            pulp_auth, pulp_version, pulp_selinux_enabled, timeout, hosts=hosts
         )
 
     @classmethod

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -274,6 +274,7 @@ def _get_pulp_smash_config(**kwargs):
     kwargs.setdefault("pulp_auth", ["admin", "admin"])
     kwargs.setdefault("pulp_version", "1!0")
     kwargs.setdefault("pulp_selinux_enabled", True)
+    kwargs.setdefault("timeout", 1800)
     hosts = [
         config.PulpHost(
             hostname="example.com", roles={"api": {"scheme": "http"}}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -374,5 +374,6 @@ def _get_pulp_smash_config(hosts):
         pulp_auth=["admin", "admin"],
         pulp_version="1!0",
         pulp_selinux_enabled=True,
+        timeout=1800,
         hosts=hosts,
     )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,44 +18,8 @@ PULP_SMASH_CONFIG = """
         "auth": ["username", "password"],
         "version": "2.12.1"
     },
+    "general": {"timeout": 1800},
     "hosts": [
-        {
-            "hostname": "first.example.com",
-            "roles": {
-                "amqp broker": {"service": "qpidd"},
-                "api": {"port": 1234, "scheme": "https", "verify": true},
-                "mongod": {},
-                "pulp cli": {},
-                "pulp celerybeat": {},
-                "pulp resource manager": {},
-                "pulp workers": {},
-                "shell": {"transport": "local"},
-                "squid": {}
-            }
-        },
-        {
-            "hostname": "second.example.com",
-            "roles": {
-                "api": {"port": 2345, "scheme": "https", "verify": false},
-                "pulp celerybeat": {},
-                "pulp resource manager": {},
-                "pulp workers": {},
-                "shell": {"transport": "ssh"},
-                "squid": {}
-            }
-        }
-    ]
-}
-"""
-
-# Identical to above, but s/hosts/systems/.
-OLD_PULP_SMASH_CONFIG = """
-{
-    "pulp": {
-        "auth": ["username", "password"],
-        "version": "2.12.1"
-    },
-    "systems": [
         {
             "hostname": "first.example.com",
             "roles": {
@@ -98,6 +62,7 @@ def _gen_attrs():
         "pulp_version": ".".join(
             str(random.randint(1, 150)) for _ in range(4)
         ),
+        "timeout": random.randint(1, 1800),
         "pulp_selinux_enabled": True,
         "hosts": [
             config.PulpHost(
@@ -179,17 +144,13 @@ class PulpSmashConfigFileTestCase(unittest.TestCase):
         """Set the environment variable."""
         os_environ = {"PULP_SMASH_CONFIG_FILE": utils.uuid4()}
         with mock.patch.dict(os.environ, os_environ, clear=True):
-            config_file = (
-                config.PulpSmashConfig._get_config_file()
-            )  # pylint:disable=protected-access
+            config_file = config.PulpSmashConfig._get_config_file()
         self.assertEqual(config_file, os_environ["PULP_SMASH_CONFIG_FILE"])
 
     def test_var_unset(self):
         """Do not set the environment variable."""
         with mock.patch.dict(os.environ, {}, clear=True):
-            config_file = (
-                config.PulpSmashConfig._get_config_file()
-            )  # pylint:disable=protected-access
+            config_file = config.PulpSmashConfig._get_config_file()
         self.assertEqual(config_file, "settings.json")
 
 
@@ -199,12 +160,6 @@ class LoadTestCase(unittest.TestCase):
     def test_load_config_file(self):
         """Ensure Pulp Smash can load the config file."""
         cfg = pulp_smash_config_load(PULP_SMASH_CONFIG)
-        self.do_validate(cfg)
-
-    def test_load_old_config_file(self):
-        """Ensure Pulp Smash can load the config file."""
-        with self.assertWarns(DeprecationWarning):
-            cfg = pulp_smash_config_load(OLD_PULP_SMASH_CONFIG)
         self.do_validate(cfg)
 
     def do_validate(self, cfg):

--- a/tests/test_pulp2_utils.py
+++ b/tests/test_pulp2_utils.py
@@ -107,6 +107,7 @@ class PulpAdminLoginTestCase(unittest.TestCase):
                 pulp_auth=["admin", "admin"],
                 pulp_version="1!0",
                 pulp_selinux_enabled=True,
+                timeout=1800,
                 hosts=[
                     config.PulpHost(
                         hostname="example.com", roles={"pulp cli": {}}

--- a/tests/test_pulp_smash_cli.py
+++ b/tests/test_pulp_smash_cli.py
@@ -55,6 +55,7 @@ class SettingsCreateTestCase(BasePulpSmashCliTestCase):
                 "selinux enabled": True,
                 "version": "2.13",
             },
+            "general": {"timeout": 1800},
             "hosts": [
                 {
                     "hostname": "pulp.example.com",
@@ -82,6 +83,7 @@ class SettingsCreateTestCase(BasePulpSmashCliTestCase):
                 "selinux enabled": True,
                 "version": "3.0",
             },
+            "general": {"timeout": 1800},
             "hosts": [
                 {
                     "hostname": "pulp3.example.com",
@@ -140,6 +142,7 @@ class SettingsCreateTestCase(BasePulpSmashCliTestCase):
             "\n"  # pulp admin username
             "\n"  # pulp admin password
             "\n"  # pulp selinux enabled
+            "\n"  # task time out
             "pulp.example.com\n"  # host hostname
             "\n"  # host amqp broker
             "\n"  # host api scheme
@@ -160,6 +163,7 @@ class SettingsCreateTestCase(BasePulpSmashCliTestCase):
             "\n"  # pulp admin username
             "\n"  # pulp admin password
             "\n"  # pulp selinux enabled
+            "\n"  # task time out
             "pulp.example.com\n"  # host hostname
             "\n"  # host amqp broker
             "\n"  # host api scheme
@@ -181,6 +185,7 @@ class SettingsCreateTestCase(BasePulpSmashCliTestCase):
             "\n"  # pulp admin username
             "\n"  # pulp admin password
             "\n"  # pulp selinux enabled
+            "\n"  # task time out
             "pulp.example.com\n"  # host hostname
             "\n"  # host amqp broker
             "\n"  # host api scheme
@@ -203,6 +208,7 @@ class SettingsCreateTestCase(BasePulpSmashCliTestCase):
             "username\n"  # pulp admin username
             "password\n"  # pulp admin password
             "n\n"  # pulp selinux enabled
+            "900\n"  # task time out
             "pulp.example.com\n"  # host hostname
             "rabbitmq\n"  # host amqp broker
             "http\n"  # host api scheme
@@ -215,6 +221,7 @@ class SettingsCreateTestCase(BasePulpSmashCliTestCase):
 
         self.expected_config_dict["pulp"]["auth"] = ["username", "password"]
         self.expected_config_dict["pulp"]["selinux enabled"] = False
+        self.expected_config_dict["general"]["timeout"] = 900
         host_roles = self.expected_config_dict["hosts"][0]["roles"]
         host_roles["amqp broker"]["service"] = "rabbitmq"
         host_roles["api"]["port"] = 1234
@@ -232,6 +239,7 @@ class SettingsCreateTestCase(BasePulpSmashCliTestCase):
             "\n"  # user
             "\n"  # password
             "\n"  # selinux enabled?
+            "\n"  # task time out
             "pulp3.example.com\n"  # hostname
             "\n"  # api scheme
             "\n"  # api verify?
@@ -259,6 +267,7 @@ class SettingsCreateTestCase(BasePulpSmashCliTestCase):
             "username\n"  # user
             "password\n"  # password
             "n\n"  # selinux enabled
+            "900\n"  # task time out
             "pulp3.example.com\n"  # api hostname
             "http\n"  # api scheme
             "n\n"  # verify api SSL?
@@ -271,6 +280,7 @@ class SettingsCreateTestCase(BasePulpSmashCliTestCase):
 
         self.expected_config_dict_3["pulp"]["auth"] = ["username", "password"]
         self.expected_config_dict_3["pulp"]["selinux enabled"] = False
+        self.expected_config_dict_3["general"]["timeout"] = 900
         roles = self.expected_config_dict_3["hosts"][0]["roles"]
         roles["api"]["port"] = 1234
         roles["api"]["scheme"] = "http"


### PR DESCRIPTION
Add optional timeout variable as part of settings.json. This will allow one to
specify the timeout for the task system in seconds from now, if not
defined it will be set to default value of 1800s. This was the previous
used value.

Tweak the task system timeout to use seconds, and query Pulp more often.
Reduce the sleep time on `poll_task` function to 0.3s.

Adjust unittests, and remove old tests.

closes:#1173