### PR TITLE
Temporarily update task polling system for Pulp 2

### DIFF
--- a/pulp_smash/api.py
+++ b/pulp_smash/api.py
@@ -688,7 +688,11 @@ def poll_task(cfg, href, pulp_host=None):
     # to see how many times we query Pulp.
     # An example: Assuming timeout = 1800s, and sleep_time = 0.3s
     # 1800s/0.3s = 6000
-    sleep_time = 0.3
+
+    if cfg.pulp_version < Version("3"):
+        sleep_time = 2
+    else:
+        sleep_time = 0.3
     poll_limit = int(cfg.timeout / sleep_time)
     poll_counter = 0
     json_client = Client(cfg, json_handler, pulp_host=pulp_host)


### PR DESCRIPTION
Temporarily update task polling system to address Pulp 2 issue.
Pulp-smash was polling at a 0.3s rate that is occasionally returning
a task "COMPLETE" but the values for the task had yet to be reset.

Adjust the task system to use the previous value of 2s for Pulp 2.

See: https://pulp.plan.io/issues/4795