### PR TITLE
Add util get_served_content_url for Pulp 3

### DIFF
--- a/pulp_smash/pulp3/utils.py
+++ b/pulp_smash/pulp3/utils.py
@@ -1,7 +1,6 @@
 # coding=utf-8
 """Utility functions for Pulp 3 tests."""
 from collections import defaultdict
-from functools import reduce
 import warnings
 from urllib.parse import urljoin, urlsplit
 
@@ -88,7 +87,7 @@ def sync(cfg, remote, repo, **kwargs):
 
 
 def download_content_unit(cfg, distribution, unit_path, **kwargs):
-    """Download the content unit from distribution base path.
+    """Download the content unit from distribution base url.
 
     :param pulp_smash.config.PulpSmashConfig cfg: Information about the Pulp
         host.
@@ -97,16 +96,22 @@ def download_content_unit(cfg, distribution, unit_path, **kwargs):
     :param kwargs: Extra arguments passed to requests.get.
     """
     client = api.Client(cfg, api.safe_handler)
-    unit_url = reduce(
-        urljoin,
-        (
-            cfg.get_content_host_base_url(),
-            "//" + distribution["base_url"] + "/",
-            unit_path,
-        ),
-    )
+    unit_url = urljoin(get_served_content_url(cfg, distribution), unit_path)
     logger.debug("Downloading content %s", unit_url)
     return client.get(unit_url, **kwargs).content
+
+
+def get_served_content_url(cfg, distribution):
+    """Return the served content url given a distribution.
+
+    :param pulp_smash.config.PulpSmashConfig cfg: Information about the Pulp
+        host.
+    :param distribution: A dict of information about the distribution.
+    :returns: A URL where the content will be served given a distribution.
+    """
+    return urljoin(
+        cfg.get_content_host_base_url(), "//" + distribution["base_url"] + "/"
+    )
 
 
 def publish(cfg, publisher, repo, version_href=None):


### PR DESCRIPTION
`get_served_content_url` will return the URL that content is served
given a distribution.
Adjust function `download_content_unit` to use the newly added function.