### PR TITLE
Changing download_policies

### DIFF
--- a/pulp_smash/pulp3/constants.py
+++ b/pulp_smash/pulp3/constants.py
@@ -22,13 +22,9 @@ CONTENT_PATH = urljoin(BASE_PATH, "content/")
 
 DISTRIBUTION_PATH = urljoin(BASE_PATH, "distributions/")
 
-DOWNLOAD_POLICIES = ("immediate", "on_demand", "streamed")
+IMMEDIATE_DOWNLOAD_POLICIES = ("immediate",)
 
-JWT_PATH = urljoin(BASE_PATH, "jwt/")
-
-LAZY_DOWNLOAD_POLICIES = tuple(
-    [item for item in DOWNLOAD_POLICIES if item != "immediate"]
-)
+ON_DEMAND_DOWNLOAD_POLICIES = ("on_demand", "streamed")
 
 MEDIA_PATH = "/var/lib/pulp"
 


### PR DESCRIPTION
With https://github.com/pulp/pulpcore/commit/59f3450286d0a3a88e4b9fd1edb3568ee65bf54f
the download policy by default only includes 'immediate'.

[noissue]