### PR TITLE
Add local flag to CLI client

### DIFF
--- a/pulp_smash/cli.py
+++ b/pulp_smash/cli.py
@@ -188,7 +188,9 @@ class Client:  # pylint:disable=too-few-public-methods
     .. _Plumbum: http://plumbum.readthedocs.io/en/latest/index.html
     """
 
-    def __init__(self, cfg, response_handler=None, pulp_host=None):
+    def __init__(
+        self, cfg, response_handler=None, pulp_host=None, local=False
+    ):
         """Initialize this object with needed instance attributes."""
         # How do we make requests?
         if not pulp_host:
@@ -196,6 +198,11 @@ class Client:  # pylint:disable=too-few-public-methods
                 pulp_host = cfg.get_hosts("pulp cli")[0]
             else:
                 pulp_host = cfg.get_hosts("shell")[0]
+
+        if local:
+            pulp_host = collections.namedtuple("Host", "hostname roles")
+            pulp_host.hostname = "localhost"
+            pulp_host.roles = {"shell": {"transport": "local"}}
 
         self.pulp_host = pulp_host
         self.response_handler = response_handler or code_handler


### PR DESCRIPTION
Add local flag to CLI client. This will force the client to run the
CLI commands in the same box that pulp-smash is installed. This will
remove the need to call subprocess to run commands locally.
Besides that, it will allow to reuse the tooling already in
place for the CLI client.