### PR TITLE
Remove service names from api role

### DIFF
--- a/pulp_smash/config.py
+++ b/pulp_smash/config.py
@@ -29,7 +29,7 @@ def _get_pulp_2_api_role():
         "properties": {
             "port": {"type": "integer", "minimum": 0, "maximum": 65535},
             "scheme": {"enum": ["http", "https"], "type": "string"},
-            "service": {"enum": ["httpd", "nginx"], "type": "string"},
+            "service": {"type": "string"},
             "verify": {"type": ["boolean", "string"]},
         },
     }


### PR DESCRIPTION
Remove names of services for the api role. This change was required due
to changes in test approach for Pulp 3.

See: https://pulp.plan.io/issues/4965